### PR TITLE
ra_log_wal: Ignore exception if the ra node is gone

### DIFF
--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -225,7 +225,7 @@ complete_batch(#state{batch = #batch{waiting = Waiting,
     % notify processes that have synced map(Pid, Token)
     Debug = maps:fold(fun (Id, Tok, Dbg) ->
                               Msg = {written, Tok},
-                              Id ! Msg,
+                              catch (Id ! Msg),
                               Evt = {out, {self(), Msg}, Id},
                               sys:handle_debug(Dbg, fun write_debug/3,
                                                ?MODULE, Evt)


### PR DESCRIPTION
In `complete_batch()`, we want to notify the ra node that its data was written. If the ra node is a registered process, sending it a message will raise an exception if the process is gone. As we can't do much about this, let's ignore the exception.