### PR TITLE
Partitions test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,14 @@ endef
 dep_aten = git https://github.com/rabbitmq/aten.git master
 DEPS = aten
 
-TEST_DEPS = proper meck eunit_formatters looking_glass
+TEST_DEPS = proper meck eunit_formatters looking_glass rabbitmq_ct_helpers
 
 BUILD_DEPS = elvis_mk
 
 LOCAL_DEPS = sasl crypto
 dep_elvis_mk = git https://github.com/inaka/elvis.mk.git master
 dep_looking_glass = git https://github.com/rabbitmq/looking-glass.git master
+dep_rabbitmq_ct_helpers = git https://github.com/rabbitmq/rabbitmq-ct-helpers
 
 DEP_PLUGINS = elvis_mk
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -3,18 +3,27 @@
 
 ### Hello World-ish tutorial.
 
+1. Prepare the application config.
+
+    RA erlang application requires a data directory to store write-ahead log file.
+    You should set it using the `data_dir` application environment variable.
+    `ok = application:set_env(ra, data_dir, "."), % Sets data directory to a current working directory`
+
 1. Write a state machine.
 
     Before you can do anything you need to write a state machine to run inside a Ra cluster. State machines operate on incoming message and return an updated state. The simplest possible statemachine is one that accepts integers as command messages and simple adds them to the state and return the result. In short `fun erlang:'+'/2` would do the trick.
+
+    initial_nodes should
 
     Now you've got a state machine function you can create a `ra_node_config()` map:
 
     ```
     NodeId = {node1, node()},
     Config = #{id => NodeId,
+               uid => <<"node1">>,
                log_module => ra_log_memory,
                log_init_args => [{node1, node()}, {node2, node()}, {node3, node()}],
-               initial_nodes => [],
+               initial_nodes => [{node1, node()}, {node2, node()}, {node3, node()}],
                machine => {simple, fun erlang:'+'/2, 0}}, % the "apply" function + the initial state
     ```
 
@@ -22,8 +31,8 @@
 
     ```
     ok = ra:start_node(Config),
-    ok = ra:start_node(Config#{id => {node2, node()}),
-    ok = ra:start_node(Config#{id => {node3, node()}),
+    ok = ra:start_node(Config#{id => {node2, node()}, uid => <<"node2">>}),
+    ok = ra:start_node(Config#{id => {node3, node()}, uid => <<"node3">>}),
     % new ra nodes are completely passive
     % trigger election
     ok = ra:trigger_election({node1, node()}).

--- a/test/erlang_node_helpers.erl
+++ b/test/erlang_node_helpers.erl
@@ -1,0 +1,57 @@
+-module(erlang_node_helpers).
+
+-export([start_erlang_nodes/2, start_erlang_node/2, stop_erlang_nodes/1, stop_erlang_node/1, wait_for_stop/2]).
+-include_lib("common_test/include/ct.hrl").
+
+start_erlang_nodes(Nodes, Config) ->
+    [start_erlang_node(Node, Config) || Node <- Nodes],
+    Nodes.
+
+start_erlang_node(Node, Config) ->
+    DistMod = ?config(erlang_dist_module, Config),
+    StartArgs = case DistMod of
+        undefined ->
+            "";
+        _ ->
+            DistModS = atom_to_list(DistMod),
+            DistModPath = filename:absname(
+              filename:dirname(code:where_is_file(DistModS ++ ".beam"))),
+            DistArg = re:replace(DistModS, "_dist$", "", [{return, list}]),
+            "-pa \"" ++ DistModPath ++ "\" -proto_dist " ++ DistArg
+    end,
+    ct_slave:start(Node, [{erl_flags, StartArgs}]),
+    wait_for_distribution(Node, 50),
+    add_lib_dir(Node),
+    Node.
+
+add_lib_dir(Node) ->
+    ct_rpc:call(Node, code, add_paths, [code:get_path()]).
+
+wait_for_distribution(Node, 0) ->
+    error({distribution_failed_for, Node, no_more_attempts});
+wait_for_distribution(Node, Attempts) ->
+    ct:pal("Waiting for node ~p~n", [Node]),
+    case ct_rpc:call(Node, erlang, node, []) of
+        Node -> ok;
+        {badrpc, nodedown} ->
+            timer:sleep(100),
+            wait_for_distribution(Node, Attempts - 1)
+    end.
+
+stop_erlang_nodes(Nodes) ->
+    [stop_erlang_node(Node) || Node <- Nodes].
+
+stop_erlang_node(Node) ->
+    ct:pal("Stopping node ~p~n", [Node]),
+    ct_slave:stop(Node),
+    wait_for_stop(Node, 100).
+
+wait_for_stop(Node, 0) ->
+    error({stop_failed_for, Node});
+wait_for_stop(Node, Attempts) ->
+    case ct_rpc:call(Node, erlang, node, []) of
+        {badrpc, nodedown} -> ok;
+        _ ->
+            timer:sleep(100),
+            wait_for_stop(Node, Attempts - 1)
+    end.

--- a/test/jepsen_like_partitions_SUITE.erl
+++ b/test/jepsen_like_partitions_SUITE.erl
@@ -69,8 +69,8 @@ publish_ack(Config) ->
         local   -> node()
     end,
 
-    Publisher = spawn_publisher(PublisherNode, NodeIds, 1000, self(), 30000),
-    Consumer = spawn_consumer(ConsumerNode, NodeIds, 1000, self(), 20000),
+    Publisher = spawn_publisher(PublisherNode, NodeIds, 1000, self(), 50000),
+    Consumer = spawn_consumer(ConsumerNode, NodeIds, 1000, self(), 50000),
     Nemesis = ?config(nemesis, Config),
     start_delayed(Publisher),
     start_delayed(Consumer),

--- a/test/jepsen_like_partitions_SUITE.erl
+++ b/test/jepsen_like_partitions_SUITE.erl
@@ -1,0 +1,300 @@
+-module(jepsen_like_partitions_SUITE).
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+
+all() -> [publish_ack].
+
+init_per_testcase(_, Config0) ->
+    error_logger:tty(false),
+    Nodes = erlang_nodes(5),
+    Nemesis = spawn_nemesis(Nodes, 2, {random, 10000}, {random, 10000, 20000}),
+    Config1 = [{nodes, Nodes}, {name, publish_ack}, {nemesis, Nemesis} | Config0 ],
+    Config2 = prepare_erlang_cluster(Config1),
+    NodeId = setup_ra_cluster(Config2),
+    %% Make sure nodes are synchronised
+    ct:pal("Members ~p~n", [ra:members(NodeId)]),
+    [{node_id, NodeId} | Config2].
+
+end_per_testcase(_, Config) ->
+    Nemesis = ?config(nemesis, Config),
+    unlink(Nemesis),
+    exit(Nemesis, stop),
+    undefined = process_info(Nemesis),
+
+    Nodes = ?config(nodes, Config),
+    erlang_node_helpers:stop_erlang_nodes(Nodes),
+    ct:pal("Stopped nodes ~p~n", [Nodes]),
+    Dir = data_dir(),
+    os:cmd("rm -rf " ++ Dir).
+
+publish_ack(Config) ->
+    NodeId = ?config(node_id, Config),
+    Nodes = ?config(nodes, Config),
+
+    PublisherNode = get_random_node(Nodes),
+    ConsumerNode = get_random_node(Nodes),
+
+    Publisher = spawn_publisher(PublisherNode, NodeId, 10000, self()),
+    Consumer = spawn_consumer(ConsumerNode, NodeId, 10000, self()),
+    Nemesis = ?config(nemesis, Config),
+    start_delayed(Publisher),
+    start_delayed(Consumer),
+
+    start_delayed(Nemesis),
+
+    wait_for_publisher_and_consumer(Publisher, Consumer, false, false).
+
+wait_for_publisher_and_consumer(Publisher, Consumer, true, true) ->
+    ok;
+wait_for_publisher_and_consumer(Publisher, Consumer, PublisherFinished, ConsumerFinished) ->
+    receive
+        {consumed, Consumed} ->
+            ct:log(" Consumed ~p~n", [Consumed]),
+            wait_for_publisher_and_consumer(Publisher, Consumer, PublisherFinished, true);
+        {published, Sent, Acked, Nacked} ->
+            ct:log(" Sent ~p~n Acked ~p~n Nacked ~p~n", [Sent, Acked, Nacked]),
+            wait_for_publisher_and_consumer(Publisher, Consumer, true, ConsumerFinished);
+        {publisher_in_progress, Sent, Acked, Nacked} ->
+            ct:pal("Still waiting on publisher~n Sent ~p~n Acked ~p~n Nacked ~p~n", [length(Sent), length(Acked), length(Nacked)]),
+            wait_for_publisher_and_consumer(Publisher, Consumer, PublisherFinished, ConsumerFinished);
+        {consumer_in_progress, Delivered, Applied, Rejected} ->
+            ct:pal("Still waiting on consumer.~n Delivered ~p~n Applied ~p~n Rejected ~p~n", [length(Delivered), length(Applied), length(Rejected)]),
+            wait_for_publisher_and_consumer(Publisher, Consumer, PublisherFinished, ConsumerFinished)
+    end.
+
+erlang_nodes(5) ->
+    [
+     foo1@localhost,
+     foo2@localhost,
+     foo3@localhost,
+     foo4@localhost,
+     foo5@localhost
+     ].
+
+client_id() ->
+     {<<"consumer">>, self()}.
+
+spawn_consumer(Node, NodeId, MessageCount, Pid) ->
+    spawn_delayed(Node,
+        fun
+        Consumer({init, Leader}) ->
+            ct:pal("Init consumer"),
+            Cid = client_id(),
+            {ok, _Result, NewLeader} = ra:send_and_await_consensus(Leader, {checkout, {auto, 50}, Cid}, infinity),
+            Consumer({NewLeader, [], [], []});
+        Consumer({Leader, Delivered, Applied, Rejected}) ->
+            receive
+            {ra_fifo, NewLeader, {delivery, _ClientTag, MsgId, N}} ->
+            % {ra_event, NewLeader, machine, {msg, MsgId, N}} ->
+                Ref = case length([D || D <- Delivered, D == N]) of
+                    0 ->
+                        {ack, N, 0};
+                    Duplicates ->
+                        ct:pal("Duplicate delivery ~p~n", [N]),
+                        {ack, N, Duplicates}
+                end,
+                %% Assuming client id does not change.
+                Cid = client_id(),
+                ok = ra:send_and_notify(NewLeader, {settle, MsgId, Cid}, Ref),
+                Consumer({NewLeader, [N | Delivered], Applied, Rejected});
+            {ra_event, {applied, NewLeader, Ref}} ->
+            % {ra_event, NewLeader, applied, Ref} ->
+                Consumer({NewLeader, Delivered, [Ref | Applied], Rejected});
+            {ra_event, {rejected, NewLeader, Ref}} ->
+            % {ra_event, NewLeader, rejected, Ref} ->
+                Consumer({NewLeader, Delivered, Applied, [Ref | Rejected]})
+            after 10000 ->
+                case length(Applied) + length(Rejected) of
+                    MessageCount ->
+                        Pid ! {consumed, Delivered},
+                        ok;
+                    Other ->
+                        ct:pal("Still waiting on consumer ~p~n", [Other]),
+                        Pid ! {consumer_in_progress, Delivered, Applied, Rejected},
+                        % print_metrics(erlang_nodes(5)),
+                        %% Keep waiting
+                        Consumer({Leader, Delivered, Applied, Rejected})
+                end
+            end
+        end,
+        {init, NodeId}).
+
+spawn_publisher(Node, NodeId, MessageCount, Pid) ->
+    spawn_delayed(Node,
+        fun Publisher({Leader, N, Sent, Acked, Nacked}) ->
+            {Sent1, N1, Wait} = case N-1 of
+                MessageCount -> {Sent, N, 1000};
+                _            ->
+                    ok = ra:send_and_notify(Leader, {enqueue, N}, N),
+                    {[N | Sent], N+1, 0}
+            end,
+            receive
+                {ra_event, {applied, NewLeader, Ref}} ->
+                % {ra_event, NewLeader, applied, Ref} ->
+                    Acked1 = [Ref | Acked],
+                    Publisher({NewLeader, N1, Sent1, Acked1, Nacked});
+                {ra_event, {rejected, NewLeader, Ref}} ->
+                % {ra_event, NewLeader, rejected, Ref} ->
+                    Nacked1 = [Ref | Nacked],
+                    Publisher({NewLeader, N1, Sent1, Acked, Nacked1})
+            after Wait ->
+                    case length(Acked) + length(Nacked) of
+                        MessageCount ->
+                            %% All messages are received
+                            % ct:pal("Published ~p~n~p~n~p~n", [Sent1, Acked, Nacked]),
+                            Pid ! {published, Sent1, Acked, Nacked},
+                            ok;
+                        Other ->
+                            ct:pal("Still waiting on publisher ~p~n", [Other]),
+                            Pid ! {publisher_in_progress, Sent, Acked, Nacked},
+                            % print_metrics(erlang_nodes(5)),
+                            %% Keep waiting for acks and nacks
+                            Publisher({Leader, N1, Sent1, Acked, Nacked})
+                    end
+            end
+        end,
+        {NodeId, 1, [], [], []}).
+
+
+-type wait_time() :: (Exactly :: integer() | infinity)
+                     | {random, UpTo :: integer()}
+                     | {random, From :: integer(), UpTo :: integer()}.
+
+-type partition_spec() :: (Size :: integer()) | (Nodes :: [node()]).
+-spec spawn_nemesis([node()], partition_spec(), wait_time(), wait_time()) -> pid().
+spawn_nemesis(Nodes, Partition, TimeForPartition, TimeForHeal) ->
+    spawn_delayed(
+        fun Nemesis(ok) ->
+            unblock_inet_tcp_proxy(Nodes),
+            wait(TimeForHeal),
+            block_random_partition_inet_tcp_proxy(Partition, Nodes),
+            wait(TimeForPartition),
+            Nemesis(ok)
+        end,
+        ok).
+
+start_delayed(Pid) ->
+    ct:pal("Starting ~p~n", [Pid]),
+    Pid ! start.
+
+
+spawn_delayed(Node, Fun, State) ->
+    spawn_link(Node, fun() ->
+        receive start -> ok
+        end,
+        ct:pal("Started ~p~n", [self()]),
+        Fun(State)
+    end).
+
+spawn_delayed(Fun, State) ->
+    spawn_delayed(node(), Fun, State).
+
+wait(Time) when is_integer(Time); Time == infinity ->
+    timer:sleep(Time);
+wait({random, UpTo}) when is_integer(UpTo) ->
+    Time = rand:uniform(UpTo),
+    timer:sleep(Time);
+wait({random, From, UpTo}) when is_integer(From), is_integer(UpTo), UpTo =/= From ->
+    Time = rand:uniform(UpTo - From),
+    timer:sleep(From + Time).
+
+prepare_erlang_cluster(Config) ->
+    Nodes = ?config(nodes, Config),
+    Config0 = tcp_inet_proxy_helpers:enable_dist_proxy_manager(Config),
+    erlang_node_helpers:start_erlang_nodes(Nodes, Config0),
+    tcp_inet_proxy_helpers:enable_dist_proxy(Nodes, Config0).
+
+setup_ra_cluster(Config) ->
+    Nodes = ?config(nodes, Config),
+    Name = ?config(name, Config),
+    {ok, Cwd} = file:get_cwd(),
+    DataDir = data_dir(),
+    filelib:ensure_dir(DataDir),
+
+    Configs = lists:map(fun(Node) ->
+        ct:pal("Start app on ~p~n", [Node]),
+        NodeConfig = make_node_ra_config(Name, Nodes, Node, Cwd),
+        ok = ct_rpc:call(Node, application, load, [ra]),
+        ok = ct_rpc:call(Node, application, set_env, [ra, data_dir, filename:join([DataDir, atom_to_list(Node)])]),
+        {ok, _} = ct_rpc:call(Node, application, ensure_all_started, [ra]),
+        spawn(Node, fun() ->
+            ets:new(ra_fifo_metrics, [public, named_table, {write_concurrency, true}]),
+            receive stop -> ok end
+        end),
+        NodeConfig
+    end,
+    Nodes),
+    lists:map(fun(#{id := {_, Node}} = NodeConfig) ->
+        ct:pal("Start ra node on ~p~n", [Node]),
+        ok = ct_rpc:call(Node, ra, start_node, [NodeConfig]),
+        NodeConfig
+    end,
+    Configs),
+
+    NodeId = {Name, hd(Nodes)},
+    ok = ra:trigger_election(NodeId),
+    NodeId.
+
+make_node_ra_config(Name, Nodes, Node, Cwd) ->
+    #{ id => {Name, Node},
+       uid => atom_to_binary(Name, utf8),
+       initial_nodes => [{Name, N} || N <- Nodes],
+       log_module => ra_log_file,
+       log_init_args =>
+            #{data_dir => filename:join([data_dir(), atom_to_list(Node)]),
+              uid => atom_to_binary(Name, utf8)},
+       machine => {module, ra_fifo}
+       }.
+
+print_metrics(Nodes) ->
+    [print_node_metrics(Node) || Node <- Nodes].
+
+print_node_metrics(Node) ->
+    ct:pal("Node ~p metrics ~p~n", [Node, ct_rpc:call(Node, ets, tab2list, [ra_fifo_metrics])]).
+
+
+
+unblock_inet_tcp_proxy(Nodes) ->
+    ct:pal("Rejoining all nodes"),
+    [ tcp_inet_proxy_helpers:allow_traffic_between(Node, OtherNode)
+      || OtherNode <- Nodes,
+         Node <- Nodes,
+         OtherNode =/= Node ].
+
+block_random_partition_inet_tcp_proxy(Partition, Nodes) ->
+    Partition1 = case Partition of
+        PartitionSize when is_integer(PartitionSize) ->
+            lists:foldl(fun(_, SelectedNodes) ->
+                Node = get_random_node(SelectedNodes, Nodes),
+                [Node | SelectedNodes]
+            end,
+            [],
+            lists:seq(1, PartitionSize));
+        PartitionNodes when is_list(PartitionNodes) ->
+            PartitionNodes
+    end,
+
+    ct:pal("Cutting off nodes: ~p from the rest of the cluster",
+           [Partition1]),
+
+    Partition2 = Nodes -- Partition1,
+
+    lists:foreach(
+        fun(Node) ->
+            [ tcp_inet_proxy_helpers:block_traffic_between(Node, OtherNode)
+              || OtherNode <- Partition2 ]
+        end,
+        Partition1).
+
+get_random_node(Nodes) ->
+    lists:nth(rand:uniform(length(Nodes)), Nodes).
+
+get_random_node(Exceptions, Nodes) ->
+    PossibleNodes = Nodes -- Exceptions,
+    get_random_node(PossibleNodes).
+
+
+data_dir() ->
+    {ok, Cwd} = file:get_cwd(),
+    filename:join(Cwd, "jepsen_like_partitions_SUITE").

--- a/test/partitions_SUITE.erl
+++ b/test/partitions_SUITE.erl
@@ -1,0 +1,245 @@
+-module(partitions_SUITE).
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+
+all() -> [
+            publish_ack_no_partition
+            ,publish_ack_node_leave
+            ,publish_ack_node_restart
+            ,publish_ack_inet_tcp_proxy_blocks_single_node
+            % ,publish_ack_inet_tcp_proxy_partition_majority
+         ].
+
+init_per_testcase(TestCase, Config) ->
+    Config0 = tcp_inet_proxy_helpers:enable_dist_proxy_manager(Config),
+    Nodes = erlang_nodes(5),
+    erlang_node_helpers:start_erlang_nodes(Nodes, Config0),
+    tcp_inet_proxy_helpers:enable_dist_proxy(Nodes, Config0),
+    {_, Node} = NodeId = setup_ra_cluster(TestCase, Nodes),
+    ok = ra:trigger_election(NodeId),
+    Config1 = [{node_id, NodeId}, {nodes, Nodes} | Config0].
+
+end_per_testcase(TestCase, Config) ->
+    Nodes = ?config(nodes, Config),
+    erlang_node_helpers:stop_erlang_nodes(Nodes),
+    {ok, Cwd} = file:get_cwd(),
+    Dir = filename:join(Cwd, "partitions_SUITE"),
+    os:cmd("rm -rf " ++ Dir).
+
+publish_ack_no_partition(Config) ->
+    Nodes = ?config(nodes, Config),
+    EveryFun = fun() -> print_metrics(Nodes) end,
+    publish_and_consume(Config, 1000, 100, EveryFun, EveryFun).
+
+publish_ack_node_leave(Config) ->
+    NodeId = ?config(node_id, Config),
+    Nodes = ?config(nodes, Config),
+    LogFun = fun() -> print_metrics(Nodes) end,
+    StopFun = fun() -> print_metrics(Nodes), stop_random_node(NodeId, Nodes) end,
+    publish_and_consume(Config, 1000, 400, LogFun, StopFun).
+
+publish_ack_node_restart(Config) ->
+    {Name, _} = NodeId = ?config(node_id, Config),
+    Nodes = ?config(nodes, Config),
+    LogFun = fun() -> print_metrics(Nodes) end,
+    RestartFun = fun() ->
+                    print_metrics(Nodes),
+                    restart_random_node(Name, NodeId, Nodes, Config)
+                 end,
+    publish_and_consume(Config, 1000, 100, LogFun, RestartFun).
+
+publish_ack_inet_tcp_proxy_blocks_single_node(Config) ->
+    NodeId = ?config(node_id, Config),
+    Nodes = ?config(nodes, Config),
+    LogFun = fun() -> print_metrics(Nodes) end,
+    BlockFun = fun() ->
+                   print_metrics(Nodes),
+                   unblock_inet_tcp_proxy(Nodes),
+                   block_random_node_inet_tcp_proxy(NodeId, Nodes)
+               end,
+    publish_and_consume(Config, 1000, 100, LogFun, BlockFun).
+
+% publish_ack_inet_tcp_proxy_partition_majority(Config) ->
+%     NodeId = ?config(node_id, Config),
+%     Nodes = ?config(nodes, Config),
+%     LogFun = fun() -> print_metrics(Nodes) end,
+%     BlockFun = fun() ->
+%                    print_metrics(Nodes),
+%                    unblock_inet_tcp_proxy(Nodes),
+%                    block_random_partition_inet_tcp_proxy(NodeId, Nodes)
+%                end,
+%     publish_and_consume(Config, 1000, 100, LogFun, BlockFun).
+
+publish_and_consume(Config, Total, Every, EveryPublishFun, EveryConsumeFun) ->
+    error_logger:tty(false),
+    NodeId = ?config(node_id, Config),
+    Nodes = ?config(nodes, Config),
+    Cid = customer_id(),
+    {ok, _Term, Leader} = R = ra:send_and_await_consensus(NodeId, {checkout, {auto, 50}, Cid}, 10000),
+    ct:pal("Checked out ~p~n", [R]),
+    publish_n_messages(Total, Leader, Every, EveryPublishFun),
+    print_metrics(Nodes),
+    wait_for_consumption(Total, Leader, Every, EveryConsumeFun).
+
+unblock_inet_tcp_proxy(Nodes) ->
+    ct:pal("Unblocking all nodes"),
+    [ tcp_inet_proxy_helpers:allow_traffic_between(Node, OtherNode)
+      || OtherNode <- Nodes,
+         Node <- Nodes,
+         OtherNode =/= Node ].
+
+block_random_node_inet_tcp_proxy(NodeId, Nodes) ->
+    TargetNode = get_random_node(NodeId, Nodes),
+    ct:pal("Blocking node ~p~n", [TargetNode]),
+    [ tcp_inet_proxy_helpers:block_traffic_between(TargetNode, OtherNode)
+      || OtherNode <- Nodes,
+         OtherNode =/= TargetNode].
+
+% block_random_partition_inet_tcp_proxy(NodeId, Nodes) ->
+%     Node1 = get_random_node(NodeId, Nodes),
+%     Node2 = get_random_node(NodeId, Nodes -- [Node1]),
+
+%     %% Node1 and Node2 will be cut off from the cluster.
+%     ct:pal("Cutting off nodes ~p and ~p from the rest of the cluster",
+%            [Node1, Node2]),
+%     [ tcp_inet_proxy_helpers:block_traffic_between(Node1, OtherNode)
+%       || OtherNode <- Nodes,
+%          OtherNode =/= Node1,
+%          OtherNode =/= Node2 ],
+%     [ tcp_inet_proxy_helpers:block_traffic_between(Node2, OtherNode)
+%       || OtherNode <- Nodes,
+%          OtherNode =/= Node1,
+%          OtherNode =/= Node2 ].
+
+get_random_node(no_exceptions, Nodes) ->
+    lists:nth(rand:uniform(length(Nodes)), Nodes);
+get_random_node({_, Node}, Nodes) ->
+    PossibleNodes = Nodes -- [Node],
+    lists:nth(rand:uniform(length(PossibleNodes)), PossibleNodes).
+
+stop_random_node(NodeId, Nodes) ->
+    TargetNode = get_random_node(NodeId, Nodes),
+    erlang_node_helpers:stop_erlang_node(TargetNode).
+
+restart_random_node(Name, NodeId, Nodes, Config) ->
+    RestartNode = get_random_node(NodeId, Nodes),
+    ct:pal("Restarting node ~p~n", [RestartNode]),
+    ct_rpc:call(RestartNode, init, stop, []),
+    erlang_node_helpers:wait_for_stop(RestartNode, 100),
+    erlang_node_helpers:start_erlang_node(RestartNode, Config),
+    setup_ra_cluster(Name, [RestartNode]).
+
+setup_ra_cluster(Name, Nodes) ->
+    {ok, Cwd} = file:get_cwd(),
+    filelib:ensure_dir(filename:join(Cwd, "partitions_SUITE")),
+    start_ra_cluster(Name, Nodes),
+    NodeId = {Name, hd(Nodes)}.
+
+print_metrics(Nodes) ->
+    [print_node_metrics(Node) || Node <- Nodes].
+
+print_node_metrics(Node) ->
+    ct:pal("Node ~p metrics ~p~n", [Node, ct_rpc:call(Node, ets, tab2list, [ra_fifo_metrics])]).
+
+publish_n_messages(MsgCount, NodeId, EveryN, EveryFun) ->
+    spawn(fun() ->
+        [begin
+            Ref = make_ref(),
+            Msg = {msg, N},
+
+            {ok, _Term, _Leader} = ra:send_and_await_consensus(NodeId, {enqueue, Msg}, infinity),
+            % ok = ra:send_and_notify(NodeId, {enqueue, Msg}, Ref),
+            % receive
+                % {ra_event, _Leader, applied, Ref} -> ok
+            % after 100000 ->
+                    % error(consensus_timeout)
+            % end,
+            case N rem EveryN of
+                0 -> EveryFun();
+                _ -> ok
+            end
+        end
+         || N <- lists:seq(1, MsgCount)]
+    end).
+
+wait_for_consumption(MsgCount, NodeId, EveryN, EveryFun) ->
+    ExpectedMessages = lists:seq(1, MsgCount),
+    ReceivedMessages = lists:foldl(fun(N, Received) ->
+        receive
+        {ra_fifo, _Leader, {delivery, Cid, MsgId, {msg, Msg}}} ->
+        % {ra_event, Leader, machine, {msg, MsgId, {msg, Msg}}} ->
+            case N rem EveryN of
+                0 -> EveryFun();
+                _ -> ok
+            end,
+            ct:pal("Leader is ~p~n", [_Leader]),
+            ct:pal("Awaiting consensus on: ~p~n with message ~p message Id ~p~n", [_Leader, Msg, MsgId]),
+            {ok, _Term, _NewLeader} = R =
+                ra:send_and_await_consensus(_Leader, {settle, MsgId, {Cid, self()}}, infinity),
+            ct:pal("Got consensus ~p~n", [R]),
+            [Msg | Received]
+        after 100000000 ->
+                  error(ra_event_timeout)
+        end
+    end,
+    [],
+    ExpectedMessages),
+    ct:pal("Received ~p~n", [ReceivedMessages]),
+    ct:pal("Expected ~p~n", [ExpectedMessages]),
+    [] = ReceivedMessages -- ExpectedMessages,
+    [] = ExpectedMessages -- ReceivedMessages.
+
+customer_id() ->  {<<"cid">>, self()}.
+
+%% ==================================
+%% RA cluster setup
+
+start_ra_cluster(Name, Nodes) ->
+    {ok, Cwd} = file:get_cwd(),
+    Configs = lists:map(fun(Node) ->
+        ct:pal("Start app on ~p~n", [Node]),
+        NodeConfig = make_node_ra_config(Name, Nodes, Node, Cwd),
+        ok = ct_rpc:call(Node, application, load, [ra]),
+        ok = ct_rpc:call(Node, application, set_env, [ra, data_dir, filename:join([Cwd, "partitions_SUITE", atom_to_list(Node)])]),
+        {ok, _} = ct_rpc:call(Node, application, ensure_all_started, [ra]),
+        prepare_node(Node),
+        NodeConfig
+    end,
+    Nodes),
+    lists:map(fun(#{id := {_, Node}} = NodeConfig) ->
+        ct:pal("Start ra node on ~p~n", [Node]),
+        ok = ct_rpc:call(Node, ra, start_node, [NodeConfig]),
+        NodeConfig
+    end,
+    Configs).
+
+make_node_ra_config(Name, Nodes, Node, Cwd) ->
+    #{ id => {Name, Node},
+       uid => atom_to_binary(Name, utf8),
+       initial_nodes => [{Name, N} || N <- Nodes],
+       log_module => ra_log_file,
+       log_init_args =>
+            #{data_dir => filename:join([Cwd, "partitions_SUITE", atom_to_list(Node)]),
+              uid => atom_to_binary(Name, utf8)},
+       machine => {module, ra_fifo}
+       }.
+
+prepare_node(Node) ->
+    spawn(Node,
+          fun() ->
+            ets:new(ra_fifo_metrics, [public, named_table, {write_concurrency, true}]),
+            receive stop -> ok end
+          end).
+
+%% ==================================
+%% Erlang node startup
+
+erlang_nodes(5) ->
+    [
+     foo1@localhost,
+     foo2@localhost,
+     foo3@localhost,
+     foo4@localhost,
+     foo5@localhost
+     ].

--- a/test/tcp_inet_proxy_helpers.erl
+++ b/test/tcp_inet_proxy_helpers.erl
@@ -1,0 +1,88 @@
+-module(tcp_inet_proxy_helpers).
+
+-export([enable_dist_proxy_manager/1,
+         enable_dist_proxy/2,
+         start_dist_proxy_on_node/1,
+         disconnect_from_other_nodes/1,
+         block_traffic_between/2,
+         allow_traffic_between/2]).
+
+enable_dist_proxy_manager(Config) ->
+    inet_tcp_proxy_manager:start(),
+    rabbit_ct_helpers:set_config(Config,
+      {erlang_dist_module, inet_proxy_dist}).
+
+enable_dist_proxy(Nodes, Config) ->
+    ManagerNode = node(),
+    %% We first start the proxy process on all nodes, then we close the
+    %% existing connection.
+    %%
+    %% If we do that in a single loop, i.e. start the proxy on node 1
+    %% and disconnect it, then, start the proxy on node 2 and disconnect
+    %% it, etc., there is a chance that the connection is reopened
+    %% by a node where the proxy is still disabled. Therefore, that
+    %% connection would bypass the proxy process even though we believe
+    %% it to be enabled.
+    Map = lists:map(
+      fun(Node) ->
+          {DistPort, ProxyPort} = ct_rpc:call(Node, ?MODULE, start_dist_proxy_on_node, [ManagerNode])
+      end, Nodes),
+    ok = lists:foreach(fun(Node) ->
+        ok = ct_rpc:call(Node, application, set_env, [kernel, dist_and_proxy_ports_map, Map])
+    end,
+    Nodes),
+    ok = lists:foreach(
+      fun(Node) ->
+          ok = ct_rpc:call(Node, ?MODULE, disconnect_from_other_nodes, [Nodes -- [Node]])
+      end, Nodes),
+    Config.
+
+start_dist_proxy_on_node(ManagerNode) ->
+    DistPort = get_dist_port(),
+    ProxyPort = get_free_port(),
+    ok = inet_tcp_proxy:start(ManagerNode, DistPort, ProxyPort),
+    {DistPort, ProxyPort}.
+
+disconnect_from_other_nodes(Nodes) ->
+    ok = inet_tcp_proxy:reconnect(Nodes).
+
+get_dist_port() ->
+    [Self | _] = string:split(atom_to_list(node()), "@"),
+    {ok, Names} = net_adm:names(),
+    proplists:get_value(Self, Names).
+
+get_free_port() ->
+    {ok, Listen} = gen_tcp:listen(0, []),
+    {ok, Port} = inet:port(Listen),
+    gen_tcp:close(Listen),
+    Port.
+
+block_traffic_between(NodeA, NodeB) ->
+    true = rpc:call(NodeA, inet_tcp_proxy, block, [NodeB]),
+    true = rpc:call(NodeB, inet_tcp_proxy, block, [NodeA]),
+    wait_for_blocked(NodeA, NodeB, 10).
+
+allow_traffic_between(NodeA, NodeB) ->
+    true = rpc:call(NodeA, inet_tcp_proxy, allow, [NodeB]),
+    true = rpc:call(NodeB, inet_tcp_proxy, allow, [NodeA]),
+    wait_for_unblocked(NodeA, NodeB, 10).
+
+wait_for_blocked(NodeA, NodeB, 0) ->
+    error({failed_to_block, NodeA, NodeB, no_more_attempts});
+wait_for_blocked(NodeA, NodeB, Attempts) ->
+    case rpc:call(NodeA, rpc, call, [NodeB, erlang, node, []], 1000) of
+        {badrpc, _} -> ok;
+        _           ->
+            timer:sleep(50),
+            wait_for_blocked(NodeA, NodeB, Attempts - 1)
+    end.
+
+wait_for_unblocked(NodeA, NodeB, 0) ->
+    error({failed_to_unblock, NodeA, NodeB, no_more_attempts});
+wait_for_unblocked(NodeA, NodeB, Attempts) ->
+    case rpc:call(NodeA, rpc, call, [NodeB, erlang, node, []], 1000) of
+        NodeB       -> ok;
+        {badrpc, _} ->
+            timer:sleep(50),
+            wait_for_unblocked(NodeA, NodeB, Attempts - 1)
+    end.

--- a/test/tcp_inet_proxy_helpers.erl
+++ b/test/tcp_inet_proxy_helpers.erl
@@ -6,7 +6,7 @@
          disconnect_from_other_nodes/1,
          block_traffic_between/2,
          allow_traffic_between/2]).
--export([get_dist_port/0]).
+-export([get_dist_port/0, get_dist_port/1]).
 -export([wait_for_blocked/3]).
 enable_dist_proxy_manager(Config) ->
     inet_tcp_proxy_manager:start(),
@@ -48,7 +48,10 @@ disconnect_from_other_nodes(Nodes) ->
     ok = inet_tcp_proxy:reconnect(Nodes).
 
 get_dist_port() ->
-    [Self | _] = string:split(atom_to_list(node()), "@"),
+    get_dist_port(node()).
+
+get_dist_port(Node) ->
+    [Self | _] = string:split(atom_to_list(Node), "@"),
     {ok, Names} = net_adm:names(),
     proplists:get_value(Self, Names).
 

--- a/test/tcp_inet_proxy_helpers.erl
+++ b/test/tcp_inet_proxy_helpers.erl
@@ -6,6 +6,7 @@
          disconnect_from_other_nodes/1,
          block_traffic_between/2,
          allow_traffic_between/2]).
+-export([get_dist_port/0]).
 
 enable_dist_proxy_manager(Config) ->
     inet_tcp_proxy_manager:start(),

--- a/test/tcp_inet_proxy_helpers.erl
+++ b/test/tcp_inet_proxy_helpers.erl
@@ -7,7 +7,7 @@
          block_traffic_between/2,
          allow_traffic_between/2]).
 -export([get_dist_port/0]).
-
+-export([wait_for_blocked/3]).
 enable_dist_proxy_manager(Config) ->
     inet_tcp_proxy_manager:start(),
     rabbit_ct_helpers:set_config(Config,


### PR DESCRIPTION
partition_SUITE - publish/consume with restarting nodes and single node being blocked out.

jepsen_like_partition_SUITE - publish consume from a node in the cluster, counting sent,
confirmed, unconfirmed, delivered and acked messages. Uses nemesis process to create random
partitions.

