### PR TITLE
support gen-batch-server 0.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PROJECT = ra
 ESCRIPT_NAME = ra_fifo_cli
 ESCRIPT_EMU_ARGS = -noinput -setcookie ra_fifo_cli
 
-dep_gen_batch_server = hex 0.5.1
+dep_gen_batch_server = hex 0.6.0
 dep_aten = hex 0.5.0
 DEPS = aten gen_batch_server
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-        {gen_batch_server, "0.5.1"},
+        {gen_batch_server, "0.6.0"},
         {aten, "0.5.0"}
 ]}.
 {profiles,

--- a/rebar.config
+++ b/rebar.config
@@ -2,9 +2,21 @@
         {gen_batch_server, "0.6.0"},
         {aten, "0.5.0"}
 ]}.
+
 {profiles,
- [{test, [{deps, [meck, proper]}]}]
+ [{test, [{deps, [proper,
+                  meck,
+                  elvis,
+                  {looking_glass,
+                   {git, "https://github.com/rabbitmq/looking-glass.git",
+                    {branch, "master"}}}%,
+%                  {rabbitmq_ct_helpers,
+%                    {git, "https://github.com/rabbitmq/rabbitmq-ct-helpers",
+%                     {branch, "master"}}}
+                 ]}]}
+ ]
 }.
+
 {dist_node, [
     {sname, 'ra'}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
-[{<<"aten">>,
-  {git,"git@github.com:rabbitmq/aten.git",
-       {ref,"e7b76746925ff0b1272b86668dd8b16fbf2ef668"}},
-  0},
- {<<"gen_batch_server">>,
-  {git,"git@github.com:rabbitmq/gen-batch-server.git",
-       {ref,"b66ed5f1eeb738e1047441499baede944ac64570"}},
-  0}].
+{"1.1.0",
+[{<<"aten">>,{pkg,<<"aten">>,<<"0.5.0">>},0},
+ {<<"gen_batch_server">>,{pkg,<<"gen_batch_server">>,<<"0.6.0">>},0}]}.
+[
+{pkg_hash,[
+ {<<"aten">>, <<"E3D625D763B0B077A802D642C37CF8159AB771AA5ACD915E1939195A223D96A7">>},
+ {<<"gen_batch_server">>, <<"2F7D3D4BF50A3AFF9CFF2C640593D02C07464452A744309A3AB2071ED335DF01">>}]}
+].

--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -92,7 +92,7 @@
 -type wal_command() ::
     {append | truncate, writer_id(), atom(), ra_index(), ra_term(), term()}.
 
--type wal_op() :: {cast, gen_batch_server:server_ref(), wal_command()} |
+-type wal_op() :: {cast, wal_command()} |
                   {call, from(), wal_command()}.
 
 -spec write(writer_id(), atom(), ra_index(), ra_term(), term()) ->

--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -200,7 +200,7 @@ format_status(#state{write_strategy = Strat,
 
 %% Internal
 
-handle_op({cast, _, WalCmd}, State) ->
+handle_op({cast, WalCmd}, State) ->
     handle_msg(WalCmd, State).
 
 recover_wal(Dir, #{max_size_bytes := MaxWalSize,


### PR DESCRIPTION
with gen-batch-server >= 0.6x cast doesn't pass the requester pid
anymore. This change fix it.