### PR TITLE
Rename committed_query to local_query.

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -50,8 +50,8 @@
 
 4. Perform a query
 
-    As we know the previous command achieved consensus a committed query to the leader is fine.
+    As we know the previous command achieved consensus a local query to the leader is fine.
 
     ```
-    {ok, {IdxTerm, 5}, Leader} = ra:committed_query({node1, node()}, fun (S) -> S end),
+    {ok, {IdxTerm, 5}, Leader} = ra:local_query({node1, node()}, fun (S) -> S end),
     ```

--- a/docs/edoc-info
+++ b/docs/edoc-info
@@ -2,7 +2,7 @@
 {application,ra}.
 {modules,[ra,ra_app,ra_directory,ra_env,ra_fifo,ra_fifo_cli,ra_fifo_client,
           ra_fifo_index,ra_file_handle,ra_lib,ra_log,ra_log_ets,ra_log_meta,
-          ra_log_segment,ra_log_segment_writer,ra_log_snapshot_writer,
-          ra_log_sup,ra_log_wal,ra_log_wal_sup,ra_lru,ra_machine,
-          ra_machine_ets,ra_machine_simple,ra_metrics_ets,ra_node,
+          ra_log_segment,ra_log_segment_writer,ra_log_snapshot,
+          ra_log_snapshot_writer,ra_log_sup,ra_log_wal,ra_log_wal_sup,ra_lru,
+          ra_machine,ra_machine_ets,ra_machine_simple,ra_metrics_ets,ra_node,
           ra_node_proc,ra_nodes_sup,ra_sup,ra_system_sup]}.

--- a/docs/modules-frame.html
+++ b/docs/modules-frame.html
@@ -22,6 +22,7 @@
 <tr><td><a href="ra_log_meta.html" target="overviewFrame" class="module">ra_log_meta</a></td></tr>
 <tr><td><a href="ra_log_segment.html" target="overviewFrame" class="module">ra_log_segment</a></td></tr>
 <tr><td><a href="ra_log_segment_writer.html" target="overviewFrame" class="module">ra_log_segment_writer</a></td></tr>
+<tr><td><a href="ra_log_snapshot.html" target="overviewFrame" class="module">ra_log_snapshot</a></td></tr>
 <tr><td><a href="ra_log_snapshot_writer.html" target="overviewFrame" class="module">ra_log_snapshot_writer</a></td></tr>
 <tr><td><a href="ra_log_sup.html" target="overviewFrame" class="module">ra_log_sup</a></td></tr>
 <tr><td><a href="ra_log_wal.html" target="overviewFrame" class="module">ra_log_wal</a></td></tr>

--- a/docs/ra.html
+++ b/docs/ra.html
@@ -28,10 +28,6 @@
   This is the least reliable way to interact with a ra node.</td></tr>
 <tr><td valign="top"><a href="#cast-3">cast/3</a></td><td>Cast a message to a node with a priority
   This is the least reliable way to interact with a ra node.</td></tr>
-<tr><td valign="top"><a href="#committed_query-2">committed_query/2</a></td><td>query the machine state on any node
-  This allows you to run the QueryFun over the the machine state and
-  return the result.</td></tr>
-<tr><td valign="top"><a href="#committed_query-3">committed_query/3</a></td><td></td></tr>
 <tr><td valign="top"><a href="#consistent_query-2">consistent_query/2</a></td><td>Query the state machine
   This allows a caller to query the state machine by appending the query
   to the log and returning the result once applied.</td></tr>
@@ -48,6 +44,10 @@
 <tr><td valign="top"><a href="#leave_and_terminate-1">leave_and_terminate/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#leave_and_terminate-2">leave_and_terminate/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#leave_and_terminate-3">leave_and_terminate/3</a></td><td></td></tr>
+<tr><td valign="top"><a href="#local_query-2">local_query/2</a></td><td>query the machine state on any node
+  This allows you to run the QueryFun over the node machine state and
+  return the result.</td></tr>
+<tr><td valign="top"><a href="#local_query-3">local_query/3</a></td><td></td></tr>
 <tr><td valign="top"><a href="#members-1">members/1</a></td><td>Query the members of a cluster.</td></tr>
 <tr><td valign="top"><a href="#members-2">members/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#overview-0">overview/0</a></td><td>return a map of overview data of the ra system on the current erlang
@@ -108,19 +108,6 @@
 </div><p>Cast a message to a node with a priority
   This is the least reliable way to interact with a ra node. If the node
   addressed isn't the leader no notification will be issued.</p>
-
-<h3 class="function"><a name="committed_query-2">committed_query/2</a></h3>
-<div class="spec">
-<p><tt>committed_query(NodeId::<a href="#type-ra_node_id">ra_node_id()</a>, QueryFun::fun((term()) -&gt; term())) -&gt; {ok, {<a href="#type-ra_idxterm">ra_idxterm()</a>, term()}, <a href="#type-ra_node_id">ra_node_id()</a> | not_known}</tt><br></p>
-</div><p>query the machine state on any node
-  This allows you to run the QueryFun over the the machine state and
-  return the result. Any ra node can be addressed.
-  This can return infinitely state results.</p>
-
-<h3 class="function"><a name="committed_query-3">committed_query/3</a></h3>
-<div class="spec">
-<p><tt>committed_query(NodeId::<a href="#type-ra_node_id">ra_node_id()</a>, QueryFun::fun((term()) -&gt; term()), Timeout::timeout()) -&gt; {ok, {<a href="#type-ra_idxterm">ra_idxterm()</a>, term()}, <a href="#type-ra_node_id">ra_node_id()</a> | not_known}</tt><br></p>
-</div>
 
 <h3 class="function"><a name="consistent_query-2">consistent_query/2</a></h3>
 <div class="spec">
@@ -191,6 +178,19 @@
 <h3 class="function"><a name="leave_and_terminate-3">leave_and_terminate/3</a></h3>
 <div class="spec">
 <p><tt>leave_and_terminate(ServerRef::<a href="#type-ra_node_id">ra_node_id()</a>, NodeId::<a href="#type-ra_node_id">ra_node_id()</a>, Timeout::timeout()) -&gt; ok | timeout | {error, no_proc}</tt><br></p>
+</div>
+
+<h3 class="function"><a name="local_query-2">local_query/2</a></h3>
+<div class="spec">
+<p><tt>local_query(NodeId::<a href="#type-ra_node_id">ra_node_id()</a>, QueryFun::fun((term()) -&gt; term())) -&gt; {ok, {<a href="#type-ra_idxterm">ra_idxterm()</a>, term()}, <a href="#type-ra_node_id">ra_node_id()</a> | not_known}</tt><br></p>
+</div><p>query the machine state on any node
+  This allows you to run the QueryFun over the node machine state and
+  return the result. Any ra node can be addressed.
+  This can return infinitely stale results.</p>
+
+<h3 class="function"><a name="local_query-3">local_query/3</a></h3>
+<div class="spec">
+<p><tt>local_query(NodeId::<a href="#type-ra_node_id">ra_node_id()</a>, QueryFun::fun((term()) -&gt; term()), Timeout::timeout()) -&gt; {ok, {<a href="#type-ra_idxterm">ra_idxterm()</a>, term()}, <a href="#type-ra_node_id">ra_node_id()</a> | not_known}</tt><br></p>
 </div>
 
 <h3 class="function"><a name="members-1">members/1</a></h3>

--- a/docs/ra_log.html
+++ b/docs/ra_log.html
@@ -16,7 +16,7 @@
 <h2><a name="types">Data Types</a></h2>
 
 <h3 class="typedecl"><a name="type-ra_log">ra_log()</a></h3>
-<p><tt>ra_log() = #state{uid = <a href="#type-ra_uid">ra_uid()</a>, first_index = <a href="#type-ra_index">ra_index()</a>, last_index = -1 | <a href="#type-ra_index">ra_index()</a>, last_term = <a href="#type-ra_term">ra_term()</a>, last_written_index_term = <a href="#type-ra_idxterm">ra_idxterm()</a>, segment_refs = [<a href="#type-segment_ref">segment_ref()</a>], open_segments = #{}, directory = list(), kv = <a href="ra_log_meta.html#type-state">ra_log_meta:state()</a>, snapshot_state = <a href="#type-maybe">maybe</a>({<a href="#type-ra_index">ra_index()</a>, <a href="#type-ra_term">ra_term()</a>, <a href="#type-maybe">maybe</a>(<a href="file.html#type-filename">file:filename()</a>)}), snapshot_interval = non_neg_integer(), snapshot_index_in_progress = <a href="#type-maybe">maybe</a>(<a href="#type-ra_index">ra_index()</a>), cache = #{}, wal = atom(), last_resend_time = <a href="#type-maybe">maybe</a>(integer()), resend_window_seconds = integer()}</tt></p>
+<p><tt>ra_log() = #state{uid = <a href="#type-ra_uid">ra_uid()</a>, first_index = <a href="#type-ra_index">ra_index()</a>, last_index = -1 | <a href="#type-ra_index">ra_index()</a>, last_term = <a href="#type-ra_term">ra_term()</a>, last_written_index_term = <a href="#type-ra_idxterm">ra_idxterm()</a>, segment_refs = [<a href="#type-segment_ref">segment_ref()</a>], open_segments = #{}, directory = <a href="file.html#type-filename">file:filename()</a>, kv = <a href="ra_log_meta.html#type-state">ra_log_meta:state()</a>, snapshot_state = <a href="#type-maybe">maybe</a>({<a href="#type-ra_index">ra_index()</a>, <a href="#type-ra_term">ra_term()</a>, <a href="#type-maybe">maybe</a>(<a href="file.html#type-filename">file:filename()</a>)}), snapshot_interval = non_neg_integer(), snapshot_index_in_progress = <a href="#type-maybe">maybe</a>(<a href="#type-ra_index">ra_index()</a>), cache = #{}, wal = atom(), last_resend_time = <a href="#type-maybe">maybe</a>(integer()), resend_window_seconds = integer()}</tt></p>
 
 
 <h3 class="typedecl"><a name="type-ra_log_event">ra_log_event()</a></h3>
@@ -27,16 +27,16 @@
 <p><tt>ra_log_init_args() = #{data_dir =&gt; string(), uid := <a href="#type-ra_uid">ra_uid()</a>, wal =&gt; atom(), snapshot_interval =&gt; non_neg_integer(), resend_window =&gt; integer()}</tt></p>
 
 
-<h3 class="typedecl"><a name="type-ra_log_snapshot">ra_log_snapshot()</a></h3>
-<p><tt>ra_log_snapshot() = {<a href="#type-ra_index">ra_index()</a>, <a href="#type-ra_term">ra_term()</a>, <a href="#type-ra_cluster">ra_cluster()</a>, term()}</tt></p>
-
-
 <h3 class="typedecl"><a name="type-ra_meta_key">ra_meta_key()</a></h3>
 <p><tt>ra_meta_key() = atom()</tt></p>
 
 
 <h3 class="typedecl"><a name="type-segment_ref">segment_ref()</a></h3>
 <p><tt>segment_ref() = {From::<a href="#type-ra_index">ra_index()</a>, To::<a href="#type-ra_index">ra_index()</a>, File::string()}</tt></p>
+
+
+<h3 class="typedecl"><a name="type-snapshot">snapshot()</a></h3>
+<p><tt>snapshot() = <a href="ra_log_snapshot.html#type-state">ra_log_snapshot:state()</a></tt></p>
 
 
 <h2><a name="index">Function Index</a></h2>
@@ -126,7 +126,7 @@
 
 <h3 class="function"><a name="install_snapshot-2">install_snapshot/2</a></h3>
 <div class="spec">
-<p><tt>install_snapshot(Snapshot::<a href="ra_log.html#type-ra_log_snapshot">ra_log:ra_log_snapshot()</a>, State::<a href="#type-ra_log">ra_log()</a>) -&gt; <a href="#type-ra_log">ra_log()</a></tt><br></p>
+<p><tt>install_snapshot(Snapshot::<a href="ra_log.html#type-snapshot">ra_log:snapshot()</a>, State::<a href="#type-ra_log">ra_log()</a>) -&gt; <a href="#type-ra_log">ra_log()</a></tt><br></p>
 </div>
 
 <h3 class="function"><a name="last_index_term-1">last_index_term/1</a></h3>
@@ -166,7 +166,7 @@
 
 <h3 class="function"><a name="read_snapshot-1">read_snapshot/1</a></h3>
 <div class="spec">
-<p><tt>read_snapshot(State::<a href="#type-ra_log">ra_log()</a>) -&gt; <a href="#type-maybe">maybe</a>(<a href="ra_log.html#type-ra_log_snapshot">ra_log:ra_log_snapshot()</a>)</tt><br></p>
+<p><tt>read_snapshot(State::<a href="#type-ra_log">ra_log()</a>) -&gt; <a href="#type-maybe">maybe</a>(<a href="ra_log.html#type-snapshot">ra_log:snapshot()</a>)</tt><br></p>
 </div>
 
 <h3 class="function"><a name="release_resources-1">release_resources/1</a></h3>

--- a/docs/ra_log_snapshot_writer.html
+++ b/docs/ra_log_snapshot_writer.html
@@ -65,12 +65,12 @@
 
 <h3 class="function"><a name="write_snapshot-3">write_snapshot/3</a></h3>
 <div class="spec">
-<p><tt>write_snapshot(From, Dir, Snapshot) -&gt; any()</tt></p>
+<p><tt>write_snapshot(From::pid(), Dir::<a href="file.html#type-filename_all">file:filename_all()</a>, Snapshot::<a href="ra_log.html#type-snapshot">ra_log:snapshot()</a>) -&gt; ok</tt><br></p>
 </div>
 
 <h3 class="function"><a name="write_snapshot_call-2">write_snapshot_call/2</a></h3>
 <div class="spec">
-<p><tt>write_snapshot_call(Dir, Snapshot) -&gt; any()</tt></p>
+<p><tt>write_snapshot_call(Dir::<a href="file.html#type-filename">file:filename()</a>, Snapshot::<a href="ra_log.html#type-snapshot">ra_log:snapshot()</a>) -&gt; {ok, File::<a href="file.html#type-filename">file:filename()</a>, Old::[<a href="file.html#type-filename">file:filename()</a>]}</tt><br></p>
 </div>
 <hr>
 

--- a/docs/ra_node_proc.html
+++ b/docs/ra_node_proc.html
@@ -178,7 +178,7 @@
 
 <h3 class="function"><a name="query-4">query/4</a></h3>
 <div class="spec">
-<p><tt>query(ServerRef::<a href="#type-ra_node_id">ra_node_id()</a>, QueryFun::<a href="#type-query_fun">query_fun()</a>, X3::dirty | consistent, Timeout::timeout()) -&gt; {ok, {<a href="#type-ra_idxterm">ra_idxterm()</a>, term()}, <a href="#type-ra_node_id">ra_node_id()</a>}</tt><br></p>
+<p><tt>query(ServerRef::<a href="#type-ra_node_id">ra_node_id()</a>, QueryFun::<a href="#type-query_fun">query_fun()</a>, X3::local | consistent, Timeout::timeout()) -&gt; {ok, {<a href="#type-ra_idxterm">ra_idxterm()</a>, term()}, <a href="#type-ra_node_id">ra_node_id()</a>}</tt><br></p>
 </div>
 
 <h3 class="function"><a name="recover-3">recover/3</a></h3>

--- a/rat.erl
+++ b/rat.erl
@@ -135,7 +135,7 @@ perc(Numbers) ->
         Perc <- [0.50, 0.75, 0.90, 0.95, 0.99, 0.999]].
 
 query(Node) ->
-    ra:dirty_query(Node, fun (S) -> S end).
+    ra:local_query(Node, fun (S) -> S end).
 
 p(F) ->
     lg:trace([ra_node, ra_node_proc, ra_proxy, ra_log_file], lg_file_tracer,

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -15,8 +15,8 @@
          send_and_notify/4,
          cast/2,
          cast/3,
-         committed_query/2,
-         committed_query/3,
+         local_query/2,
+         local_query/3,
          members/1,
          members/2,
          consistent_query/2,
@@ -468,21 +468,21 @@ cast(ServerRef, Priority, Command) ->
     ra_node_proc:cast_command(ServerRef, Priority, Cmd).
 
 %% @doc query the machine state on any node
-%% This allows you to run the QueryFun over the the machine state and
+%% This allows you to run the QueryFun over the node machine state and
 %% return the result. Any ra node can be addressed.
-%% This can return infinitely state results.
--spec committed_query(NodeId :: ra_node_id(),
+%% This can return infinitely stale results.
+-spec local_query(NodeId :: ra_node_id(),
                       QueryFun :: fun((term()) -> term())) ->
     {ok, {ra_idxterm(), term()}, ra_node_id() | not_known}.
-committed_query(ServerRef, QueryFun) ->
-    committed_query(ServerRef, QueryFun, ?DEFAULT_TIMEOUT).
+local_query(ServerRef, QueryFun) ->
+    local_query(ServerRef, QueryFun, ?DEFAULT_TIMEOUT).
 
--spec committed_query(NodeId :: ra_node_id(),
+-spec local_query(NodeId :: ra_node_id(),
                       QueryFun :: fun((term()) -> term()),
                       Timeout :: timeout()) ->
     {ok, {ra_idxterm(), term()}, ra_node_id() | not_known}.
-committed_query(ServerRef, QueryFun, Timeout) ->
-    ra_node_proc:query(ServerRef, QueryFun, dirty, Timeout).
+local_query(ServerRef, QueryFun, Timeout) ->
+    ra_node_proc:query(ServerRef, QueryFun, local, Timeout).
 
 %% @doc Query the state machine
 %% This allows a caller to query the state machine by appending the query

--- a/src/ra_fifo_cli.erl
+++ b/src/ra_fifo_cli.erl
@@ -99,7 +99,7 @@ print_machine_state(#{nodes := Nodes}) ->
     end,
     io:format("Starting ra cluster on nodes ~w~n", [Nodes]),
     [begin
-         {ok, {IdxTerm, MacState}, _} = ra:committed_query(NodeId, fun (S) -> S end),
+         {ok, {IdxTerm, MacState}, _} = ra:local_query(NodeId, fun (S) -> S end),
          io:format("Machine state of node ~w at ~w:~n~p~n",
                    [NodeId, IdxTerm, MacState])
      end

--- a/src/ra_fifo_client.erl
+++ b/src/ra_fifo_client.erl
@@ -530,7 +530,7 @@ get_missing_deliveries(Leader, From, To, CustomerTag) ->
     Query = fun (State) ->
                     ra_fifo:get_checked_out(CustomerId, From, To, State)
             end,
-    {ok, {_, Missing}, _} = ra:committed_query(Leader, Query),
+    {ok, {_, Missing}, _} = ra:local_query(Leader, Query),
     Missing.
 
 pick_node(#state{leader = undefined, nodes = [N | _]}) ->

--- a/test/partitions_SUITE.erl
+++ b/test/partitions_SUITE.erl
@@ -138,7 +138,7 @@ validate_machine_state(Nodes) ->
     % give the cluster a bit of time to settle first
     timer:sleep(1000),
     MacStates = [begin
-                     {ok, S, _} = ra:committed_query(N, fun ra_lib:id/1),
+                     {ok, S, _} = ra:local_query(N, fun ra_lib:id/1),
                      S
                  end || N <- Nodes],
     H = hd(MacStates),

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -23,7 +23,7 @@ all_tests() ->
      send_and_notify,
      send_and_notify_reject,
      cast,
-     committed_query,
+     local_query,
      members,
      consistent_query,
      node_catches_up,
@@ -310,13 +310,13 @@ cast(Config) ->
     {ok, {_IdxTrm, 15}, _} = ra:consistent_query(A, fun (X) -> X end),
     terminate_cluster(Cluster).
 
-committed_query(Config) ->
+local_query(Config) ->
     [A, B, _C] = Cluster = start_local_cluster(3, ?config(test_name, Config),
                                                {simple, fun erlang:'+'/2, 9}, Config),
-    {ok, {{_, _}, 9}, _} = ra:committed_query(B, fun(S) -> S end),
+    {ok, {{_, _}, 9}, _} = ra:local_query(B, fun(S) -> S end),
     {ok, {_, Term}, Leader} = ra:send_and_await_consensus(A, 5,
                                                           ?SEND_AND_AWAIT_CONSENSUS_TIMEOUT),
-    {ok, {{_, Term}, 14}, _} = ra:committed_query(Leader, fun(S) -> S end),
+    {ok, {{_, Term}, 14}, _} = ra:local_query(Leader, fun(S) -> S end),
     terminate_cluster(Cluster).
 
 members(Config) ->
@@ -368,9 +368,9 @@ node_catches_up(Config) ->
     {ok, {_, Term}, _Leader} = ra:add_node(Leader, {N3, node()}),
     timer:sleep(1000),
     % at this point the node should be caught up
-    {ok, {_, Res}, _} = ra:committed_query(N1, fun ra_lib:id/1),
-    {ok, {_, Res}, _} = ra:committed_query(N2, fun ra_lib:id/1),
-    {ok, {_, Res}, _} = ra:committed_query(N3, fun ra_lib:id/1),
+    {ok, {_, Res}, _} = ra:local_query(N1, fun ra_lib:id/1),
+    {ok, {_, Res}, _} = ra:local_query(N2, fun ra_lib:id/1),
+    {ok, {_, Res}, _} = ra:local_query(N3, fun ra_lib:id/1),
     % check that the message isn't delivered multiple times
     terminate_cluster([N3 | InitialNodes]).
 

--- a/test/ra_fifo_SUITE.erl
+++ b/test/ra_fifo_SUITE.erl
@@ -450,15 +450,15 @@ test_queries(Config) ->
           end),
     F0 = ra_fifo_client:init(ClusterId, [NodeId], 4),
     {ok, _} = ra_fifo_client:checkout(<<"tag">>, 1, F0),
-    {ok, {_, Ready}, _} = ra:committed_query(NodeId,
+    {ok, {_, Ready}, _} = ra:local_query(NodeId,
                                              fun ra_fifo:query_messages_ready/1),
     ?assertEqual(1, maps:size(Ready)),
     ct:pal("Ready ~w~n", [Ready]),
-    {ok, {_, Checked}, _} = ra:committed_query(NodeId,
+    {ok, {_, Checked}, _} = ra:local_query(NodeId,
                                                fun ra_fifo:query_messages_checked_out/1),
     ?assertEqual(1, maps:size(Checked)),
     ct:pal("Checked ~w~n", [Checked]),
-    {ok, {_, Processes}, _} = ra:committed_query(NodeId,
+    {ok, {_, Processes}, _} = ra:local_query(NodeId,
                                                  fun ra_fifo:query_processes/1),
     ct:pal("Processes ~w~n", [Processes]),
     ?assertEqual(2, length(Processes)),
@@ -762,21 +762,21 @@ recover_after_kill(Config) ->
     %% this should by the default release cursor interval of 128
     %% create a new snapshot
     {_F3, _AllDeq} = enq_deq_n(65, F2, Deqd),
-    {ok, {_X, MS}, _} = ra:committed_query(NodeId, fun (S) -> S end),
+    {ok, {_X, MS}, _} = ra:local_query(NodeId, fun (S) -> S end),
     %% kill node again to trigger post snapshot recovery
     exit(whereis(Name), kill),
     timer:sleep(250),
     ra:members(NodeId),
     timer:sleep(100),
     % give leader time to commit noop
-    {ok, {_X2, MS2}, _} = ra:committed_query(NodeId, fun (S) -> S end),
+    {ok, {_X2, MS2}, _} = ra:local_query(NodeId, fun (S) -> S end),
     ok = ra:stop_node(NodeId),
     % ct:pal("Indexes ~p ~p~nMS: ~p ~n MS2: ~p~nDequeued ~p~n",
     %        [X, X2, MS, MS2, AllDeq]),
     ?assertEqual(MS, MS2),
     ok = ra:restart_node(NodeId),
     ra:members(NodeId),
-    {ok, {_, MS3}, _} = ra:committed_query(NodeId, fun (S) -> S end),
+    {ok, {_, MS3}, _} = ra:local_query(NodeId, fun (S) -> S end),
     ?assertEqual(MS2, MS3),
     ok.
 

--- a/test/ra_props_SUITE.erl
+++ b/test/ra_props_SUITE.erl
@@ -48,9 +48,9 @@ non_assoc_prop([A, B, C], {Ops, Initial}) ->
     [ra:send_and_await_consensus(Leader, Op) || Op <- Ops],
     {ok, _, Leader} = ra:consistent_query(A, fun(_) -> ok end),
     timer:sleep(100),
-    {ok, {_, ARes}, _} = ra:committed_query(A, fun id/1),
-    {ok, {_, BRes}, _} = ra:committed_query(B, fun id/1),
-    {ok, {_, CRes}, _} = ra:committed_query(C, fun id/1),
+    {ok, {_, ARes}, _} = ra:local_query(A, fun id/1),
+    {ok, {_, BRes}, _} = ra:local_query(B, fun id/1),
+    {ok, {_, CRes}, _} = ra:local_query(C, fun id/1),
     % ct:pal("Result ~p ~p ~p Expected ~p Initial ~p~n",
     %        [ARes, BRes, CRes, Expected, Initial]),
     % assert all nodes have the same final state


### PR DESCRIPTION
The committed_query function name is confusing, because it makes
you think the query is being committed.
Since it's already marked as dirty in the internal protocol, why
not call it like this?
This also highlights a difference between consistent and dirty.

