### PR TITLE
Ra machine apply 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# Ra: a Raft Implementation for Erlang and Elixir
 
 [![Build Status](https://travis-ci.org/rabbitmq/ra.svg?branch=master)](https://travis-ci.org/rabbitmq/ra)
 

--- a/docs/edoc-info
+++ b/docs/edoc-info
@@ -1,3 +1,3 @@
 %% encoding: UTF-8
 {application,ra}.
-{modules,[ra,ra_directory,ra_env,ra_machine]}.
+{modules,[ra,ra_directory,ra_env,ra_machine,ra_server,ra_snapshot]}.

--- a/docs/modules-frame.html
+++ b/docs/modules-frame.html
@@ -10,6 +10,8 @@
 <tr><td><a href="ra.html" target="overviewFrame" class="module">ra</a></td></tr>
 <tr><td><a href="ra_directory.html" target="overviewFrame" class="module">ra_directory</a></td></tr>
 <tr><td><a href="ra_env.html" target="overviewFrame" class="module">ra_env</a></td></tr>
-<tr><td><a href="ra_machine.html" target="overviewFrame" class="module">ra_machine</a></td></tr></table>
+<tr><td><a href="ra_machine.html" target="overviewFrame" class="module">ra_machine</a></td></tr>
+<tr><td><a href="ra_server.html" target="overviewFrame" class="module">ra_server</a></td></tr>
+<tr><td><a href="ra_snapshot.html" target="overviewFrame" class="module">ra_snapshot</a></td></tr></table>
 </body>
 </html>

--- a/docs/ra.html
+++ b/docs/ra.html
@@ -391,7 +391,7 @@ withing some time window.
 When the command is applied to the state machine the ra server will send  
 the calling process a ra_event of the following structure:</p>
  
-  <p><code>{ra_event, {applied, [{Correlation, Reply}]}}</code></p>
+  <p><code>{ra_event, CurrentLeader, {applied, [{Correlation, Reply}]}}</code></p>
  
   <p>Not that ra will batch notification and thus return a list of correlation  
 and result tuples.</p>
@@ -400,7 +400,7 @@ and result tuples.</p>
 structure will be returned informing the caller that it cannot process the  
 message including the current leader, if known:</p>
  
-  <p><code>{ra_event, {rejected, {not_leader, Leader | undefined, Correlation}}}</code>  
+  <p><code>{ra_event, CurrentLeader, {rejected, {not_leader, Leader | undefined, Correlation}}}</code>  
 The caller can then redirect the command for the correlation identifier to  
 the correct ra server.</p>
  

--- a/docs/ra_directory.html
+++ b/docs/ra_directory.html
@@ -20,6 +20,7 @@
 <tr><td valign="top"><a href="#unregister_name-1">unregister_name/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#where_is-1">where_is/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#name_of-1">name_of/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#pid_of-1">pid_of/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#uid_of-1">uid_of/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#send-2">send/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#overview-0">overview/0</a></td><td></td></tr>
@@ -59,6 +60,11 @@
 <h3 class="function"><a name="name_of-1">name_of/1</a></h3>
 <div class="spec">
 <p><pre>name_of(UId :: <a href="#type-ra_uid">ra_uid()</a>) -&gt; atom()</pre></p>
+</div>
+
+<h3 class="function"><a name="pid_of-1">pid_of/1</a></h3>
+<div class="spec">
+<p><pre>pid_of(UId :: <a href="#type-ra_uid">ra_uid()</a>) -&gt; <a href="#type-maybe">maybe</a>(pid())</pre></p>
 </div>
 
 <h3 class="function"><a name="uid_of-1">uid_of/1</a></h3>

--- a/docs/ra_machine.html
+++ b/docs/ra_machine.html
@@ -25,15 +25,14 @@
  
  <p><br>
   <code>-callback apply(Meta :: command_meta_data(),
-                        <a href="#type-command"><code>command()</code></a>, effects(), State) -&gt;
-     {State, <a href="#type-effects"><code>effects()</code></a>, <a href="#type-reply"><code>reply()</code></a>}</code></p>
+                        <a href="#type-command"><code>command()</code></a>, State) -&gt;
+     {State, <a href="#type-reply"><code>reply()</code></a>, <a href="#type-effects"><code>effects()</code></a>} | {State, <a href="#type-reply"><code>reply()</code></a>}</code></p>
  
-  <p>Applies each entry to the state machine. Effects should be prepended to the  
-incoming list of effects. Ra will reverse the list of effects before  
-processing.</p>
+  <p>Applies each entry to the state machine.</p>
  
  <p><br>
-  <code>-callback state_enter(ra_server:ra_state() | eol, state()) -&gt; effects().
+  <code>
+  -callback state_enter(ra_server:ra_state() | eol, state()) -&gt; effects().
   </code></p>
  
   <p>Optional. Called when the ra server enters a new state. Called for all states
@@ -83,7 +82,7 @@ Suitable for issuing periodic side effects such as updating metrics systems.</p>
     {release_cursor, <a href="#type-ra_index">ra_index()</a>, <a href="#type-state">state()</a>} |
     {aux, term()} |
     garbage_collection</pre></p>
-<p><p>  Effects are data structure that can be returned by <a href="#apply-4"><code>apply/4</code></a> to ask  
+<p><p>  Effects are data structure that can be returned by <a href="#apply-3"><code>apply/3</code></a> to ask  
 ra to realise a side-effect in the real works, such as sending  
 a message to a process.</p>
  
@@ -142,7 +141,7 @@ is a good idea.</p>
   <a href="ra.html#process_command-3"><code>ra:process_command/3</code></a></p>
 
 <h3 class="typedecl"><a name="type-send_msg_opt">send_msg_opt()</a></h3>
-<p><pre>send_msg_opt() = [ra_event | cast]</pre></p>
+<p><pre>send_msg_opt() = [ra_event | cast] | ra_event | cast</pre></p>
 <p><p>  ra_event: the message will be wrapped up and sent as a ra event
   e.g: <code>{ra_event, ra_server_id(), Msg}</code></p>
  
@@ -162,7 +161,7 @@ is a good idea.</p>
 
 <h2><a name="index">Function Index</a></h2>
 <table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#init-2">init/2</a></td><td>initialise a new machine.</td></tr>
-<tr><td valign="top"><a href="#apply-5">apply/5</a></td><td></td></tr>
+<tr><td valign="top"><a href="#apply-4">apply/4</a></td><td></td></tr>
 <tr><td valign="top"><a href="#tick-3">tick/3</a></td><td></td></tr>
 <tr><td valign="top"><a href="#state_enter-3">state_enter/3</a></td><td>called when the ra_server_proc enters a new state.</td></tr>
 <tr><td valign="top"><a href="#overview-2">overview/2</a></td><td></td></tr>
@@ -170,6 +169,7 @@ is a good idea.</p>
 <tr><td valign="top"><a href="#handle_aux-7">handle_aux/7</a></td><td></td></tr>
 <tr><td valign="top"><a href="#query-3">query/3</a></td><td></td></tr>
 <tr><td valign="top"><a href="#module-1">module/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#snapshot_module-1">snapshot_module/1</a></td><td></td></tr>
 </table>
 
 <h2><a name="functions">Function Details</a></h2>
@@ -179,14 +179,13 @@ is a good idea.</p>
 <p><pre>init(X1 :: <a href="#type-machine">machine()</a>, Name :: atom()) -&gt; <a href="#type-state">state()</a></pre></p>
 </div><p>initialise a new machine</p>
 
-<h3 class="function"><a name="apply-5">apply/5</a></h3>
+<h3 class="function"><a name="apply-4">apply/4</a></h3>
 <div class="spec">
 <p><pre>apply(X1 :: <a href="#type-machine">machine()</a>,
       Metadata :: <a href="#type-command_meta_data">command_meta_data()</a>,
       Cmd :: <a href="#type-command">command()</a>,
-      Effects :: <a href="#type-effects">effects()</a>,
       State) -&gt;
-         {State, <a href="#type-effects">effects()</a>, <a href="#type-reply">reply()</a>}</pre></p>
+         {State, <a href="#type-reply">reply()</a>, <a href="#type-effects">effects()</a>} | {State, <a href="#type-reply">reply()</a>}</pre></p>
 </div>
 
 <h3 class="function"><a name="tick-3">tick/3</a></h3>
@@ -240,6 +239,11 @@ is a good idea.</p>
 <h3 class="function"><a name="module-1">module/1</a></h3>
 <div class="spec">
 <p><pre>module(X1 :: <a href="#type-machine">machine()</a>) -&gt; module()</pre></p>
+</div>
+
+<h3 class="function"><a name="snapshot_module-1">snapshot_module/1</a></h3>
+<div class="spec">
+<p><pre>snapshot_module(X1 :: <a href="#type-machine">machine()</a>) -&gt; module()</pre></p>
 </div>
 <hr>
 

--- a/docs/ra_server.html
+++ b/docs/ra_server.html
@@ -1,0 +1,391 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Module ra_server</title>
+<link rel="stylesheet" type="text/css" href="stylesheet.css" title="EDoc">
+</head>
+<body bgcolor="white">
+<div class="navbar"><a name="#navbar_top"></a><table width="100%" border="0" cellspacing="0" cellpadding="2" summary="navigation bar"><tr><td><a href="overview-summary.html" target="overviewFrame">Overview</a></td><td><a href="http://www.erlang.org/"><img src="erlang.png" align="right" border="0" alt="erlang logo"></a></td></tr></table></div>
+<hr>
+
+<h1>Module ra_server</h1>
+<ul class="index"><li><a href="#types">Data Types</a></li><li><a href="#index">Function Index</a></li><li><a href="#functions">Function Details</a></li></ul>
+
+
+<h2><a name="types">Data Types</a></h2>
+
+<h3 class="typedecl"><a name="type-command">command()</a></h3>
+<p><pre>command() = 
+    {<a href="#type-command_type">command_type()</a>,
+     <a href="#type-command_meta">command_meta()</a>,
+     UserCommand :: term(),
+     <a href="#type-command_reply_mode">command_reply_mode()</a>} |
+    noop</pre></p>
+
+
+<h3 class="typedecl"><a name="type-command_correlation">command_correlation()</a></h3>
+<p><pre>command_correlation() = integer() | reference()</pre></p>
+
+
+<h3 class="typedecl"><a name="type-command_meta">command_meta()</a></h3>
+<p><pre>command_meta() = #{from := <a href="#type-maybe">maybe</a>(<a href="#type-from">from()</a>)}</pre></p>
+
+
+<h3 class="typedecl"><a name="type-command_reply_mode">command_reply_mode()</a></h3>
+<p><pre>command_reply_mode() = 
+    after_log_append |
+    await_consensus |
+    {notify_on_consensus, <a href="#type-command_correlation">command_correlation()</a>, pid()} |
+    noreply</pre></p>
+
+
+<h3 class="typedecl"><a name="type-command_type">command_type()</a></h3>
+<p><pre>command_type() = 
+    '$usr' |
+    '$ra_query' |
+    '$ra_join' |
+    '$ra_leave' |
+    '$ra_cluster_change' |
+    '$ra_cluster'</pre></p>
+
+
+<h3 class="typedecl"><a name="type-machine_conf">machine_conf()</a></h3>
+<p><pre>machine_conf() = 
+    {module, module(), InitConfig :: map()} |
+    {simple, <a href="#type-simple_apply_fun">simple_apply_fun</a>(term()), InitialState :: term()}</pre></p>
+<p>  The machine configuration.
+  This is how ra knows which module to use to invoke the ra_machine callbacks
+  and the config to pass to the <a href="ra_machine.html#init-1"><code>ra_machine:init/1</code></a> implementation.
+  The simple machine config is version that can only be used for simple state
+  machines that cannot access any of the advanced features.</p>
+
+<h3 class="typedecl"><a name="type-ra_await_condition_fun">ra_await_condition_fun()</a></h3>
+<p><pre>ra_await_condition_fun() = 
+    fun((<a href="#type-ra_msg">ra_msg()</a>, <a href="#type-ra_server_state">ra_server_state()</a>) -&gt; boolean())</pre></p>
+
+
+<h3 class="typedecl"><a name="type-ra_effect">ra_effect()</a></h3>
+<p><pre>ra_effect() = 
+    <a href="ra_machine.html#type-effect">ra_machine:effect()</a> |
+    <a href="ra_log.html#type-effect">ra_log:effect()</a> |
+    {reply, <a href="#type-ra_reply_body">ra_reply_body()</a>} |
+    {reply, term(), <a href="#type-ra_reply_body">ra_reply_body()</a>} |
+    {cast, <a href="#type-ra_server_id">ra_server_id()</a>, term()} |
+    {send_vote_requests,
+     [{<a href="#type-ra_server_id">ra_server_id()</a>, #request_vote_rpc{} | #pre_vote_rpc{}}]} |
+    {send_rpc, <a href="#type-ra_server_id">ra_server_id()</a>, #append_entries_rpc{}} |
+    {send_snapshot,
+     To :: <a href="#type-ra_server_id">ra_server_id()</a>,
+     {Module :: module(),
+      Ref :: term(),
+      LeaderId :: <a href="#type-ra_server_id">ra_server_id()</a>,
+      Term :: <a href="#type-ra_term">ra_term()</a>}} |
+    {next_event, <a href="#type-ra_msg">ra_msg()</a>} |
+    {next_event, cast, <a href="#type-ra_msg">ra_msg()</a>} |
+    {notify, pid(), reference()} |
+    {incr_metrics,
+     Table :: atom(),
+     [{Pos :: non_neg_integer(), Incr :: integer()}]}</pre></p>
+
+
+<h3 class="typedecl"><a name="type-ra_effects">ra_effects()</a></h3>
+<p><pre>ra_effects() = [<a href="#type-ra_effect">ra_effect()</a>]</pre></p>
+
+
+<h3 class="typedecl"><a name="type-ra_msg">ra_msg()</a></h3>
+<p><pre>ra_msg() = 
+    #append_entries_rpc{} |
+    {<a href="#type-ra_server_id">ra_server_id()</a>, #append_entries_reply{}} |
+    {<a href="#type-ra_server_id">ra_server_id()</a>, #install_snapshot_result{}} |
+    #request_vote_rpc{} |
+    #request_vote_result{} |
+    #pre_vote_rpc{} |
+    #pre_vote_result{} |
+    #install_snapshot_rpc{} |
+    election_timeout |
+    await_condition_timeout |
+    {command, <a href="#type-command">command()</a>} |
+    {commands, [<a href="#type-command">command()</a>]} |
+    <a href="ra_log.html#type-event">ra_log:event()</a></pre></p>
+
+
+<h3 class="typedecl"><a name="type-ra_reply_body">ra_reply_body()</a></h3>
+<p><pre>ra_reply_body() = 
+    #append_entries_reply{} |
+    #request_vote_result{} |
+    #install_snapshot_result{} |
+    #pre_vote_result{}</pre></p>
+
+
+<h3 class="typedecl"><a name="type-ra_server_config">ra_server_config()</a></h3>
+<p><pre>ra_server_config() = 
+    #{id := <a href="#type-ra_server_id">ra_server_id()</a>,
+      uid := <a href="#type-ra_uid">ra_uid()</a>,
+      cluster_name := <a href="#type-ra_cluster_name">ra_cluster_name()</a>,
+      log_init_args := <a href="ra_log.html#type-ra_log_init_args">ra_log:ra_log_init_args()</a>,
+      initial_members := [<a href="#type-ra_server_id">ra_server_id()</a>],
+      machine := <a href="#type-machine_conf">machine_conf()</a>,
+      broadcast_time =&gt; non_neg_integer(),
+      tick_timeout =&gt; non_neg_integer(),
+      await_condition_timeout =&gt; non_neg_integer()}</pre></p>
+
+
+<h3 class="typedecl"><a name="type-ra_server_state">ra_server_state()</a></h3>
+<p><pre>ra_server_state() = 
+    #{id := <a href="#type-ra_server_id">ra_server_id()</a>,
+      uid := <a href="#type-ra_uid">ra_uid()</a>,
+      leader_id =&gt; <a href="#type-maybe">maybe</a>(<a href="#type-ra_server_id">ra_server_id()</a>),
+      cluster := <a href="#type-ra_cluster">ra_cluster()</a>,
+      cluster_change_permitted := boolean(),
+      cluster_index_term := <a href="#type-ra_idxterm">ra_idxterm()</a>,
+      pending_cluster_changes := [term()],
+      previous_cluster =&gt; {<a href="#type-ra_index">ra_index()</a>, <a href="#type-ra_term">ra_term()</a>, <a href="#type-ra_cluster">ra_cluster()</a>},
+      current_term := <a href="#type-ra_term">ra_term()</a>,
+      log := term(),
+      voted_for =&gt; <a href="#type-maybe">maybe</a>(<a href="#type-ra_server_id">ra_server_id()</a>),
+      votes =&gt; non_neg_integer(),
+      commit_index := <a href="#type-ra_index">ra_index()</a>,
+      last_applied := <a href="#type-ra_index">ra_index()</a>,
+      persisted_last_applied =&gt; <a href="#type-ra_index">ra_index()</a>,
+      stop_after =&gt; <a href="#type-ra_index">ra_index()</a>,
+      machine := <a href="ra_machine.html#type-machine">ra_machine:machine()</a>,
+      machine_state := term(),
+      aux_state =&gt; term(),
+      condition =&gt; <a href="#type-ra_await_condition_fun">ra_await_condition_fun()</a>,
+      condition_timeout_effects =&gt; [<a href="#type-ra_effect">ra_effect()</a>],
+      pre_vote_token =&gt; reference()}</pre></p>
+
+
+<h3 class="typedecl"><a name="type-ra_state">ra_state()</a></h3>
+<p><pre>ra_state() = 
+    leader |
+    follower |
+    candidate |
+    pre_vote |
+    await_condition |
+    delete_and_terminate |
+    terminating_leader |
+    terminating_follower |
+    recover |
+    recovered |
+    stop |
+    receive_snapshot</pre></p>
+
+
+<h3 class="typedecl"><a name="type-simple_apply_fun">simple_apply_fun()</a></h3>
+<p><pre>simple_apply_fun(State) = fun((term(), State) -&gt; State)</pre></p>
+
+
+<h2><a name="index">Function Index</a></h2>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#name-2">name/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#init-1">init/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#recover-1">recover/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#handle_leader-2">handle_leader/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#handle_candidate-2">handle_candidate/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#handle_pre_vote-2">handle_pre_vote/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#handle_follower-2">handle_follower/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#handle_receive_snapshot-2">handle_receive_snapshot/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#handle_await_condition-2">handle_await_condition/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#tick-1">tick/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#handle_state_enter-2">handle_state_enter/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#overview-1">overview/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#is_new-1">is_new/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#is_fully_persisted-1">is_fully_persisted/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#is_fully_replicated-1">is_fully_replicated/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#handle_aux-4">handle_aux/4</a></td><td></td></tr>
+<tr><td valign="top"><a href="#id-1">id/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#uid-1">uid/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#machine-1">machine/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#leader_id-1">leader_id/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#current_term-1">current_term/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#make_rpcs-1">make_rpcs/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#update_release_cursor-3">update_release_cursor/3</a></td><td></td></tr>
+<tr><td valign="top"><a href="#persist_last_applied-1">persist_last_applied/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#update_peer_status-3">update_peer_status/3</a></td><td></td></tr>
+<tr><td valign="top"><a href="#handle_down-5">handle_down/5</a></td><td></td></tr>
+<tr><td valign="top"><a href="#terminate-2">terminate/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#log_fold-3">log_fold/3</a></td><td></td></tr>
+</table>
+
+<h2><a name="functions">Function Details</a></h2>
+
+<h3 class="function"><a name="name-2">name/2</a></h3>
+<div class="spec">
+<p><pre>name(ClusterName :: <a href="#type-ra_cluster_name">ra_cluster_name()</a>, UniqueSuffix :: string()) -&gt;
+        atom()</pre></p>
+</div>
+
+<h3 class="function"><a name="init-1">init/1</a></h3>
+<div class="spec">
+<p><pre>init(Config :: <a href="#type-ra_server_config">ra_server_config()</a>) -&gt; <a href="#type-ra_server_state">ra_server_state()</a></pre></p>
+</div>
+
+<h3 class="function"><a name="recover-1">recover/1</a></h3>
+<div class="spec">
+<p><tt>recover(State0) -&gt; any()</tt></p>
+</div>
+
+<h3 class="function"><a name="handle_leader-2">handle_leader/2</a></h3>
+<div class="spec">
+<p><pre>handle_leader(Install_snapshot_rpc :: <a href="#type-ra_msg">ra_msg()</a>,
+              State0 :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt;
+                 {<a href="#type-ra_state">ra_state()</a>, <a href="#type-ra_server_state">ra_server_state()</a>, <a href="#type-ra_effects">ra_effects()</a>}</pre></p>
+</div>
+
+<h3 class="function"><a name="handle_candidate-2">handle_candidate/2</a></h3>
+<div class="spec">
+<p><pre>handle_candidate(Request_vote_result ::
+                     <a href="#type-ra_msg">ra_msg()</a> | election_timeout,
+                 State0 :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt;
+                    {<a href="#type-ra_state">ra_state()</a>, <a href="#type-ra_server_state">ra_server_state()</a>, <a href="#type-ra_effects">ra_effects()</a>}</pre></p>
+</div>
+
+<h3 class="function"><a name="handle_pre_vote-2">handle_pre_vote/2</a></h3>
+<div class="spec">
+<p><pre>handle_pre_vote(Append_entries_rpc :: <a href="#type-ra_msg">ra_msg()</a>,
+                State0 :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt;
+                   {<a href="#type-ra_state">ra_state()</a>, <a href="#type-ra_server_state">ra_server_state()</a>, <a href="#type-ra_effects">ra_effects()</a>}</pre></p>
+</div>
+
+<h3 class="function"><a name="handle_follower-2">handle_follower/2</a></h3>
+<div class="spec">
+<p><pre>handle_follower(Append_entries_rpc :: <a href="#type-ra_msg">ra_msg()</a>,
+                State000 :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt;
+                   {<a href="#type-ra_state">ra_state()</a>, <a href="#type-ra_server_state">ra_server_state()</a>, <a href="#type-ra_effects">ra_effects()</a>}</pre></p>
+</div>
+
+<h3 class="function"><a name="handle_receive_snapshot-2">handle_receive_snapshot/2</a></h3>
+<div class="spec">
+<p><tt>handle_receive_snapshot(Install_snapshot_rpc, State0) -&gt; any()</tt></p>
+</div>
+
+<h3 class="function"><a name="handle_await_condition-2">handle_await_condition/2</a></h3>
+<div class="spec">
+<p><pre>handle_await_condition(Request_vote_rpc :: <a href="#type-ra_msg">ra_msg()</a>,
+                       State :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt;
+                          {<a href="#type-ra_state">ra_state()</a>,
+                           <a href="#type-ra_server_state">ra_server_state()</a>,
+                           <a href="#type-ra_effects">ra_effects()</a>}</pre></p>
+</div>
+
+<h3 class="function"><a name="tick-1">tick/1</a></h3>
+<div class="spec">
+<p><pre>tick(X1 :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt; <a href="#type-ra_effects">ra_effects()</a></pre></p>
+</div>
+
+<h3 class="function"><a name="handle_state_enter-2">handle_state_enter/2</a></h3>
+<div class="spec">
+<p><pre>handle_state_enter(RaftState :: <a href="#type-ra_state">ra_state()</a> | eol,
+                   State :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt;
+                      {<a href="#type-ra_server_state">ra_server_state()</a> | eol, <a href="#type-ra_effects">ra_effects()</a>}</pre></p>
+</div>
+
+<h3 class="function"><a name="overview-1">overview/1</a></h3>
+<div class="spec">
+<p><pre>overview(State :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt; map()</pre></p>
+</div>
+
+<h3 class="function"><a name="is_new-1">is_new/1</a></h3>
+<div class="spec">
+<p><pre>is_new(X1 :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt; boolean()</pre></p>
+</div>
+
+<h3 class="function"><a name="is_fully_persisted-1">is_fully_persisted/1</a></h3>
+<div class="spec">
+<p><pre>is_fully_persisted(X1 :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt; boolean()</pre></p>
+</div>
+
+<h3 class="function"><a name="is_fully_replicated-1">is_fully_replicated/1</a></h3>
+<div class="spec">
+<p><pre>is_fully_replicated(State :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt; boolean()</pre></p>
+</div>
+
+<h3 class="function"><a name="handle_aux-4">handle_aux/4</a></h3>
+<div class="spec">
+<p><tt>handle_aux(RaftState, Type, Cmd, State0) -&gt; any()</tt></p>
+</div>
+
+<h3 class="function"><a name="id-1">id/1</a></h3>
+<div class="spec">
+<p><pre>id(X1 :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt; <a href="#type-ra_server_id">ra_server_id()</a></pre></p>
+</div>
+
+<h3 class="function"><a name="uid-1">uid/1</a></h3>
+<div class="spec">
+<p><pre>uid(X1 :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt; <a href="#type-ra_uid">ra_uid()</a></pre></p>
+</div>
+
+<h3 class="function"><a name="machine-1">machine/1</a></h3>
+<div class="spec">
+<p><pre>machine(X1 :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt; module()</pre></p>
+</div>
+
+<h3 class="function"><a name="leader_id-1">leader_id/1</a></h3>
+<div class="spec">
+<p><pre>leader_id(State :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt; <a href="#type-maybe">maybe</a>(<a href="#type-ra_server_id">ra_server_id()</a>)</pre></p>
+</div>
+
+<h3 class="function"><a name="current_term-1">current_term/1</a></h3>
+<div class="spec">
+<p><pre>current_term(State :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt; <a href="#type-maybe">maybe</a>(<a href="#type-ra_term">ra_term()</a>)</pre></p>
+</div>
+
+<h3 class="function"><a name="make_rpcs-1">make_rpcs/1</a></h3>
+<div class="spec">
+<p><tt>make_rpcs(State) -&gt; any()</tt></p>
+</div>
+
+<h3 class="function"><a name="update_release_cursor-3">update_release_cursor/3</a></h3>
+<div class="spec">
+<p><pre>update_release_cursor(Index :: <a href="#type-ra_index">ra_index()</a>,
+                      MacState :: term(),
+                      State :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt;
+                         {<a href="#type-ra_server_state">ra_server_state()</a>, <a href="#type-ra_effects">ra_effects()</a>}</pre></p>
+</div>
+
+<h3 class="function"><a name="persist_last_applied-1">persist_last_applied/1</a></h3>
+<div class="spec">
+<p><pre>persist_last_applied(State :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt;
+                        <a href="#type-ra_server_state">ra_server_state()</a></pre></p>
+</div>
+
+<h3 class="function"><a name="update_peer_status-3">update_peer_status/3</a></h3>
+<div class="spec">
+<p><pre>update_peer_status(PeerId :: <a href="#type-ra_server_id">ra_server_id()</a>,
+                   Status :: <a href="#type-ra_peer_status">ra_peer_status()</a>,
+                   State :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt;
+                      <a href="#type-ra_server_state">ra_server_state()</a></pre></p>
+</div>
+
+<h3 class="function"><a name="handle_down-5">handle_down/5</a></h3>
+<div class="spec">
+<p><pre>handle_down(RaftState :: <a href="#type-ra_state">ra_state()</a>,
+            X2 :: machine | snapshot_sender | snapshot_writer,
+            Pid :: pid(),
+            Info :: term(),
+            State :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt;
+               {<a href="#type-ra_state">ra_state()</a>, <a href="#type-ra_server_state">ra_server_state()</a>, <a href="#type-ra_effects">ra_effects()</a>}</pre></p>
+</div>
+
+<h3 class="function"><a name="terminate-2">terminate/2</a></h3>
+<div class="spec">
+<p><pre>terminate(State :: <a href="#type-ra_server_state">ra_server_state()</a>,
+          Reason :: {shutdown, delete} | term()) -&gt;
+             ok</pre></p>
+</div>
+
+<h3 class="function"><a name="log_fold-3">log_fold/3</a></h3>
+<div class="spec">
+<p><pre>log_fold(RaState :: <a href="#type-ra_server_state">ra_server_state()</a>,
+         Fun :: fun((term(), State) -&gt; State),
+         State) -&gt;
+            {ok, State, <a href="#type-ra_server_state">ra_server_state()</a>} |
+            {error, term(), <a href="#type-ra_server_state">ra_server_state()</a>}</pre></p>
+</div>
+<hr>
+
+<div class="navbar"><a name="#navbar_bottom"></a><table width="100%" border="0" cellspacing="0" cellpadding="2" summary="navigation bar"><tr><td><a href="overview-summary.html" target="overviewFrame">Overview</a></td><td><a href="http://www.erlang.org/"><img src="erlang.png" align="right" border="0" alt="erlang logo"></a></td></tr></table></div>
+<p><i>Generated by EDoc</i></p>
+</body>
+</html>

--- a/docs/ra_snapshot.html
+++ b/docs/ra_snapshot.html
@@ -1,0 +1,188 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Module ra_snapshot</title>
+<link rel="stylesheet" type="text/css" href="stylesheet.css" title="EDoc">
+</head>
+<body bgcolor="white">
+<div class="navbar"><a name="#navbar_top"></a><table width="100%" border="0" cellspacing="0" cellpadding="2" summary="navigation bar"><tr><td><a href="overview-summary.html" target="overviewFrame">Overview</a></td><td><a href="http://www.erlang.org/"><img src="erlang.png" align="right" border="0" alt="erlang logo"></a></td></tr></table></div>
+<hr>
+
+<h1>Module ra_snapshot</h1>
+<ul class="index"><li><a href="#types">Data Types</a></li><li><a href="#index">Function Index</a></li><li><a href="#functions">Function Details</a></li></ul>
+
+
+<h2><a name="types">Data Types</a></h2>
+
+<h3 class="typedecl"><a name="type-effect">effect()</a></h3>
+<p><pre>effect() = {monitor, process, snapshot_writer, pid()}</pre></p>
+
+
+<h3 class="typedecl"><a name="type-file_err">file_err()</a></h3>
+<p><pre>file_err() = <a href="file.html#type-posix">file:posix()</a> | badarg | terminated | system_limit</pre></p>
+
+
+<h3 class="typedecl"><a name="type-meta">meta()</a></h3>
+<p><pre>meta() = {<a href="#type-ra_index">ra_index()</a>, <a href="#type-ra_term">ra_term()</a>, <a href="#type-ra_cluster_servers">ra_cluster_servers()</a>}</pre></p>
+
+
+<h3 class="typedecl"><a name="type-state">state()</a></h3>
+<p><b>abstract datatype</b>: <tt>state()</tt></p>
+
+
+<h2><a name="index">Function Index</a></h2>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#init-3">init/3</a></td><td></td></tr>
+<tr><td valign="top"><a href="#init_ets-0">init_ets/0</a></td><td></td></tr>
+<tr><td valign="top"><a href="#current-1">current/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#pending-1">pending/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#accepting-1">accepting/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#directory-1">directory/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#last_index_for-1">last_index_for/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#begin_snapshot-3">begin_snapshot/3</a></td><td></td></tr>
+<tr><td valign="top"><a href="#complete_snapshot-2">complete_snapshot/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#begin_accept-4">begin_accept/4</a></td><td></td></tr>
+<tr><td valign="top"><a href="#accept_chunk-3">accept_chunk/3</a></td><td></td></tr>
+<tr><td valign="top"><a href="#abort_accept-1">abort_accept/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#handle_down-3">handle_down/3</a></td><td></td></tr>
+<tr><td valign="top"><a href="#delete-2">delete/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#save-4">save/4</a></td><td></td></tr>
+<tr><td valign="top"><a href="#read-2">read/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#recover-1">recover/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#read_meta-2">read_meta/2</a></td><td></td></tr>
+</table>
+
+<h2><a name="functions">Function Details</a></h2>
+
+<h3 class="function"><a name="init-3">init/3</a></h3>
+<div class="spec">
+<p><pre>init(UId :: <a href="#type-ra_uid">ra_uid()</a>,
+     Module :: module(),
+     SnapshotsDir :: <a href="file.html#type-filename">file:filename()</a>) -&gt;
+        <a href="#type-state">state()</a></pre></p>
+</div>
+
+<h3 class="function"><a name="init_ets-0">init_ets/0</a></h3>
+<div class="spec">
+<p><pre>init_ets() -&gt; ok</pre></p>
+</div>
+
+<h3 class="function"><a name="current-1">current/1</a></h3>
+<div class="spec">
+<p><pre>current(X1 :: <a href="#type-state">state()</a>) -&gt; <a href="#type-maybe">maybe</a>(<a href="#type-ra_idxterm">ra_idxterm()</a>)</pre></p>
+</div>
+
+<h3 class="function"><a name="pending-1">pending/1</a></h3>
+<div class="spec">
+<p><pre>pending(X1 :: <a href="#type-state">state()</a>) -&gt; <a href="#type-maybe">maybe</a>({pid(), <a href="#type-ra_idxterm">ra_idxterm()</a>})</pre></p>
+</div>
+
+<h3 class="function"><a name="accepting-1">accepting/1</a></h3>
+<div class="spec">
+<p><pre>accepting(X1 :: <a href="#type-state">state()</a>) -&gt; <a href="#type-maybe">maybe</a>(<a href="#type-ra_idxterm">ra_idxterm()</a>)</pre></p>
+</div>
+
+<h3 class="function"><a name="directory-1">directory/1</a></h3>
+<div class="spec">
+<p><pre>directory(X1 :: <a href="#type-state">state()</a>) -&gt; <a href="file.html#type-filename">file:filename()</a></pre></p>
+</div>
+
+<h3 class="function"><a name="last_index_for-1">last_index_for/1</a></h3>
+<div class="spec">
+<p><pre>last_index_for(UId :: <a href="#type-ra_uid">ra_uid()</a>) -&gt; <a href="#type-maybe">maybe</a>(<a href="#type-ra_index">ra_index()</a>)</pre></p>
+</div>
+
+<h3 class="function"><a name="begin_snapshot-3">begin_snapshot/3</a></h3>
+<div class="spec">
+<p><pre>begin_snapshot(Meta :: <a href="#type-meta">meta()</a>,
+               ReleaseCursorRef :: term(),
+               State :: <a href="#type-state">state()</a>) -&gt;
+                  {<a href="#type-state">state()</a>, [<a href="#type-effect">effect()</a>]}</pre></p>
+</div>
+
+<h3 class="function"><a name="complete_snapshot-2">complete_snapshot/2</a></h3>
+<div class="spec">
+<p><pre>complete_snapshot(IdxTerm :: <a href="#type-ra_idxterm">ra_idxterm()</a>, State :: <a href="#type-state">state()</a>) -&gt;
+                     <a href="#type-state">state()</a></pre></p>
+</div>
+
+<h3 class="function"><a name="begin_accept-4">begin_accept/4</a></h3>
+<div class="spec">
+<p><pre>begin_accept(Crc :: non_neg_integer(),
+             Meta :: <a href="#type-meta">meta()</a>,
+             NumChunks :: non_neg_integer(),
+             State :: <a href="#type-state">state()</a>) -&gt;
+                {ok, <a href="#type-state">state()</a>}</pre></p>
+</div>
+
+<h3 class="function"><a name="accept_chunk-3">accept_chunk/3</a></h3>
+<div class="spec">
+<p><pre>accept_chunk(Chunk :: term(),
+             Num :: non_neg_integer(),
+             State :: <a href="#type-state">state()</a>) -&gt;
+                {ok, <a href="#type-state">state()</a>}</pre></p>
+</div>
+
+<h3 class="function"><a name="abort_accept-1">abort_accept/1</a></h3>
+<div class="spec">
+<p><pre>abort_accept(State :: <a href="#type-state">state()</a>) -&gt; <a href="#type-state">state()</a></pre></p>
+</div>
+
+<h3 class="function"><a name="handle_down-3">handle_down/3</a></h3>
+<div class="spec">
+<p><pre>handle_down(Pid :: pid(), Info :: term(), State :: <a href="#type-state">state()</a>) -&gt;
+               <a href="#type-state">state()</a></pre></p>
+</div>
+
+<h3 class="function"><a name="delete-2">delete/2</a></h3>
+<div class="spec">
+<p><tt>delete(Dir, X2) -&gt; any()</tt></p>
+</div>
+
+<h3 class="function"><a name="save-4">save/4</a></h3>
+<div class="spec">
+<p><pre>save(Module :: module(),
+     Location :: <a href="file.html#type-filename">file:filename()</a>,
+     Meta :: <a href="#type-meta">meta()</a>,
+     Data :: term()) -&gt;
+        ok | {error, <a href="#type-file_err">file_err()</a> | term()}</pre></p>
+</div>
+
+<h3 class="function"><a name="read-2">read/2</a></h3>
+<div class="spec">
+<p><pre>read(ChunkSizeBytes :: non_neg_integer(), State :: <a href="#type-state">state()</a>) -&gt;
+        {ok,
+         Crc :: non_neg_integer(),
+         Meta :: <a href="#type-meta">meta()</a>,
+         ChunkState,
+         [ChunkThunk ::
+              fun((ChunkState) -&gt; {binary(), ChunkState})]} |
+        {error, term()}</pre>
+<ul class="definitions"><li><pre>ChunkState = term()</pre></li></ul></p>
+</div>
+
+<h3 class="function"><a name="recover-1">recover/1</a></h3>
+<div class="spec">
+<p><pre>recover(X1 :: <a href="#type-state">state()</a>) -&gt;
+           {ok, Meta :: <a href="#type-meta">meta()</a>, State :: term()} |
+           {error, no_current_snapshot} |
+           {error, term()}</pre></p>
+</div>
+
+<h3 class="function"><a name="read_meta-2">read_meta/2</a></h3>
+<div class="spec">
+<p><pre>read_meta(Module :: module(), Location :: <a href="file.html#type-filename">file:filename()</a>) -&gt;
+             {ok, <a href="#type-meta">meta()</a>} |
+             {error,
+              invalid_format |
+              {invalid_version, integer()} |
+              checksum_error |
+              <a href="#type-file_err">file_err()</a> |
+              term()}</pre></p>
+</div>
+<hr>
+
+<div class="navbar"><a name="#navbar_bottom"></a><table width="100%" border="0" cellspacing="0" cellpadding="2" summary="navigation bar"><tr><td><a href="overview-summary.html" target="overviewFrame">Overview</a></td><td><a href="http://www.erlang.org/"><img src="erlang.png" align="right" border="0" alt="erlang logo"></a></td></tr></table></div>
+<p><i>Generated by EDoc</i></p>
+</body>
+</html>

--- a/src/ra_machine_simple.erl
+++ b/src/ra_machine_simple.erl
@@ -4,16 +4,16 @@
 
 -export([
          init/1,
-         apply/4
+         apply/3
          ]).
 
 init(#{simple_fun := Fun,
        initial_state := Initial}) ->
     {simple, Fun, Initial}.
 
-apply(_, Cmd, Effects, {simple, Fun, State}) ->
+apply(_, Cmd, {simple, Fun, State}) ->
     Next = Fun(Cmd, State),
     %% return the next state as the reply as well
-    {{simple, Fun, Next}, Effects, Next}.
+    {{simple, Fun, Next}, Next}.
 
 

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -828,11 +828,16 @@ perform_local_query(QueryFun, _, #{machine := {machine, MacMod, _},
 
 % effect handler: either executes an effect or builds up a list of
 % gen_statem 'Actions' to be returned.
-handle_effects(RaftState, Effects, EvtType, State0) ->
-    lists:foldl(fun(Effect, {State, Actions}) ->
+handle_effects(RaftState, Effects0, EvtType, State0) ->
+    lists:foldl(fun(Effects, {State, Actions}) when is_list(Effects) ->
+                        {S, A} = handle_effects(RaftState, Effects, EvtType,
+                                                State),
+                        %% TODO: avoid concat
+                        {S, Actions ++ A};
+                   (Effect, {State, Actions}) ->
                         handle_effect(RaftState, Effect, EvtType,
                                       State, Actions)
-                end, {State0, []}, Effects).
+                end, {State0, []}, Effects0).
 
 handle_effect(_, {send_rpc, To, Rpc}, _, State0, Actions) ->
     % fully qualified use only so that we can mock it for testing

--- a/src/ra_server_sup.erl
+++ b/src/ra_server_sup.erl
@@ -68,6 +68,7 @@ prepare_restart_rpc(RaName) ->
 
 -spec stop_server(RaNodeId :: ra_server_id()) -> ok | {error, term()}.
 stop_server({RaName, Node}) ->
+    %% TODO: this could timeout
     Pid = rpc:call(Node, ra_directory,
                    where_is, [RaName]),
     supervisor:terminate_child({?MODULE, Node}, Pid);

--- a/test/ra_2_SUITE.erl
+++ b/test/ra_2_SUITE.erl
@@ -324,21 +324,21 @@ start_cluster(ClusterName, ServerIds) ->
 init(_) ->
     queue:new().
 
-'apply'(_Meta, {enq, Msg}, Effects, State) ->
-    {queue:in(Msg, State), Effects, ok};
-'apply'(_Meta, deq, Effects, State0) ->
+'apply'(_Meta, {enq, Msg}, State) ->
+    {queue:in(Msg, State), ok};
+'apply'(_Meta, deq, State0) ->
     case queue:out(State0) of
         {{value, Item}, State} ->
-            {State, Effects, Item};
+            {State, Item};
         {empty, _} ->
-            {State0, Effects, empty}
+            {State0, empty}
     end;
-'apply'(_Meta, {deq, Pid}, Effects, State0) ->
+'apply'(_Meta, {deq, Pid}, State0) ->
     case queue:out(State0) of
         {{value, Item}, State} ->
-            {State, [{send_msg, Pid, Item, ra_event} | Effects], ok};
+            {State, ok, {send_msg, Pid, Item, ra_event}};
         {empty, _} ->
-            {State0, Effects, ok}
+            {State0, ok}
     end.
 
 state_enter(eol, State) ->

--- a/test/ra_machine_int_SUITE.erl
+++ b/test/ra_machine_int_SUITE.erl
@@ -77,8 +77,8 @@ send_msg_without_options(Config) ->
     Mod = ?config(modname, Config),
     meck:new(Mod, [non_strict]),
     meck:expect(Mod, init, fun (_) -> the_state end),
-    meck:expect(Mod, apply, fun (_, {echo, Pid, Msg}, _, State) ->
-                                    {State, [{send_msg, Pid, Msg}], ok}
+    meck:expect(Mod, apply, fun (_, {echo, Pid, Msg}, State) ->
+                                    {State, ok, {send_msg, Pid, Msg}}
                             end),
     ClusterName = ?config(cluster_name, Config),
     ServerId = ?config(server_id, Config),
@@ -95,8 +95,8 @@ send_msg_with_ra_event_option(Config) ->
     Mod = ?config(modname, Config),
     meck:new(Mod, [non_strict]),
     meck:expect(Mod, init, fun (_) -> the_state end),
-    meck:expect(Mod, apply, fun (_, {echo, Pid, Msg}, _, State) ->
-                                    {State, [{send_msg, Pid, Msg, ra_event}], ok}
+    meck:expect(Mod, apply, fun (_, {echo, Pid, Msg}, State) ->
+                                    {State, ok, {send_msg, Pid, Msg, ra_event}}
                             end),
     ClusterName = ?config(cluster_name, Config),
     ServerId = ?config(server_id, Config),
@@ -114,8 +114,8 @@ send_msg_with_cast_option(Config) ->
     Mod = ?config(modname, Config),
     meck:new(Mod, [non_strict]),
     meck:expect(Mod, init, fun (_) -> the_state end),
-    meck:expect(Mod, apply, fun (_, {echo, Pid, Msg}, _, State) ->
-                                    {State, [{send_msg, Pid, Msg, cast}], ok}
+    meck:expect(Mod, apply, fun (_, {echo, Pid, Msg}, State) ->
+                                    {State, ok, {send_msg, Pid, Msg, cast}}
                             end),
     ClusterName = ?config(cluster_name, Config),
     ServerId = ?config(server_id, Config),
@@ -134,8 +134,8 @@ send_msg_with_ra_event_and_cast_options(Config) ->
     meck:new(Mod, [non_strict]),
     meck:expect(Mod, init, fun (_) -> the_state end),
     meck:expect(Mod, apply,
-                fun (_, {echo, Pid, Msg}, _, State) ->
-                        {State, [{send_msg, Pid, Msg, [ra_event, cast]}], ok}
+                fun (_, {echo, Pid, Msg}, State) ->
+                        {State, ok, {send_msg, Pid, Msg, [ra_event, cast]}}
                 end),
     ClusterName = ?config(cluster_name, Config),
     ServerId = ?config(server_id, Config),
@@ -152,10 +152,10 @@ machine_replies(Config) ->
     Mod = ?config(modname, Config),
     meck:new(Mod, [non_strict]),
     meck:expect(Mod, init, fun (_) -> the_state end),
-    meck:expect(Mod, apply, fun (_, c1, _, State) ->
-                                    {State, [], the_reply};
-                                (_, c2, _, State) ->
-                                    {State, [], {error, some_error_reply}}
+    meck:expect(Mod, apply, fun (_, c1, State) ->
+                                    {State, the_reply};
+                                (_, c2, State) ->
+                                    {State, {error, some_error_reply}}
                             end),
     ClusterName = ?config(cluster_name, Config),
     ServerId = ?config(server_id, Config),
@@ -173,8 +173,8 @@ leader_monitors(Config) ->
     Mod = ?config(modname, Config),
     meck:new(Mod, [non_strict]),
     meck:expect(Mod, init, fun (_) -> [] end),
-    meck:expect(Mod, apply, fun (_, {monitor_me, Pid}, _, State) ->
-                                    {[Pid | State], [{monitor, process, Pid}], ok}
+    meck:expect(Mod, apply, fun (_, {monitor_me, Pid}, State) ->
+                                    {[Pid | State], ok,  {monitor, process, Pid}}
                             end),
     meck:expect(Mod, state_enter,
                 fun (leader, State) ->
@@ -207,12 +207,12 @@ follower_takes_over_monitor(Config) ->
     meck:new(Mod, [non_strict]),
     meck:expect(Mod, init, fun (_) -> [] end),
     meck:expect(Mod, apply,
-                fun (_, {monitor_me, Pid}, _, State) ->
-                        {[Pid | State], [{monitor, process, Pid}], ok};
-                    (_, Cmd, _, State) ->
+                fun (_, {monitor_me, Pid}, State) ->
+                        {[Pid | State], ok, [{monitor, process, Pid}]};
+                    (_, Cmd, State) ->
                         ct:pal("handling ~p", [Cmd]),
                         %% handle all
-                        {State, [], ok}
+                        {State, ok}
                 end),
     meck:expect(Mod, state_enter,
                 fun (leader, State) ->
@@ -252,8 +252,8 @@ deleted_cluster_emits_eol_effect(Config) ->
     meck:new(Mod, [non_strict]),
     meck:expect(Mod, init, fun (_) -> [] end),
     meck:expect(Mod, apply,
-                fun (_, {monitor_me, Pid}, _, State) ->
-                        {[Pid | State], [{monitor, process, Pid}], ok}
+                fun (_, {monitor_me, Pid}, State) ->
+                        {[Pid | State], ok, [{monitor, process, Pid}]}
                 end),
     meck:expect(Mod, state_enter,
                 fun (eol, State) ->
@@ -285,7 +285,7 @@ machine_state_enter_effects(Config) ->
     meck:new(Mod, [non_strict]),
     meck:expect(Mod, init, fun (_) -> [] end),
     meck:expect(Mod, apply,
-                fun (_, _, _, State) ->
+                fun (_, _, State) ->
                         {State, [], ok}
                 end),
     meck:expect(Mod, state_enter,

--- a/test/ra_queue.erl
+++ b/test/ra_queue.erl
@@ -4,23 +4,22 @@
 
 -export([
          init/1,
-         apply/4,
+         apply/3,
          state_enter/2,
          tick/2,
          overview/1
         ]).
 init(_) -> [].
 
-apply(#{index := Idx}, {enq, Msg}, Effects, State) ->
-    {State ++ [{Idx, Msg}], Effects, ok};
-apply(_Meta, {deq, ToPid}, Effects, [{EncIdx, Msg} | State]) ->
-    {State, [{send_msg, ToPid, Msg},
-             {release_cursor, EncIdx, []}
-             | Effects], ok};
-apply(_Meta, deq, Effects, [{EncIdx, Msg} | State]) ->
-    {State, [{release_cursor, EncIdx, State} | Effects], Msg};
-apply(_Meta, _, Effects, [] = State) ->
-    {State, Effects, ok}.
+apply(#{index := Idx}, {enq, Msg}, State) ->
+    {State ++ [{Idx, Msg}], ok};
+apply(_Meta, {deq, ToPid}, [{EncIdx, Msg} | State]) ->
+    {State, ok, [{send_msg, ToPid, Msg},
+                 {release_cursor, EncIdx, []}]};
+apply(_Meta, deq, [{EncIdx, Msg} | State]) ->
+    {State, Msg, {release_cursor, EncIdx, State}};
+apply(_Meta, _, [] = State) ->
+    {State, ok}.
 
 
 state_enter(_, _) -> [].


### PR DESCRIPTION
Change ra_machine apply/4 into apply/3

    This simplifies the ra_machine apply behaviour function not to take a
    list of effects and necessitate that any further effects are cons-ed to
    the existing list. Instead implemetors just return a list of effects in
    execution order.

    Also extended and amended the return type to avoid creating unnecessary
    lists and tuple slots.

Closes #38.