### PR TITLE
Delete mem tables outside of ra process

### DIFF
--- a/src/ra_log_ets.erl
+++ b/src/ra_log_ets.erl
@@ -3,7 +3,8 @@
 -behaviour(gen_server).
 
 -export([start_link/1,
-         give_away/1]).
+         give_away/1,
+         delete_tables/1]).
 
 -export([init/1,
          handle_call/3,
@@ -29,6 +30,10 @@ start_link(DataDir) ->
 give_away(Tid) ->
     ets:give_away(Tid, whereis(?MODULE), undefined).
 
+-spec delete_tables([ets:tid()]) -> ok.
+delete_tables(Tids) ->
+    gen_server:cast(?MODULE, {delete_tables, Tids}).
+
 %%%===================================================================
 %%% gen_server callbacks
 %%%===================================================================
@@ -51,13 +56,29 @@ init([DataDir]) ->
     %% {RaUId, ra_index()}
     _ = ets:new(ra_log_snapshot_state, [set | TableFlags]),
 
-    ra_directory:init(DataDir),
+    ok = ra_directory:init(DataDir),
     {ok, #state{}}.
 
 handle_call(_Request, _From, State) ->
     Reply = ok,
     {reply, Reply, State}.
 
+handle_cast({delete_tables, Tids}, State) ->
+    %% delete ets tables,
+    %% we need to be defensive here.
+    %% it is better to leak a table than to crash them all
+    [begin
+         try ets:delete(Tid) of
+             true -> ok
+         catch
+             _:Err ->
+                 ?WARN("ra_log_ets: failed to delete ets table ~w with ~w "
+                       "This table may need to be cleaned up manually~n",
+                       [Tid, Err]),
+                 ok
+         end
+     end || Tid <- Tids],
+    {noreply, State};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 

--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -471,7 +471,7 @@ close_open_mem_tables(OpnMemTbls, Filename, TblWriter) ->
 
     % notify segment_writer of new unflushed memtables
     ok = ra_log_segment_writer:accept_mem_tables(TblWriter, MemTables,
-                                                      Filename),
+                                                 Filename),
     ok.
 
 recovering_to_closed(Filename) ->

--- a/test/ra_log_ets_SUITE.erl
+++ b/test/ra_log_ets_SUITE.erl
@@ -1,0 +1,70 @@
+-module(ra_log_ets_SUITE).
+
+-compile(export_all).
+
+-export([
+         ]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [
+     {group, tests}
+    ].
+
+
+all_tests() ->
+    [
+     deletes_tables
+    ].
+
+groups() ->
+    [
+     {tests, [], all_tests()}
+    ].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+deletes_tables(Config) ->
+    _ = ra_log_ets:start_link(?config(priv_dir, Config)),
+    T1 = ets:new(t1, []),
+    T2 = ets:new(t2, []),
+    T3 = ets:new(t2, [public]),
+    ra_log_ets:give_away(T1),
+    ra_log_ets:give_away(T2),
+    ra_log_ets:give_away(T3),
+    ets:delete(T3),
+    ra_log_ets:delete_tables([T1, T2, T3]),
+    %% ensure prior messages have been processed
+    gen_server:call(ra_log_ets, noop),
+    undefined = ets:info(T1),
+    undefined = ets:info(T2),
+    proc_lib:stop(ra_log_ets),
+    ok.
+
+%% Utility


### PR DESCRIPTION
Large Mem tables (ETS) can take quite a bit of time to delete. This
change moves the ETS deletion from the ra process to the ETS owner
process, thus avoiding potential blocking inside Ra.
