### PR TITLE
Optimisation

### DIFF
--- a/src/noop.erl
+++ b/src/noop.erl
@@ -38,7 +38,6 @@ apply(#{index := I}, {noop, _}, State) ->
 
 
 start(Nodes) ->
-    application:ensure_all_started(ra),
     Servers = [begin
                    rpc:call(N, ?MODULE, prepare, []),
                    {noop, N}
@@ -63,8 +62,13 @@ client_loop(Leader) ->
             N = length(Applied),
             send_n(Leader, N),
             client_loop(Leader);
+        {ra_event, _, {rejected, {not_leader, NewLeader, _}}} ->
+            io:format("new leader ~w~n", [NewLeader]),
+            send_n(NewLeader, 1),
+            client_loop(NewLeader);
         {ra_event, Leader, Evt} ->
-            io:format("unexpected ra_event ~w", [Evt]),
+            io:format("unexpected ra_event ~w~n", [Evt]),
+
             client_loop(Leader)
     end.
 

--- a/src/noop.erl
+++ b/src/noop.erl
@@ -1,0 +1,105 @@
+-module(noop).
+
+-behaviour(ra_machine).
+
+-compile(inline_list_funcs).
+-compile(inline).
+-compile({no_auto_import, [apply/3]}).
+
+-include("ra.hrl").
+
+-include_lib("eunit/include/eunit.hrl").
+-export([
+         init/1,
+         apply/3,
+
+         start/1,
+         spawn_client/1,
+         print_metrics/1,
+
+         prepare/0,
+         profile/0,
+         stop_profile/0
+        ]).
+
+
+init(#{}) ->
+    undefined.
+
+% msg_ids are scoped per customer
+% ra_indexes holds all raft indexes for enqueues currently on queue
+apply(#{index := I}, {noop, _}, State) ->
+    case I rem 100000 of
+        0 ->
+            {State, ok, {release_cursor, I, State}};
+        _ ->
+            {State, ok}
+    end.
+
+
+start(Nodes) ->
+    application:ensure_all_started(ra),
+    Servers = [begin
+                   rpc:call(N, ?MODULE, prepare, []),
+                   {noop, N}
+               end || N <- Nodes],
+    {ra:start_cluster(noop, {module, ?MODULE, #{}}, Servers),
+     Servers}.
+
+prepare() ->
+    application:ensure_all_started(ra),
+    % error_logger:logfile(filename:join(ra_env:data_dir(), "log.log")),
+    ok.
+
+send_n(_, 0) -> ok;
+send_n(Leader, N) ->
+    ra:pipeline_command(Leader, {noop, <<>>}, make_ref(), normal),
+    send_n(Leader, N-1).
+
+
+client_loop(Leader) ->
+    receive
+        {ra_event, Leader, {applied, Applied}} ->
+            N = length(Applied),
+            send_n(Leader, N),
+            client_loop(Leader);
+        {ra_event, Leader, Evt} ->
+            io:format("unexpected ra_event ~w", [Evt]),
+            client_loop(Leader)
+    end.
+
+spawn_client(Servers) ->
+    spawn_link(
+      fun () ->
+              %% first send one 1000 noop commands
+              %% then top up as they are applied
+              {ok, _, Leader} = ra:members(hd(Servers)),
+              send_n(Leader, 1000),
+              client_loop(Leader)
+      end).
+
+print_metrics(undefined) ->
+    print_metrics(hd(ets:lookup(ra_metrics, noop)));
+print_metrics({noop, A0, B0}) ->
+    timer:sleep(1000),
+    [{noop, A, B} = X] = ets:lookup(ra_metrics, noop),
+    io:format("metrics ~b ~b per second~n",
+              [A-A0, B-B0]),
+    print_metrics(X).
+
+
+profile() ->
+    GzFile = atom_to_list(node()) ++ ".gz",
+    lg:trace([noop, ra_server, ra_server_proc, ra_snapshot, ra_machine,
+              ra_log, ra_flru, ra_machine, ra_log_meta, ra_log_segment],
+             lg_file_tracer,
+             GzFile, #{running => false, mode => profile}),
+    ok.
+
+stop_profile() ->
+    lg:stop(),
+    Base = atom_to_list(node()),
+    GzFile = Base ++ ".gz.*",
+    lg_callgrind:profile_many(GzFile, Base ++ ".out",#{}),
+    ok.
+

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -678,12 +678,13 @@ truncate_cache(FromIdx, ToIdx,
                 false ->
                     %% if there are fewer entries left than to be removed
                     %% extract the remaning entries
-                    cache_with(ToIdx, LastIdx, Cache0, #{})
+                    cache_with(ToIdx + 1, LastIdx, Cache0, #{})
             end,
     {State#?MODULE{cache = Cache}, Effects}.
 
-cache_with(Idx, Idx, Source, Cache) ->
-    Cache#{Idx => maps:get(Idx, Source)};
+cache_with(FromIdx, ToIdx, _, Cache)
+  when FromIdx > ToIdx ->
+    Cache;
 cache_with(From, To, Source, Cache) ->
     cache_with(From + 1, To, Source, Cache#{From => maps:get(From, Source)}).
 

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -150,16 +150,16 @@ init(#{uid := UId} = Conf) ->
         false -> ok
     end,
     State000 = #?MODULE{directory = Dir,
-                      uid = UId,
-                      first_index = max(SnapIdx + 1, FirstIdx),
-                      last_index = max(SnapIdx, LastIdx0),
-                      segment_refs = SegRefs,
-                      snapshot_state = SnapshotState,
-                      snapshot_interval = SnapInterval,
-                      wal = Wal,
-                      open_segments = ra_flru:new(MaxOpen, fun flru_handler/1),
-                      resend_window_seconds = ResendWindow,
-                      snapshot_module = SnapModule},
+                        uid = UId,
+                        first_index = max(SnapIdx + 1, FirstIdx),
+                        last_index = max(SnapIdx, LastIdx0),
+                        segment_refs = SegRefs,
+                        snapshot_state = SnapshotState,
+                        snapshot_interval = SnapInterval,
+                        wal = Wal,
+                        open_segments = ra_flru:new(MaxOpen, fun flru_handler/1),
+                        resend_window_seconds = ResendWindow,
+                        snapshot_module = SnapModule},
 
     LastIdx = State000#?MODULE.last_index,
     % recover the last term
@@ -207,7 +207,7 @@ append({Idx, _, _}, #?MODULE{last_index = LastIdx}) ->
     {error, {integrity_error, term()} | wal_down}.
 write([{FstIdx, _, _} = First | Rest] = Entries,
       #?MODULE{last_index = LastIdx,
-             snapshot_state = SnapState} = State00)
+               snapshot_state = SnapState} = State00)
   when FstIdx =< LastIdx + 1 andalso FstIdx >= 0 ->
     case ra_snapshot:current(SnapState) of
         {SnapIdx, _} when FstIdx =:= SnapIdx + 1 ->
@@ -259,12 +259,13 @@ take(Start, Num, #?MODULE{uid = UId, first_index = FirstIdx,
                                     MOp = {?METRICS_SEGMENT_POS, E - S + 1},
                                     ok = update_metrics(UId,
                                                         [MOp | MetricOps2]),
-                                    {Entries, State#?MODULE{open_segments = Open}}
+                                    {Entries,
+                                     State#?MODULE{open_segments = Open}}
                             end
                     end
             end
     end;
-take(_Start, _Num, State) ->
+take(_, _, State) ->
     {[], State}.
 
 -spec last_index_term(ra_log()) -> ra_idxterm().
@@ -288,16 +289,16 @@ set_last_index(Idx, #?MODULE{last_written_index_term = {LWIdx0, _}} = State0) ->
             %% this should always be found but still assert just in case
             true = LWTerm =/= undefined,
             {ok, State2#?MODULE{last_index = Idx,
-                              last_term = Term,
-                              last_written_index_term = {LWIdx, LWTerm}}}
+                                last_term = Term,
+                                last_written_index_term = {LWIdx, LWTerm}}}
     end.
 
 -spec handle_event(event_body(), ra_log()) ->
     {ra_log(), [effect()]}.
 handle_event({written, {FromIdx, ToIdx, Term}},
              #?MODULE{last_written_index_term = {LastWrittenIdx0,
-                                               LastWrittenTerm0},
-                    snapshot_state = SnapState} = State0)
+                                                 LastWrittenTerm0},
+                      snapshot_state = SnapState} = State0)
   when FromIdx =< LastWrittenIdx0 + 1 ->
     MaybeCurrent = ra_snapshot:current(SnapState),
     % We need to ignore any written events for the same index
@@ -309,7 +310,7 @@ handle_event({written, {FromIdx, ToIdx, Term}},
             % this case truncation shouldn't be too expensive as the cache
             % only contains the unflushed window of entries typically less than
             % 10ms worth of entries
-            truncate_cache(ToIdx,
+            truncate_cache(FromIdx, ToIdx,
                            State#?MODULE{last_written_index_term = {ToIdx, Term}},
                            []);
         {undefined, State} when FromIdx =< element(1, MaybeCurrent ) ->
@@ -381,9 +382,10 @@ handle_event({snapshot_written, {Idx, _} = Snap},
     Effects = [{delete_snapshot,
                 ra_snapshot:directory(SnapState),
                 ra_snapshot:current(SnapState0)}],
-    %% do not set last index here as the snapshot may be for a past index
-    truncate_cache(Idx, State#?MODULE{first_index = Idx + 1,
-                                      snapshot_state = SnapState}, Effects);
+    %% do not set last written index here as the snapshot may
+    %% be for a past index
+    {State#?MODULE{first_index = Idx + 1,
+                   snapshot_state = SnapState}, Effects};
 handle_event({resend_write, Idx}, State) ->
     % resend missing entries from cache.
     % The assumption is they are available in the cache
@@ -440,9 +442,9 @@ set_snapshot_state(SnapState, State) ->
 install_snapshot({Idx, _} = IdxTerm, SnapState, State0) ->
     State = delete_segments(Idx, State0),
     State#?MODULE{snapshot_state = SnapState,
-                first_index = Idx + 1,
-                last_index = Idx,
-                last_written_index_term = IdxTerm}.
+                  first_index = Idx + 1,
+                  last_index = Idx,
+                  last_written_index_term = IdxTerm}.
 
 -spec recover_snapshot(State :: ra_log()) ->
     maybe({ra_snapshot:meta(), term()}).
@@ -472,9 +474,9 @@ update_release_cursor(Idx, Cluster, MacState,
     end.
 
 update_release_cursor0(Idx, Cluster, MacState,
-                      #?MODULE{segment_refs = SegRefs,
-                             snapshot_state = SnapState,
-                             snapshot_interval = SnapInter} = State0) ->
+                       #?MODULE{segment_refs = SegRefs,
+                                snapshot_state = SnapState,
+                                snapshot_interval = SnapInter} = State0) ->
     ClusterServerIds = maps:keys(Cluster),
     SnapLimit = case ra_snapshot:current(SnapState) of
                     undefined -> SnapInter;
@@ -545,10 +547,10 @@ exists({Idx, Term}, Log0) ->
     end.
 
 overview(#?MODULE{last_index = LastIndex,
-                last_written_index_term = LWIT,
-                segment_refs = Segs,
-                snapshot_state = SnapshotState,
-                open_segments = OpenSegs}) ->
+                  last_written_index_term = LWIT,
+                  segment_refs = Segs,
+                  snapshot_state = SnapshotState,
+                  open_segments = OpenSegs}) ->
     #{type => ?MODULE,
       last_index => LastIndex,
       last_written_index_term => LWIT,
@@ -664,11 +666,32 @@ wal_write_batch(#?MODULE{uid = UId, cache = Cache0, wal = Wal} = State,
             exit(wal_down)
     end.
 
-truncate_cache(Idx, #?MODULE{cache = Cache0} = State, Effects) ->
-    Cache = maps:filter(fun (K, _) when K > Idx -> true;
-                            (_, _) -> false
-                        end, Cache0),
+truncate_cache(FromIdx, ToIdx,
+               #?MODULE{cache = Cache0,
+                        last_index = LastIdx} = State,
+               Effects) ->
+    Cache = case ToIdx - FromIdx < LastIdx - ToIdx of
+                true ->
+                    %% if the range to be deleted is smaller than the
+                    %% remaining range truncate the cache by removing entries
+                    cache_without(FromIdx, ToIdx, Cache0);
+                false ->
+                    %% if there are fewer entries left than to be removed
+                    %% extract the remaning entries
+                    cache_with(ToIdx, LastIdx, Cache0, #{})
+            end,
     {State#?MODULE{cache = Cache}, Effects}.
+
+cache_with(Idx, Idx, Source, Cache) ->
+    Cache#{Idx => maps:get(Idx, Source)};
+cache_with(From, To, Source, Cache) ->
+    cache_with(From + 1, To, Source, Cache#{From => maps:get(From, Source)}).
+
+cache_without(Idx, Idx, Cache) ->
+    maps:remove(Idx, Cache);
+cache_without(FromIdx, ToIdx, Cache) ->
+    cache_without(FromIdx + 1, ToIdx, maps:remove(FromIdx, Cache)).
+
 
 update_metrics(Id, Ops) ->
     _ = ets:update_counter(ra_log_metrics, Id, Ops),
@@ -751,8 +774,8 @@ lookup_range(Tid, Start, End, Acc) when End > Start ->
 
 
 segment_take(#?MODULE{segment_refs = SegRefs,
-                    open_segments = OpenSegs,
-                    directory = Dir},
+                      open_segments = OpenSegs,
+                      directory = Dir},
              Range, Entries0) ->
     lists:foldl(
       fun(_, {_, undefined, _} = Acc) ->
@@ -877,7 +900,7 @@ resend_from0(Idx, #?MODULE{last_index = LastIdx,
                 % TODO: replace with recursive function
                 lists:seq(Idx, LastIdx));
 resend_from0(Idx, #?MODULE{last_resend_time = LastResend,
-                        resend_window_seconds = ResendWindow} = State) ->
+                           resend_window_seconds = ResendWindow} = State) ->
     case erlang:system_time(seconds) > LastResend + ResendWindow of
         true ->
             % it has been more than a minute since last resend
@@ -949,12 +972,23 @@ recover_range(UId) ->
     ClosedRanges = [{F, L} || {_, _, F, L, _} <- closed_mem_tables(UId)],
     % 2. check segments
     SegFiles = ra_log_segment_writer:my_segments(UId),
-    SegRefs = [begin
+    SegRefs = lists:foldl(
+                fun (S, Acc) ->
                    {ok, Seg} = ra_log_segment:open(S, #{mode => read}),
-                   SegRef = ra_log_segment:segref(Seg),
-                   ok = ra_log_segment:close(Seg),
-                   SegRef
-               end || S <- lists:reverse(SegFiles)],
+                   %% if a server recovered when a segment had been opened
+                   %% but never had any entries written the segref would be
+                   %% undefined
+                   case ra_log_segment:segref(Seg) of
+                       undefined ->
+                           ok = ra_log_segment:close(Seg),
+                           %% delete the empty segment
+                           ok = file:delete(ra_log_segment:filename(Seg)),
+                           Acc;
+                       SegRef ->
+                           ok = ra_log_segment:close(Seg),
+                           [SegRef | Acc]
+                   end
+                end, [], SegFiles),
     SegRanges = [{F, L} || {F, L, _} <- SegRefs],
     Ranges = OpenRanges ++ ClosedRanges ++ SegRanges,
     {pick_range(Ranges, undefined), SegRefs}.

--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -306,7 +306,7 @@ append_to_segment(UId, Tid, Idx, EndIdx, Seg0, Closed, SegConf) ->
             % close and open a new segment
             Seg = open_successor_segment(Seg0, SegConf),
             %% re-evaluate snapshot state for the server in case a snapshot
-            %% has completed during segmeng flush
+            %% has completed during segment flush
             StartIdx = start_index(UId, Idx),
             % recurse
             % TODO: there is a micro-inefficiency here in that we need to

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -853,7 +853,7 @@ handle_effect(_, {send_msg, To, Msg}, _, State, Actions) ->
     ok = send(To, Msg),
     {State, Actions};
 handle_effect(_, {send_msg, To, Msg, Options}, _, State, Actions) ->
-    case  parse_send_msg_options(Options) of
+    case parse_send_msg_options(Options) of
         {true, true} ->
             gen_cast(To, wrap_ra_event(id(State), machine, Msg));
         {true, false} ->
@@ -1084,7 +1084,7 @@ follower_leader_change(Old, #state{pending_commands = Pending,
         NewLeader ->
             MRef = swap_monitor(OldMRef, NewLeader),
             LeaderNode = ra_lib:ra_server_id_node(NewLeader),
-            ok = aten:register(LeaderNode),
+            ok = aten_register(LeaderNode),
             OldLeaderNode = ra_lib:ra_server_id_node(OldLeader),
             ok = aten:unregister(OldLeaderNode),
             % leader has either changed or just been set
@@ -1094,6 +1094,13 @@ follower_leader_change(Old, #state{pending_commands = Pending,
              || {From, _Data} <- Pending],
             New#state{pending_commands = [],
                       leader_monitor = MRef}
+    end.
+
+aten_register(Node) ->
+    case node() of
+        Node -> ok;
+        _ ->
+            aten:register(Node)
     end.
 
 swap_monitor(MRef, L) ->

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -478,6 +478,7 @@ snapshot_installation_with_call_crash(Config) ->
               fun () ->
                       {ok, {N1Idx, _}, _} = ra:local_query({N1, node()},
                                                            fun ra_lib:id/1),
+                      ct:pal("N1 idx ~w", [N1Idx]),
                       {ok, {N2Idx, _}, _} = ra:local_query({N2, node()},
                                                            fun ra_lib:id/1),
                       {ok, {N3Idx, _}, _} = ra:local_query({N3, node()},

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -826,3 +826,12 @@ new_peer() ->
     #{next_index => 1,
       match_index => 0,
       commit_index_sent => 0}.
+
+flush() ->
+    receive
+        Any ->
+            ct:pal("flush ~p", [Any]),
+            flush()
+    after 0 ->
+              ok
+    end.

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -817,11 +817,13 @@ follower_pre_vote(_Config) ->
                                vote_granted = false}}]} =
     ra_server:handle_follower(Msg#pre_vote_rpc{term = 4}, State),
 
-     % reject when candidate last log entry has a lower term
-     % still update current term if incoming is higher
-    {follower, #{current_term := 6},
-     [{reply, #pre_vote_result{term = 6, token = Token,
-                               vote_granted = false}}]} =
+    % when candidate last log entry has a lower term
+    % the current server is a better candidate and thus
+    % immedately enters pre_vote state
+    {pre_vote, #{current_term := 6},
+     [{next_event, cast, #pre_vote_result{term = 6, token = _,
+                                          vote_granted = true}},
+      {send_vote_requests, _}]} =
     ra_server:handle_follower(Msg#pre_vote_rpc{last_log_term = 4,
                                                term = 6},
                               State),


### PR DESCRIPTION
Various optimisation and minor fixes found during throughput testing using the noop machine.

Optimised hot code paths such as AppendEntriesRpc generation and ra log cache truncation

Also ensure that pipelining of very behind followers isn't unnecessarily slow.

Fix rare crash bug when an empty segment is created and then the server is restarted.

