### PR TITLE
Do not configure data_dir. Use the current dir by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,6 @@ PROJECT = ra
 
 ##NB: ra uses an src/ra.app.src file
 
-# define PROJECT_ENV
-# [
-# 	{data_dir, "/tmp/ra_data"}
-# ]
-# endef
-
 ESCRIPT_NAME = ra_fifo_cli
 ESCRIPT_EMU_ARGS = -noinput -setcookie ra_fifo_cli
 

--- a/src/ra.app.src
+++ b/src/ra.app.src
@@ -31,4 +31,4 @@
               {registered,[ra_sup]},
               {applications,[kernel,stdlib,sasl,crypto,aten,gen_batch_server]},
               {mod,{ra_app,[]}},
-              {env,[{data_dir,"/tmp/ra_data"}]}]}.
+              {env,[]}]}.

--- a/src/ra_env.erl
+++ b/src/ra_env.erl
@@ -10,13 +10,15 @@
               ]).
 
 data_dir() ->
-    case application:get_env(ra, data_dir) of
+    DataDir = case application:get_env(ra, data_dir) of
         {ok, Dir} ->
-            Node = ra_lib:to_list(node()),
-            filename:join(Dir, Node);
+            Dir;
         undefined ->
-            exit({ra_missing_config, data_dir})
-    end.
+            {ok, Cwd} = file:get_cwd(),
+            Cwd
+    end,
+    Node = ra_lib:to_list(node()),
+    filename:join(DataDir, Node).
 
 server_data_dir(UId) ->
     Me = ra_lib:to_list(UId),


### PR DESCRIPTION
Do not set the default `data_dir`. Use the current dir if it's not set.

The applications can check if it's set in the config file by checking the env variable.