### PR TITLE
Various fixes

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -31,7 +31,7 @@
          start_server/4,
          restart_server/1,
          stop_server/1,
-         delete_server/1,
+         force_delete_server/1,
          trigger_election/1,
          trigger_election/2,
          %% membership
@@ -139,8 +139,8 @@ stop_server(ServerId) ->
 %% The server is forcefully deleted.
 %% @param ServerId the ra_server_id() of the server
 %% @returns `{ok | error, nodedown}'
--spec delete_server(ServerId :: ra_server_id()) -> ok | {error, term()}.
-delete_server(ServerId) ->
+-spec force_delete_server(ServerId :: ra_server_id()) -> ok | {error, term()}.
+force_delete_server(ServerId) ->
     ra_server_sup_sup:delete_server(ServerId).
 
 %% @doc Starts or restarts a ra cluster.
@@ -230,7 +230,7 @@ start_cluster(ClusterName, Machine, ServerIds) ->
                 Err ->
                     ?WARN("ra: failed to form new cluster ~w.~n "
                           "Error: ~w~n", [ClusterName, Err]),
-                    _ = [delete_server(N) || N <- Started],
+                    _ = [force_delete_server(N) || N <- Started],
                     % we do not have a functioning cluster
                     {error, cluster_not_formed}
             end
@@ -376,7 +376,7 @@ leave_and_delete_server(ServerRef, ServerId, Timeout) ->
             Err;
         {ok, _, _} ->
             ?ERR("~p has left the building. terminating", [ServerId]),
-            delete_server(ServerId)
+            force_delete_server(ServerId)
     end.
 
 

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -241,7 +241,7 @@ start_cluster(ClusterName, Machine, ServerIds) ->
                    ra_server:machine_conf(), [ra_server_id()]) ->
     ok | {error, term()}.
 start_server(ClusterName, ServerId, Machine, ServerIds) ->
-    Prefix = ra_lib:derive_safe_string(ra_lib:to_binary(ClusterName), 4),
+    Prefix = ra_lib:derive_safe_string(ra_lib:to_binary(ClusterName), 6),
     UId = ra_lib:make_uid(string:uppercase(Prefix)),
     Conf = #{cluster_name => ClusterName,
              id => ServerId,

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -184,7 +184,7 @@ init(#{uid := UId} = Conf) ->
           [State#?MODULE.uid,
            last_index_term(State),
            State#?MODULE.first_index]),
-    State.
+    delete_segments(SnapIdx, State).
 
 -spec close(ra_log()) -> ok.
 close(#?MODULE{open_segments = OpenSegs}) ->

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -187,10 +187,16 @@ init(#{uid := UId} = Conf) ->
     delete_segments(SnapIdx, State).
 
 -spec close(ra_log()) -> ok.
-close(#?MODULE{open_segments = OpenSegs}) ->
+close(#?MODULE{uid = UId,
+               open_segments = OpenSegs}) ->
     % deliberately ignoring return value
     % close all open segments
     _ = ra_flru:evict_all(OpenSegs),
+    %% delete ra_log_metrics record
+    catch ets:delete(ra_log_metrics, UId),
+    %% inserted in ra_snapshot but it doesn't havea terminate callback so
+    %% deleting ets table here
+    catch ets:delete(ra_log_snapshot_state, UId),
     ok.
 
 -spec append(Entry :: log_entry(), State :: ra_log()) ->

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -653,7 +653,7 @@ terminating_leader(EvtType, Msg, State0) ->
         false ->
             ?INFO("~w: is not fully replicated after ~W~n", [id(State),
                                                              Msg, 7]),
-            {keep_state, State, Actions}
+            {keep_state, send_rpcs(State), Actions}
     end.
 
 terminating_follower(enter, _OldState, State0) ->

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -737,6 +737,8 @@ terminate(Reason, StateName,
                     ra_log_segment_writer, UId),
             catch ra_directory:unregister_name(UId),
             catch ra_log_meta:delete_sync(UId),
+            catch ets:delete(ra_state, UId),
+            catch ets:delete(ra_state, UId),
             Self = self(),
             %% we have to terminate the child spec from the supervisor as it
             %% wont do this automatically, even for transient children

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -738,7 +738,6 @@ terminate(Reason, StateName,
             catch ra_directory:unregister_name(UId),
             catch ra_log_meta:delete_sync(UId),
             catch ets:delete(ra_state, UId),
-            catch ets:delete(ra_state, UId),
             Self = self(),
             %% we have to terminate the child spec from the supervisor as it
             %% wont do this automatically, even for transient children

--- a/test/coordination_SUITE.erl
+++ b/test/coordination_SUITE.erl
@@ -86,9 +86,9 @@ start_stop_restart_delete_on_remote(Config) ->
     ok = ra:stop_server(NodeId),
     % idempotency
     ok = ra:stop_server(NodeId),
-    ok = ra:delete_server(NodeId),
+    ok = ra:force_delete_server(NodeId),
     % idempotency
-    {error, _} = ra:delete_server(NodeId),
+    {error, _} = ra:force_delete_server(NodeId),
     timer:sleep(500),
     slave:stop(S1),
     ok.

--- a/test/ra_2_SUITE.erl
+++ b/test/ra_2_SUITE.erl
@@ -18,7 +18,7 @@ all() ->
 all_tests() ->
     [
      start_stopped_server,
-     server_is_deleted,
+     server_is_force_deleted,
      cluster_is_deleted,
      cluster_is_deleted_with_server_down,
      cluster_cannot_be_deleted_in_minority,
@@ -86,7 +86,7 @@ start_stopped_server(Config) ->
     ok.
 
 
-server_is_deleted(Config) ->
+server_is_force_deleted(Config) ->
     ClusterName = ?config(cluster_name, Config),
     PrivDir = ?config(priv_dir, Config),
     ServerId = ?config(server_id, Config),
@@ -98,7 +98,7 @@ server_is_deleted(Config) ->
     % force roll over
     ok = ra_log_wal:force_roll_over(ra_log_wal),
     Pid = ra_directory:where_is(UId),
-    ok = ra:delete_server(ServerId),
+    ok = ra:force_delete_server(ServerId),
 
     validate_ets_table_deletes([UId], [Pid], [ServerId]),
     % start a node with the same nodeid but different uid
@@ -115,7 +115,7 @@ server_is_deleted(Config) ->
             exit(unexpected_dequeue_result)
     end,
 
-    ok = ra:delete_server(ServerId),
+    ok = ra:force_delete_server(ServerId),
     ok.
 
 cluster_is_deleted(Config) ->


### PR DESCRIPTION
Various smaller fixes:

See individual commits. Some highlights:

* Delete segments after log init
* ETS table cleanup
* rename ra:delete_server/1 to ra:force_delete_server/1