### PR TITLE
ra_node: Reset `leader_id` when starting an election

### DIFF
--- a/src/ra_node.erl
+++ b/src/ra_node.erl
@@ -695,8 +695,11 @@ handle_election_timeout(State0 = #{id := Id, current_term := CurrentTerm}) ->
     % vote for self
     VoteForSelf = #request_vote_result{term = NewTerm, vote_granted = true},
     State = update_meta([{current_term, NewTerm}, {voted_for, Id}], State0),
-    {candidate, State#{votes => 0}, [{next_event, cast, VoteForSelf},
-                                     {send_vote_requests, VoteRequests}]}.
+    {candidate,
+     State#{leader_id => undefined,
+            votes => 0},
+     [{next_event, cast, VoteForSelf},
+      {send_vote_requests, VoteRequests}]}.
 
 peers(#{id := Id, cluster := Nodes}) ->
     maps:remove(Id, Nodes).


### PR DESCRIPTION
Before that, we kept the old `leader_id` value around. If the same leader is elected, the `leader_id` remained the same: this prevented the `pending_commands` from being processed in `ra_node_proc:follower_leader_change()`.

In the `ra_SUITE:node_recovery()` testcase, this caused a deadlock because the synchronous `gen_statem:call()` in the second `ra:send_and_await_consensus()` never got a reply.