### PR TITLE
Ra server supervision

### DIFF
--- a/src/noop.erl
+++ b/src/noop.erl
@@ -46,7 +46,7 @@ start(Nodes) ->
      Servers}.
 
 prepare() ->
-    application:ensure_all_started(ra),
+    _ = application:ensure_all_started(ra),
     % error_logger:logfile(filename:join(ra_env:data_dir(), "log.log")),
     ok.
 

--- a/src/ra.app.src
+++ b/src/ra.app.src
@@ -25,6 +25,7 @@
                         ra_server,
                         ra_server_proc,
                         ra_server_sup,
+                        ra_server_sup_sup,
                         ra_sup,
                         ra_system_sup,
                         ra_snapshot]},

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -96,7 +96,7 @@ start_server(Conf) ->
     case ra_lib:validate_base64uri(maps:get(uid, Conf)) of
         true ->
             % don't match on return value in case it is already running
-            case catch ra_server_sup:start_server(Conf) of
+            case catch ra_server_sup_sup:start_server(Conf) of
                 {ok, _} -> ok;
                 {ok, _, _} -> ok;
                 {error, _} = Err -> Err;
@@ -115,7 +115,7 @@ start_server(Conf) ->
 -spec restart_server(ra_server_id()) -> ok | {error, term()}.
 restart_server(ServerId) ->
     % don't match on return value in case it is already running
-    case catch ra_server_sup:restart_server(ServerId) of
+    case catch ra_server_sup_sup:restart_server(ServerId) of
         {ok, _} -> ok;
         {ok, _, _} -> ok;
         {error, _} = Err -> Err;
@@ -127,7 +127,7 @@ restart_server(ServerId) ->
 %% @returns `{ok | error, nodedown}'
 -spec stop_server(ra_server_id()) -> ok | {error, nodedown}.
 stop_server(ServerId) ->
-    try ra_server_sup:stop_server(ServerId) of
+    try ra_server_sup_sup:stop_server(ServerId) of
         ok -> ok;
         {error, not_found} -> ok
     catch
@@ -141,7 +141,7 @@ stop_server(ServerId) ->
 %% @returns `{ok | error, nodedown}'
 -spec delete_server(ServerId :: ra_server_id()) -> ok | {error, term()}.
 delete_server(ServerId) ->
-    ra_server_sup:delete_server(ServerId).
+    ra_server_sup_sup:delete_server(ServerId).
 
 %% @doc Starts or restarts a ra cluster.
 %%
@@ -166,10 +166,10 @@ delete_server(ServerId) ->
     {error, cluster_not_formed}.
 start_or_restart_cluster(ClusterName, Machine,
                          [FirstServer | RemServers] = ServerIds) ->
-    case ra_server_sup:restart_server(FirstServer) of
+    case ra_server_sup_sup:restart_server(FirstServer) of
         {ok, _} ->
             %% restart the rest of the servers
-            _ = [{ok, _} = ra_server_sup:restart_server(N) || N <- RemServers],
+            _ = [{ok, _} = ra_server_sup_sup:restart_server(N) || N <- RemServers],
             {ok, ServerIds, []};
         {error, Err} ->
             ?INFO("start_or_restart_cluster: got error ~p~n", [Err]),

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -563,8 +563,10 @@ overview(#?MODULE{last_index = LastIndex,
                         end
      }.
 
-write_config(Config, #?MODULE{directory = Dir}) ->
+write_config(Config0, #?MODULE{directory = Dir}) ->
     ConfigPath = filename:join(Dir, "config"),
+    % clean config of potentially unserialisable data
+    Config = maps:without([parent], Config0),
     ok = file:write_file(ConfigPath,
                          list_to_binary(io_lib:format("~p.", [Config]))),
     ok.
@@ -573,7 +575,7 @@ read_config(Dir) ->
     ConfigPath = filename:join(Dir, "config"),
     case filelib:is_file(ConfigPath) of
         true ->
-            {ok, [C]} =  file:consult(ConfigPath),
+            {ok, [C]} = file:consult(ConfigPath),
             {ok, C};
         false ->
             not_found

--- a/src/ra_server_sup.erl
+++ b/src/ra_server_sup.erl
@@ -1,134 +1,42 @@
-%% @hidden
 -module(ra_server_sup).
 
 -behaviour(supervisor).
 
-
 %% API functions
--export([start_server/1,
-         restart_server/1,
-         stop_server/1,
-         delete_server/1,
-         remove_all/0,
-         start_link/0,
-         % for rpcs only
-         prepare_start_rpc/1,
-         prepare_restart_rpc/1,
-         delete_server_rpc/1]).
+-export([start_link/1]).
 
 %% Supervisor callbacks
 -export([init/1]).
 
 -include("ra.hrl").
+%%%===================================================================
+%%% API functions
+%%%===================================================================
 
--spec start_server(ra_server:ra_server_config()) ->
-    supervisor:startchild_ret() | {error, not_new}.
-start_server(#{id := NodeId,
-               uid := UId} = Config) ->
-    %% check that the node isn't already registered
-    Node = ra_lib:ra_server_id_node(NodeId),
-    case rpc:call(Node, ?MODULE, prepare_start_rpc, [UId]) of
-        ok ->
-            supervisor:start_child({?MODULE, Node}, [Config]);
-        Err ->
-            Err
-    end.
+start_link(Config) ->
+    supervisor:start_link(?MODULE, [Config]).
 
--spec restart_server(ra_server_id()) -> supervisor:startchild_ret().
-restart_server({RaName, Node}) ->
-    case rpc:call(Node, ?MODULE, prepare_restart_rpc, [RaName]) of
-        {ok, Config} ->
-            supervisor:start_child({?MODULE, Node}, [Config]);
-        Err ->
-            {error, Err}
-    end.
+%%%===================================================================
+%%% Supervisor callbacks
+%%%===================================================================
 
-prepare_start_rpc(UId) ->
-    case ra_directory:name_of(UId) of
-        undefined ->
-            ok;
-        Name ->
-            case whereis(Name) of
-                undefined ->
-                    {error, not_new};
-                Pid ->
-                    {error, {already_started, Pid}}
-              end
-    end.
+%%--------------------------------------------------------------------
 
-prepare_restart_rpc(RaName) ->
-    case ra_directory:uid_of(RaName) of
-        undefined ->
-            name_not_registered;
-        UId ->
-            Dir = ra_env:server_data_dir(UId),
-            % can it be made generic without already knowing the config state?
-            ra_log:read_config(Dir)
-    end.
-
--spec stop_server(RaNodeId :: ra_server_id()) -> ok | {error, term()}.
-stop_server({RaName, Node}) ->
-    %% TODO: this could timeout
-    Pid = rpc:call(Node, ra_directory,
-                   where_is, [RaName]),
-    supervisor:terminate_child({?MODULE, Node}, Pid);
-stop_server(RaName) ->
-    % local node
-    case ra_directory:where_is(RaName) of
-        undefined -> ok;
-        Pid ->
-            supervisor:terminate_child(?MODULE, Pid)
-    end.
-
--spec delete_server(NodeId :: ra_server_id()) -> ok | {error, term()}.
-delete_server(NodeId) ->
-    Node = ra_lib:ra_server_id_node(NodeId),
-    Name = ra_lib:ra_server_id_to_local_name(NodeId),
-    case stop_server(NodeId) of
-        ok ->
-            ?INFO("Deleting node ~p and it's data.~n", [NodeId]),
-            rpc:call(Node, ?MODULE, delete_server_rpc, [Name]);
-        {error, _} = Err -> Err
-    end.
-
-delete_server_rpc(RaName) ->
-    %% TODO: better handle and report errors
-    UId = ra_directory:uid_of(RaName),
-    Dir = ra_env:server_data_dir(UId),
-    ok = ra_log_segment_writer:release_segments(
-           ra_log_segment_writer, UId),
-    _ = supervisor:terminate_child(?MODULE, UId),
-    % TODO: move into separate retrying process
-    try ra_lib:recursive_delete(Dir) of
-        ok -> ok
-    catch
-        _:_ = Err ->
-            ?WARN("delete_server/1 failed to delete directory ~s~n"
-                  "Error: ~p~n", [Dir, Err])
-    end,
-    _ = ra_directory:unregister_name(UId),
-    ok.
-
-remove_all() ->
-    _ = [begin
-             supervisor:terminate_child(?MODULE, Pid)
-         end
-         || {_, Pid, _, _} <- supervisor:which_children(?MODULE)],
-    ok.
-
--spec start_link() ->
-    {ok, pid()} | ignore | {error, term()}.
-start_link() ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
-
-init([]) ->
-    SupFlags = #{strategy => simple_one_for_one,
-                 intensity => 10,
+init([Config0]) ->
+    Id = maps:get(id, Config0),
+    Config = Config0#{parent => self()},
+    Name = ra_lib:ra_server_id_to_local_name(Id),
+    SupFlags = #{strategy => one_for_one,
+                 intensity => 5,
                  period => 5},
-    ChildSpec = #{id => undefined,
+    ChildSpec = #{id => Name,
                   type => worker,
                   % needs to be transient as may shut itself down by returning
                   % {stop, normal, State}
                   restart => transient,
-                  start => {ra_server_proc, start_link, []}},
+                  start => {ra_server_proc, start_link, [Config]}},
     {ok, {SupFlags, [ChildSpec]}}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/src/ra_server_sup.erl
+++ b/src/ra_server_sup.erl
@@ -27,7 +27,7 @@ init([Config0]) ->
     Config = Config0#{parent => self()},
     Name = ra_lib:ra_server_id_to_local_name(Id),
     SupFlags = #{strategy => one_for_one,
-                 intensity => 5,
+                 intensity => 2,
                  period => 5},
     ChildSpec = #{id => Name,
                   type => worker,

--- a/src/ra_server_sup_sup.erl
+++ b/src/ra_server_sup_sup.erl
@@ -1,0 +1,145 @@
+%% @hidden
+-module(ra_server_sup_sup).
+
+-behaviour(supervisor).
+
+
+%% API functions
+-export([start_server/1,
+         restart_server/1,
+         stop_server/1,
+         delete_server/1,
+         remove_all/0,
+         start_link/0,
+         % for rpcs only
+         prepare_start_rpc/1,
+         prepare_restart_rpc/1,
+         delete_server_rpc/1]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+-include("ra.hrl").
+
+-spec start_server(ra_server:ra_server_config()) ->
+    supervisor:startchild_ret() | {error, not_new}.
+start_server(#{id := NodeId,
+               uid := UId} = Config) ->
+    %% check that the node isn't already registered
+    Node = ra_lib:ra_server_id_node(NodeId),
+    case rpc:call(Node, ?MODULE, prepare_start_rpc, [UId]) of
+        ok ->
+            ?INFO("start_server here", []),
+            supervisor:start_child({?MODULE, Node}, [Config]);
+        Err ->
+            Err
+    end.
+
+-spec restart_server(ra_server_id()) -> supervisor:startchild_ret().
+restart_server({RaName, Node}) ->
+    case rpc:call(Node, ?MODULE, prepare_restart_rpc, [RaName]) of
+        {ok, Config} ->
+            supervisor:start_child({?MODULE, Node}, [Config]);
+        {error, _} = Err ->
+            Err;
+        Err ->
+            {error, Err}
+    end.
+
+prepare_start_rpc(UId) ->
+    case ra_directory:name_of(UId) of
+        undefined ->
+            ok;
+        Name ->
+            case whereis(Name) of
+                undefined ->
+                    {error, not_new};
+                Pid ->
+                    {error, {already_started, Pid}}
+              end
+    end.
+
+prepare_restart_rpc(RaName) ->
+    case ra_directory:uid_of(RaName) of
+        undefined ->
+            name_not_registered;
+        UId ->
+            Dir = ra_env:server_data_dir(UId),
+            case ra_directory:where_is(UId) of
+                Pid when is_pid(Pid) ->
+                    case is_process_alive(Pid) of
+                        true ->
+                            {error, {already_started, Pid}};
+                        false ->
+                            ra_log:read_config(Dir)
+                    end;
+                _ ->
+                    % can it be made generic without already knowing the config state?
+                    ra_log:read_config(Dir)
+            end
+    end.
+
+-spec stop_server(RaNodeId :: ra_server_id()) -> ok | {error, term()}.
+stop_server({RaName, Node}) ->
+    %% TODO: this could timeout
+    Pid = rpc:call(Node, ra_directory,
+                   where_is_parent, [RaName]),
+    supervisor:terminate_child({?MODULE, Node}, Pid);
+stop_server(RaName) ->
+    % local node
+    case ra_directory:where_is_parent(RaName) of
+        undefined -> ok;
+        Pid ->
+            supervisor:terminate_child(?MODULE, Pid)
+    end.
+
+-spec delete_server(NodeId :: ra_server_id()) ->
+    ok | {error, term()}.
+delete_server(NodeId) ->
+    Node = ra_lib:ra_server_id_node(NodeId),
+    Name = ra_lib:ra_server_id_to_local_name(NodeId),
+    case stop_server(NodeId) of
+        ok ->
+            ?INFO("Deleting node ~w and all it's data.~n", [NodeId]),
+            rpc:call(Node, ?MODULE, delete_server_rpc, [Name]);
+        {error, _} = Err -> Err
+    end.
+
+delete_server_rpc(RaName) ->
+    %% TODO: better handle and report errors
+    UId = ra_directory:uid_of(RaName),
+    Dir = ra_env:server_data_dir(UId),
+    ok = ra_log_segment_writer:release_segments(
+           ra_log_segment_writer, UId),
+    _ = supervisor:terminate_child(?MODULE, UId),
+    % TODO: move into separate retrying process
+    try ra_lib:recursive_delete(Dir) of
+        ok -> ok
+    catch
+        _:_ = Err ->
+            ?WARN("delete_server/1 failed to delete directory ~s~n"
+                  "Error: ~p~n", [Dir, Err])
+    end,
+    _ = ra_directory:unregister_name(UId),
+    ok.
+
+remove_all() ->
+    _ = [begin
+             ?INFO("terminating child ~w~n", [Pid]),
+             supervisor:terminate_child(?MODULE, Pid)
+         end
+         || {_, Pid, _, _} <- supervisor:which_children(?MODULE)],
+    ok.
+
+-spec start_link() ->
+    {ok, pid()} | ignore | {error, term()}.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    SupFlags = #{strategy => simple_one_for_one},
+    ChildSpec = #{id => undefined,
+                  type => supervisor,
+                  restart => temporary,
+                  start => {ra_server_sup, start_link, []}},
+    {ok, {SupFlags, [ChildSpec]}}.

--- a/src/ra_system_sup.erl
+++ b/src/ra_system_sup.erl
@@ -25,10 +25,10 @@ init([]) ->
     RaLogSup = #{id => ra_log_sup,
                  type => supervisor,
                  start => {ra_log_sup, start_link, [DataDir]}},
-    RaServerSup = #{id => ra_server_sup,
-                    type => supervisor,
-                    start => {ra_server_sup, start_link, []}},
-    {ok, {SupFlags, [Ets, RaLogSup, RaServerSup]}}.
+    RaServerSupSup = #{id => ra_server_sup_sup,
+                       type => supervisor,
+                       start => {ra_server_sup_sup, start_link, []}},
+    {ok, {SupFlags, [Ets, RaLogSup, RaServerSupSup]}}.
 
 
 

--- a/test/ra_2_SUITE.erl
+++ b/test/ra_2_SUITE.erl
@@ -44,7 +44,7 @@ end_per_group(_, Config) ->
     Config.
 
 init_per_testcase(TestCase, Config) ->
-    ra_server_sup:remove_all(),
+    ra_server_sup_sup:remove_all(),
     NodeName2 = list_to_atom(atom_to_list(TestCase) ++ "2"),
     NodeName3 = list_to_atom(atom_to_list(TestCase) ++ "3"),
     [

--- a/test/ra_2_SUITE.erl
+++ b/test/ra_2_SUITE.erl
@@ -24,6 +24,7 @@ all_tests() ->
      server_restart_after_application_restart,
      restarted_server_does_not_reissue_side_effects,
      recover,
+     supervision_tree,
      recover_after_kill,
      start_server_uid_validation
     ].
@@ -229,6 +230,28 @@ recover(Config) ->
     msg1 = dequeue(ServerId),
 
     ok = ra:stop_server(ServerId),
+    ok.
+
+supervision_tree(Config) ->
+    ServerId = {Name, _} = ?config(server_id, Config),
+    ClusterName = ?config(cluster_name, Config),
+    ok = start_cluster(ClusterName, [ServerId]),
+    % start another cluster
+    ok = start_cluster(another_cluster, [{another, node()}]),
+    %% kill server in close succession
+    %% 3 crashes in a 5s period should stop restart attempts
+    exit(whereis(Name), kill),
+    timer:sleep(1000),
+    ?assert(whereis(Name) =/= undefined),
+    exit(whereis(Name), kill),
+    timer:sleep(250),
+    ?assert(whereis(Name) =/= undefined),
+    exit(whereis(Name), kill),
+    timer:sleep(250),
+    %% assert server is permanently down
+    ?assert(whereis(Name) == undefined),
+    %% assert another is still up
+    ?assert(whereis(another) =/= undefined),
     ok.
 
 recover_after_kill(Config) ->

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -73,7 +73,7 @@ init_per_testcase(TestCase, Config) ->
     [{test_name, ra_lib:to_list(TestCase)} | Config].
 
 end_per_testcase(_TestCase, Config) ->
-    ra_server_sup:remove_all(),
+    ra_server_sup_sup:remove_all(),
     Config.
 
 single_server_processes_command(Config) ->

--- a/test/ra_machine_int_SUITE.erl
+++ b/test/ra_machine_int_SUITE.erl
@@ -51,7 +51,7 @@ end_per_group(_Group, _Config) ->
     ok.
 
 init_per_testcase(TestCase, Config) ->
-    ra_server_sup:remove_all(),
+    ra_server_sup_sup:remove_all(),
     ServerName2 = list_to_atom(atom_to_list(TestCase) ++ "2"),
     ServerName3 = list_to_atom(atom_to_list(TestCase) ++ "3"),
     [
@@ -268,7 +268,8 @@ deleted_cluster_emits_eol_effect(Config) ->
     ok = validate_process_down(element(1, ServerId), 50),
     Dir = filename:join(PrivDir, UId),
     false = filelib:is_dir(Dir),
-    [] = supervisor:which_children(ra_server_sup),
+    timer:sleep(100),
+    [] = supervisor:which_children(ra_server_sup_sup),
     % validate an end of life is emitted
     receive
         {ra_event, _, {machine, eol}} -> ok


### PR DESCRIPTION
Add a temporary supervisor for each ra server

This is so that a ra server can restart continiously until it exhausts
it's restart strategy without taking down the entire supervision tree.