### PR TITLE
Switch to logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,12 @@ Indicate whether the wal should compute and validate checksums. Default: true
     flag this mode falls back to `default`
 
 
+* `logger_module`:
 
-Example:
+Allows the configuration of a custom logger module. The default is `logger`.
+The module must implement a function of the same signature
+as [logger:log/4](http://erlang.org/doc/man/logger.html#log-4) (the variant
+that takes a format not the variant that takes a fun).
 
 ```
 [{data_dir, "/tmp/ra-data"},

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The following Raft features are implemented:
 
 ## Supported Erlang/OTP Versions
 
-Ra requires Erlang/OTP 21.x.
+Ra requires Erlang/OTP 21.2+.
 
 ## Quick start
 

--- a/include/ra.hrl
+++ b/include/ra.hrl
@@ -142,7 +142,9 @@
 -define(INFO(Fmt, Args), ?DISPATCH_LOG(info, Fmt, Args)).
 -define(NOTICE(Fmt, Args), ?DISPATCH_LOG(notice, Fmt, Args)).
 -define(WARN(Fmt, Args), ?DISPATCH_LOG(warning, Fmt, Args)).
+-define(WARNING(Fmt, Args), ?DISPATCH_LOG(warning, Fmt, Args)).
 -define(ERR(Fmt, Args), ?DISPATCH_LOG(error, Fmt, Args)).
+-define(ERROR(Fmt, Args), ?DISPATCH_LOG(error, Fmt, Args)).
 
 -define(DISPATCH_LOG(Level, Fmt, Args),
         %% same as OTP logger does when using the macro
@@ -157,5 +159,3 @@
 -define(DEFAULT_TIMEOUT, 5000).
 
 -define(DEFAULT_SNAPSHOT_MODULE, ra_log_snapshot).
-
-

--- a/include/ra.hrl
+++ b/include/ra.hrl
@@ -137,28 +137,12 @@
 %% WAL defaults
 -define(WAL_MAX_SIZE_BYTES, 1024 * 1024 * 1024).
 
-% primitive logging abstraction
--define(error, true).
--define(warn, true).
--define(info, true).
 
--ifdef(info).
--define(INFO(Fmt, Args), error_logger:info_msg(Fmt, Args)).
--else.
--define(INFO(_F, _A), ok).
--endif.
-
--ifdef(warn).
--define(WARN(Fmt, Args), error_logger:warning_msg(Fmt, Args)).
--else.
--define(WARN(_, _), ok).
--endif.
-
--ifdef(error).
--define(ERR(Fmt, Args), error_logger:error_msg(Fmt, Args)).
--else.
--define(ERR(_, _), ok).
--endif.
+-define(DEBUG(Fmt, Args), logger:debug(Fmt, Args)).
+-define(INFO(Fmt, Args), logger:info(Fmt, Args)).
+-define(NOTICE(Fmt, Args), logger:notice(Fmt, Args)).
+-define(WARN(Fmt, Args), logger:warning(Fmt, Args)).
+-define(ERR(Fmt, Args), logger:error(Fmt, Args)).
 
 -define(DEFAULT_TIMEOUT, 5000).
 

--- a/include/ra.hrl
+++ b/include/ra.hrl
@@ -137,12 +137,22 @@
 %% WAL defaults
 -define(WAL_MAX_SIZE_BYTES, 1024 * 1024 * 1024).
 
+%% logging shim
+-define(DEBUG(Fmt, Args), ?DISPATCH_LOG(debug, Fmt, Args)).
+-define(INFO(Fmt, Args), ?DISPATCH_LOG(info, Fmt, Args)).
+-define(NOTICE(Fmt, Args), ?DISPATCH_LOG(notice, Fmt, Args)).
+-define(WARN(Fmt, Args), ?DISPATCH_LOG(warning, Fmt, Args)).
+-define(ERR(Fmt, Args), ?DISPATCH_LOG(error, Fmt, Args)).
 
--define(DEBUG(Fmt, Args), logger:debug(Fmt, Args)).
--define(INFO(Fmt, Args), logger:info(Fmt, Args)).
--define(NOTICE(Fmt, Args), logger:notice(Fmt, Args)).
--define(WARN(Fmt, Args), logger:warning(Fmt, Args)).
--define(ERR(Fmt, Args), logger:error(Fmt, Args)).
+-define(DISPATCH_LOG(Level, Fmt, Args),
+        %% same as OTP logger does when using the macro
+        catch (persistent_term:get('$ra_logger')):log(Level, Fmt, Args,
+                                                      #{mfa => {?MODULE,
+                                                                ?FUNCTION_NAME,
+                                                                ?FUNCTION_ARITY},
+                                                        file => ?FILE,
+                                                        line => ?LINE}),
+       ok).
 
 -define(DEFAULT_TIMEOUT, 5000).
 

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -172,7 +172,7 @@ start_or_restart_cluster(ClusterName, Machine,
             _ = [{ok, _} = ra_server_sup_sup:restart_server(N) || N <- RemServers],
             {ok, ServerIds, []};
         {error, Err} ->
-            ?DEBUG("start_or_restart_cluster: got error ~p~n", [Err]),
+            ?ERR("start_or_restart_cluster: got an error: ~p~n", [Err]),
             start_cluster(ClusterName, Machine, ServerIds)
     end.
 
@@ -203,14 +203,14 @@ start_cluster(ClusterName, Machine, ServerIds) ->
                 case start_server(ClusterName, N, Machine, ServerIds) of
                     ok  -> true;
                     Err ->
-                        ?WARN("ra: failed to start a server ~w : ~p~n",
+                        ?ERR("ra: failed to start a server ~w, error: ~p~n",
                               [N, Err]),
                         false
                 end
             end, ServerIds),
     case Started of
         [] ->
-            ?WARN("ra: failed to form new cluster ~w.~n "
+            ?ERR("ra: failed to form a new cluster ~w.~n "
                   "No servers were succesfully started.~n", [ClusterName]),
             {error, cluster_not_formed};
         _ ->
@@ -346,12 +346,12 @@ leave_and_terminate(ServerRef, ServerId, Timeout) ->
     LeaveCmd = {'$ra_leave', ServerId, await_consensus},
     case ra_server_proc:command(ServerRef, LeaveCmd, Timeout) of
         {timeout, Who} ->
-            ?ERR("request to ~p timed out trying to leave the cluster", [Who]),
+            ?ERR("Failed to leave the cluster: request to ~p timed out", [Who]),
             timeout;
         {error, no_proc} = Err ->
             Err;
         {ok, _, _} ->
-            ?ERR("~p has left the building. terminating", [ServerId]),
+            ?INFO("We (Ra node ~p) have successfully left the cluster. Terminating.", [ServerId]),
             stop_server(ServerId)
     end.
 
@@ -370,12 +370,12 @@ leave_and_delete_server(ServerRef, ServerId, Timeout) ->
     LeaveCmd = {'$ra_leave', ServerId, await_consensus},
     case ra_server_proc:command(ServerRef, LeaveCmd, Timeout) of
         {timeout, Who} ->
-            ?ERR("request to ~p timed out trying to leave the cluster", [Who]),
+            ?ERR("Failed to leave the cluster: request to ~p timed out", [Who]),
             timeout;
         {error, no_proc} = Err ->
             Err;
         {ok, _, _} ->
-            ?ERR("~p has left the building. terminating", [ServerId]),
+            ?INFO("We (Ra node ~p) have succesfully left the cluster. Terminating.", [ServerId]),
             force_delete_server(ServerId)
     end.
 
@@ -549,4 +549,3 @@ sort_by_local([{_, N} = X | Rem], Acc) when N =:= node() ->
     [X | Acc] ++ Rem;
 sort_by_local([X | Rem], Acc) ->
     sort_by_local(Rem, [X | Acc]).
-

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -172,7 +172,7 @@ start_or_restart_cluster(ClusterName, Machine,
             _ = [{ok, _} = ra_server_sup_sup:restart_server(N) || N <- RemServers],
             {ok, ServerIds, []};
         {error, Err} ->
-            ?INFO("start_or_restart_cluster: got error ~p~n", [Err]),
+            ?DEBUG("start_or_restart_cluster: got error ~p~n", [Err]),
             start_cluster(ClusterName, Machine, ServerIds)
     end.
 

--- a/src/ra_env.erl
+++ b/src/ra_env.erl
@@ -3,7 +3,8 @@
 -export([
          data_dir/0,
          server_data_dir/1,
-         wal_data_dir/0
+         wal_data_dir/0,
+         configure_logger/1
          ]).
 
 -export_type([
@@ -32,3 +33,7 @@ wal_data_dir() ->
         _ ->
             data_dir()
     end.
+
+%% use this when interacting with Ra from a node without Ra running on it
+configure_logger(Module) ->
+    persistent_term:put('$ra_logger', Module).

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -179,11 +179,11 @@ init(#{uid := UId} = Conf) ->
     % initialized with a default 0 index 0 term dummy value
     % and an empty meta data map
     State = maybe_append_first_entry(State0),
-    ?INFO("~s: ra_log:init recovered last_index_term ~w"
-          " first index ~b~n",
-          [State#?MODULE.uid,
-           last_index_term(State),
-           State#?MODULE.first_index]),
+    ?DEBUG("~s: ra_log:init recovered last_index_term ~w"
+           " first index ~b~n",
+           [State#?MODULE.uid,
+            last_index_term(State),
+            State#?MODULE.first_index]),
     delete_segments(SnapIdx, State).
 
 -spec close(ra_log()) -> ok.
@@ -330,9 +330,9 @@ handle_event({written, {FromIdx, ToIdx, Term}},
                                   max(LastWrittenTerm0, Term)},
             {State#?MODULE{last_written_index_term = LastWrittenIdxTerm}, []};
         {_X, State} ->
-            ?INFO("~s: written event did not find term ~b for index ~b "
-                  "found ~w",
-                  [State#?MODULE.uid, Term, ToIdx, _X]),
+            ?DEBUG("~s: written event did not find term ~b for index ~b "
+                   "found ~w",
+                   [State#?MODULE.uid, Term, ToIdx, _X]),
             {State, []}
     end;
 handle_event({written, {FromIdx, _, _}}, %% ToIdx, Term
@@ -631,8 +631,8 @@ delete_segments(Idx, #?MODULE{uid = UId,
             ObsoleteFiles = [filename:join(Dir, O) || O <- ObsoleteKeys],
             ok = ra_log_segment_writer:delete_segments(UId, Idx,
                                                        ObsoleteFiles),
-            ?INFO("~s: ~b obsolete segments at ~b - remaining: ~b",
-                  [UId, length(ObsoleteKeys), Idx, length(Active)]),
+            ?DEBUG("~s: ~b obsolete segments at ~b - remaining: ~b",
+                   [UId, length(ObsoleteKeys), Idx, length(Active)]),
             State0#?MODULE{open_segments = OpenSegs,
                            segment_refs = Active}
     end.
@@ -900,8 +900,8 @@ resend_from(Idx, #?MODULE{uid = UId} = State0) ->
 resend_from0(Idx, #?MODULE{last_index = LastIdx,
                          last_resend_time = undefined,
                          cache = Cache} = State) ->
-    ?INFO("~s: ra_log: resending from ~b to ~b",
-          [State#?MODULE.uid, Idx, LastIdx]),
+    ?DEBUG("~s: ra_log: resending from ~b to ~b",
+           [State#?MODULE.uid, Idx, LastIdx]),
     lists:foldl(fun (I, Acc) ->
                         X = maps:get(I, Cache),
                         wal_write(Acc, erlang:insert_element(1, X, I))

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -341,8 +341,8 @@ handle_event({written, {FromIdx, _, _}}, %% ToIdx, Term
   when FromIdx > LastWrittenIdx + 1 ->
     % leaving a gap is not ok - resend from cache
     Expected = LastWrittenIdx + 1,
-    ?WARN("~s: ra_log: written gap detected at ~b expected ~b!",
-         [UId, FromIdx, Expected]),
+    ?INFO("~s: ra_log: written gap detected at ~b expected ~b!",
+          [UId, FromIdx, Expected]),
     {resend_from(Expected, State0), []};
 handle_event({segments, Tid, NewSegs},
              #?MODULE{uid = UId,

--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -141,7 +141,7 @@ handle_cast({mem_tables, Tables, WalFile}, State0) ->
     % TODO: test scenario when server crashes after segments but before
     % deleting walfile
     % can we make segment writer idempotent somehow
-    ?INFO("segment_writer: deleting wal file: ~s~n",
+    ?DEBUG("segment_writer: deleting wal file: ~s~n",
           [filename:basename(WalFile)]),
     %% temporarily disable wal deletion
     %% TODO: this shoudl be a debug option config?
@@ -250,8 +250,8 @@ do_segment({ServerUId, StartIdx0, EndIdx, Tid},
                                 ActiveSegments#{ServerUId => Segment}}
             end;
         false ->
-            ?INFO("segment_writer: skipping segment as directory ~s does "
-                  "not exist~n", [Dir]),
+            ?DEBUG("segment_writer: skipping segment as directory ~s does "
+                   "not exist~n", [Dir]),
             State
     end.
 
@@ -267,10 +267,10 @@ send_segments(ServerUId, Tid, Segments) ->
     Msg = {ra_log_event, {segments, Tid, Segments}},
     case ra_directory:pid_of(ServerUId) of
         undefined ->
-            ?INFO("ra_log_segment_writer: error sending "
-                  "ra_log_event to: "
-                  "~s. Error: ~s",
-                  [ServerUId, "No Pid"]),
+            ?DEBUG("ra_log_segment_writer: error sending "
+                   "ra_log_event to: "
+                   "~s. Error: ~s",
+                   [ServerUId, "No Pid"]),
             _ = ets:delete(Tid),
             _ = clean_closed_mem_tables(ServerUId, Tid),
             ok;
@@ -282,8 +282,8 @@ send_segments(ServerUId, Tid, Segments) ->
 clean_closed_mem_tables(UId, Tid) ->
     Tables = ets:lookup(ra_log_closed_mem_tables, UId),
     [begin
-         ?INFO("~w: cleaning closed table for '~s' range: ~b-~b~n",
-               [?MODULE, UId, From, To]),
+         ?DEBUG("~w: cleaning closed table for '~s' range: ~b-~b~n",
+                [?MODULE, UId, From, To]),
          %% delete the entry in the closed table lookup
          true = ets:delete_object(ra_log_closed_mem_tables, O)
      end || {_, _, From, To, T} = O <- Tables, T == Tid].

--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -351,9 +351,9 @@ handle_msg({append, {UId, Pid} = Id, Idx, Term, Entry},
         {ok, {in_seq, PrevIdx}} ->
             % writer was in seq but has sent an out of seq entry
             % notify writer
-            ?WARN("WAL: requesting resend from `~p`, "
-                  "last idx ~b idx received ~b",
-                  [UId, PrevIdx, Idx]),
+            ?DEBUG("WAL: requesting resend from `~p`, "
+                   "last idx ~b idx received ~b",
+                   [UId, PrevIdx, Idx]),
             Pid ! {ra_log_event, {resend_write, PrevIdx + 1}},
             State0#state{writers = Writers#{UId => {out_of_seq, PrevIdx}}}
     end;
@@ -411,7 +411,7 @@ roll_over(OpnMemTbls, #state{wal = Wal0, dir = Dir, file_num = Num0,
     Num = Num0 + 1,
     Fn = ra_lib:zpad_filename("", "wal", Num),
     NextFile = filename:join(Dir, Fn),
-    ?INFO("wal: opening new file ~p~n", [Fn]),
+    ?DEBUG("wal: opening new file ~p~n", [Fn]),
     case Wal0 of
         undefined ->
             ok;
@@ -587,7 +587,7 @@ try_recover_records(Data, Cache) ->
     try recover_records(Data, Cache) of
         ok -> ok
     catch _:_ = Err ->
-              ?INFO("wal: encountered error during recovery: ~w~n"
+              ?WARN("wal: encountered error during recovery: ~w~n"
                     "Continuing.~n", [Err]),
               ok
     end.

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -251,8 +251,8 @@ recover(#{id := Id,
           commit_index := CommitIndex,
           last_applied := _LastApplied,
           machine := Machine} = State0) ->
-    ?INFO("~w: recovering state machine from ~b to ~b~n",
-          [Id, _LastApplied, CommitIndex]),
+    ?DEBUG("~w: recovering state machine from ~b to ~b~n",
+           [Id, _LastApplied, CommitIndex]),
     {#{log := Log0} = State, _, _} =
         apply_to(CommitIndex,
                  fun(E, S) ->
@@ -320,9 +320,9 @@ handle_leader({PeerId, #append_entries_reply{term = Term}},
                   [Id, PeerId]),
             {leader, State0, []};
         _ ->
-            ?INFO("~w leader saw append_entries_reply for term ~b "
-                  "abdicates term: ~b!~n",
-                  [Id, Term, CurTerm]),
+            ?NOTICE("~w leader saw append_entries_reply for term ~b "
+                    "abdicates term: ~b!~n",
+                    [Id, Term, CurTerm]),
             {follower, update_term(Term, State0), []}
     end;
 handle_leader({PeerId, #append_entries_reply{success = false,
@@ -337,14 +337,15 @@ handle_leader({PeerId, #append_entries_reply{success = false,
     {Peer, Log} = case ra_log:fetch_term(LastIdx, Log0) of
                       {undefined, L} ->
                           % entry was not found - simply set next index to
-                          ?INFO("~w: setting next index for ~w ~b",
-                                [Id, PeerId, NextIdx]),
+                          ?DEBUG("~w: setting next index for ~w ~b",
+                                 [Id, PeerId, NextIdx]),
                           {Peer0#{match_index => LastIdx,
                                   next_index => NextIdx}, L};
                       % entry exists we can forward
                       {LastTerm, L} when LastIdx >= MI ->
-                          ?INFO("~w: setting last index to ~b, next_index ~b"
-                                " for ~w", [Id, LastIdx, NextIdx, PeerId]),
+                          ?DEBUG("~w: setting last index to ~b, "
+                                 " next_index ~b for ~w",
+                                 [Id, LastIdx, NextIdx, PeerId]),
                           {Peer0#{match_index => LastIdx,
                                   next_index => NextIdx}, L};
                       {_Term, L} when LastIdx < MI ->
@@ -352,17 +353,20 @@ handle_leader({PeerId, #append_entries_reply{success = false,
                           % non-persistent.
                           % should they turn-into non-voters when this sitution
                           % is detected
-                          ?ERR("~w: leader saw peer with last_index [~b in ~b]"
-                               " lower than recorded match index [~b]."
+                          ?WARN("~w: leader saw peer with last_index [~b in ~b]"
+                                " lower than recorded match index [~b]."
                                 "Resetting peer's state to last_index.~n",
-                               [Id, LastIdx, LastTerm, MI]),
+                                [Id, LastIdx, LastTerm, MI]),
                           {Peer0#{match_index => LastIdx,
                                   next_index => LastIdx + 1}, L};
                       {_EntryTerm, L} ->
-                          ?INFO("~w: leader received last_index ~b"
-                                " from ~w with "
-                                "term ~b different term ~b~n",
-                                [Id, LastIdx, PeerId, LastTerm, _EntryTerm]),
+                          NextIndex = max(min(NI-1, LastIdx), MI),
+                          ?DEBUG("~w: leader received last_index ~b"
+                                 " from ~w with term ~b "
+                                 "- expected term ~b. Setting"
+                                 "next_index to ~b~n",
+                                 [Id, LastIdx, PeerId, LastTerm, _EntryTerm,
+                                  NextIndex]),
                           % last_index has a different term or entry does not
                           % exist
                           % The peer must have received an entry from a previous
@@ -370,7 +374,7 @@ handle_leader({PeerId, #append_entries_reply{success = false,
                           % entry at the same index in a different term.
                           % decrement next_index but don't go lower than
                           % match index.
-                          {Peer0#{next_index => max(min(NI-1, LastIdx), MI)}, L}
+                          {Peer0#{next_index => NextIndex}, L}
                   end,
     State1 = State0#{cluster => Nodes#{PeerId => Peer}, log => Log},
     {State, _, Effects} = make_pipelined_rpc_effects(State1, []),
@@ -435,7 +439,7 @@ handle_leader({PeerId, #install_snapshot_result{term = Term}},
                   [Id, PeerId]),
             {leader, State0, []};
         _ ->
-            ?INFO("~w: leader saw install_snapshot_result for term ~b"
+            ?DEBUG("~w: leader saw install_snapshot_result for term ~b"
                   " abdicates term: ~b!~n", [Id, Term, CurTerm]),
             {follower, update_term(Term, State0), []}
     end;
@@ -543,6 +547,12 @@ handle_leader(#pre_vote_rpc{term = Term},
     % enforce leadership
     {State, Effects} = make_all_rpcs(State0),
     {leader, State, Effects};
+handle_leader(#request_vote_result{}, State) ->
+    %% handle to avoid logging as unhandled
+    {leader, State, []};
+handle_leader(#pre_vote_result{}, State) ->
+    %% handle to avoid logging as unhandled
+    {leader, State, []};
 handle_leader(Msg, State) ->
     log_unhandled_msg(leader, Msg, State),
     {leader, State, []}.
@@ -567,7 +577,7 @@ handle_candidate(#request_vote_result{term = Term},
                  #{current_term := CurTerm} = State0)
   when Term > CurTerm ->
     ?INFO("~w: candidate request_vote_result with higher term"
-          " received ~b -> ~b", [id(State0), CurTerm, Term]),
+           " received ~b -> ~b", [id(State0), CurTerm, Term]),
     State = update_meta(Term, undefined, State0),
     {follower, State, []};
 handle_candidate(#request_vote_result{vote_granted = false}, State) ->
@@ -596,9 +606,25 @@ handle_candidate(#request_vote_rpc{term = Term} = Msg,
           [id(State0), CurTerm, Term]),
     State = update_meta(Term, undefined, State0),
     {follower, State, [{next_event, Msg}]};
+handle_candidate(#pre_vote_rpc{term = Term} = Msg,
+                 #{current_term := CurTerm} = State0)
+  when Term > CurTerm ->
+    ?INFO("~w: candidate pre_vote_rpc with higher term received ~b -> ~b~n",
+          [id(State0), CurTerm, Term]),
+    State = update_meta(Term, undefined, State0),
+    {follower, State, [{next_event, Msg}]};
 handle_candidate(#request_vote_rpc{}, State = #{current_term := Term}) ->
     Reply = #request_vote_result{term = Term, vote_granted = false},
     {candidate, State, [{reply, Reply}]};
+handle_candidate(#pre_vote_rpc{}, State) ->
+    %% just ignore pre_votes that aren't of a higher term
+    {candidate, State, []};
+handle_candidate(#request_vote_result{}, State) ->
+    %% handle to avoid logging as unhandled
+    {candidate, State, []};
+handle_candidate(#pre_vote_result{}, State) ->
+    %% handle to avoid logging as unhandled
+    {candidate, State, []};
 handle_candidate(election_timeout, State) ->
     call_for_election(candidate, State);
 handle_candidate(Msg, State) ->
@@ -647,6 +673,12 @@ handle_pre_vote(#pre_vote_result{vote_granted = false}, State) ->
     {pre_vote, State, []};
 handle_pre_vote(#pre_vote_rpc{} = PreVote, State) ->
     process_pre_vote(pre_vote, PreVote, State);
+handle_pre_vote(#request_vote_result{}, State) ->
+    %% handle to avoid logging as unhandled
+    {pre_vote, State, []};
+handle_pre_vote(#pre_vote_result{}, State) ->
+    %% handle to avoid logging as unhandled
+    {pre_vote, State, []};
 handle_pre_vote(election_timeout, State) ->
     call_for_election(pre_vote, State);
 handle_pre_vote({ra_log_event, Evt}, State = #{log := Log0}) ->
@@ -680,7 +712,7 @@ handle_follower(#append_entries_rpc{term = Term,
                                [] when element(1, LastIdx) > PLIdx ->
                                    %% if no entries were sent we need to reset
                                    %% last index to match the leader
-                                   ?INFO("ra: resetting last index to ~b~n",
+                                   ?DEBUG("ra: resetting last index to ~b~n",
                                          [PLIdx]),
                                    {ok, L} = ra_log:set_last_index(PLIdx, Log1),
                                    L;
@@ -757,7 +789,7 @@ handle_follower(#append_entries_rpc{term = _Term, leader_id = LeaderId},
                 #{id := Id, current_term := CurTerm} = State) ->
     % the term is lower than current term
     Reply = append_entries_reply(CurTerm, false, State),
-    ?INFO("~w: follower request_vote_rpc in ~b but current term ~b~n",
+    ?DEBUG("~w: follower request_vote_rpc in ~b but current term ~b~n",
           [Id, _Term, CurTerm]),
     {follower, State, [cast_reply(Id, LeaderId, Reply)]};
 handle_follower({ra_log_event, {written, _} = Evt},
@@ -775,8 +807,8 @@ handle_follower(#request_vote_rpc{candidate_id = Cand, term = Term},
                 #{current_term := Term, voted_for := VotedFor} = State)
   when VotedFor /= undefined andalso VotedFor /= Cand ->
     % already voted for another in this term
-    ?INFO("~w: follower request_vote_rpc for ~w already voted for ~w in ~b",
-          [id(State), Cand, VotedFor, Term]),
+    ?DEBUG("~w: follower request_vote_rpc for ~w already voted for ~w in ~b",
+           [id(State), Cand, VotedFor, Term]),
     Reply = #request_vote_result{term = Term, vote_granted = false},
     {follower, State, [{reply, Reply}]};
 handle_follower(#request_vote_rpc{term = Term, candidate_id = Cand,
@@ -817,7 +849,7 @@ handle_follower(#install_snapshot_rpc{term = Term,
                                       last_term = LastTerm},
                 State = #{id := Id, current_term := CurTerm})
   when Term < CurTerm ->
-    ?INFO("~w: install_snapshot old term ~b in ~b~n",
+    ?DEBUG("~w: install_snapshot old term ~b in ~b~n",
           [Id, LastIndex, LastTerm]),
     % follower receives a snapshot from an old term
     Reply = #install_snapshot_result{term = CurTerm,
@@ -838,14 +870,20 @@ handle_follower(#install_snapshot_rpc{term = Term,
   when Term >= CurTerm andalso Idx > LastApplied ->
     %% only begin snapshot procedure if Idx is higher than the last_applied
     %% index.
-    ?INFO("~w: begin_accept snapshot at index ~b in term ~b~n",
-          [Id, Idx, Term]),
+    ?DEBUG("~w: begin_accept snapshot at index ~b in term ~b~n",
+           [Id, Idx, Term]),
     SnapState0 = ra_log:snapshot_state(Log0),
     {ok, SS} = ra_snapshot:begin_accept({Idx, SnapTerm, Cluster},
                                         SnapState0),
     Log = ra_log:set_snapshot_state(SS, Log0),
     {receive_snapshot, State0#{log => Log,
                                leader_id => LeaderId}, [{next_event, Rpc}]};
+handle_follower(#request_vote_result{}, State) ->
+    %% handle to avoid logging as unhandled
+    {follower, State, []};
+handle_follower(#pre_vote_result{}, State) ->
+    %% handle to avoid logging as unhandled
+    {follower, State, []};
 handle_follower(election_timeout, State) ->
     call_for_election(pre_vote, State);
 handle_follower(Msg, State) ->
@@ -860,8 +898,8 @@ handle_receive_snapshot(#install_snapshot_rpc{term = Term,
                         #{id := Id, log := Log0,
                           current_term := CurTerm} = State0)
   when Term >= CurTerm ->
-    ?INFO("~w: receiving snapshot chunk: ~b / ~b~n",
-          [Id, Num, ChunkFlag]),
+    ?DEBUG("~w: receiving snapshot chunk: ~b / ~b~n",
+           [Id, Num, ChunkFlag]),
     SnapState0 = ra_log:snapshot_state(Log0),
     {ok, SnapState} = ra_snapshot:accept_chunk(Data, Num, ChunkFlag, SnapState0),
     Reply = #install_snapshot_result{term = CurTerm,
@@ -1265,7 +1303,7 @@ handle_down(leader, machine, Pid, Info, State) ->
                              {down, Pid, Info}, noreply}},
                   State);
 handle_down(leader, snapshot_sender, Pid, Info, #{id := Id} = State) ->
-    ?INFO("~w: Snapshot sender process ~w exited with ~W~n",
+    ?DEBUG("~w: Snapshot sender process ~w exited with ~W~n",
           [Id, Pid, Info, 10]),
     {leader, peer_snapshot_process_exited(Pid, State), []};
 handle_down(RaftState, snapshot_writer, Pid, Info,
@@ -1285,7 +1323,7 @@ handle_down(RaftState, snapshot_writer, Pid, Info,
 
 -spec terminate(ra_server_state(), Reason :: {shutdown, delete} | term()) -> ok.
 terminate(#{log := Log} = _State, {shutdown, delete}) ->
-    ?INFO("~w: terminating and deleting all data~n", [id(_State)]),
+    ?NOTICE("~w: terminating and deleting all data~n", [id(_State)]),
     catch ra_log:delete_everything(Log),
     ok;
 terminate(State, _Reason) ->
@@ -1333,7 +1371,7 @@ call_for_election(candidate, #{id := Id,
      [{next_event, cast, VoteForSelf}, {send_vote_requests, Reqs}]};
 call_for_election(pre_vote, #{id := Id,
                               current_term := Term} = State0) ->
-    ?INFO("~w: pre_vote election called for in term ~b~n", [Id, Term]),
+    ?DEBUG("~w: pre_vote election called for in term ~b~n", [Id, Term]),
     Token = make_ref(),
     PeerIds = peer_ids(State0),
     {LastIdx, LastTerm} = last_idx_term(State0),
@@ -1362,20 +1400,20 @@ process_pre_vote(FsmState, #pre_vote_rpc{term = Term, candidate_id = Cand,
     LastIdxTerm = last_idx_term(State),
     case is_candidate_log_up_to_date(LLIdx, LLTerm, LastIdxTerm) of
         true when Version =< ?RA_PROTO_VERSION ->
-            ?INFO("~w: granting pre-vote for ~w with last indexterm ~w"
-                  " for term ~b previous term ~b~n",
-                  [id(State0), Cand, {LLIdx, LLTerm}, Term, CurTerm]),
+            ?DEBUG("~w: granting pre-vote for ~w with last indexterm ~w"
+                   " for term ~b previous term ~b~n",
+                   [id(State0), Cand, {LLIdx, LLTerm}, Term, CurTerm]),
             {FsmState, State#{voted_for => Cand},
              [{reply, pre_vote_result(Term, Token, true)}]};
         true ->
-            ?INFO("~w: declining pre-vote for ~w for protocol version ~b~n",
-                  [id(State0), Cand, Version]),
+            ?DEBUG("~w: declining pre-vote for ~w for protocol version ~b~n",
+                   [id(State0), Cand, Version]),
             {FsmState, State, [{reply, pre_vote_result(Term, Token, false)}]};
         false ->
-            ?INFO("~w: declining pre-vote for ~w for term ~b,"
-                  " candidate last log index term was: ~w~n"
-                  "Last log entry idxterm seen was: ~w~n",
-                  [id(State0), Cand, Term, {LLIdx, LLTerm}, LastIdxTerm]),
+            ?DEBUG("~w: declining pre-vote for ~w for term ~b,"
+                   " candidate last log index term was: ~w~n"
+                   "Last log entry idxterm seen was: ~w~n",
+                   [id(State0), Cand, Term, {LLIdx, LLTerm}, LastIdxTerm]),
             case FsmState of
                 follower ->
                     %% immediately enter pre_vote election as this node is more
@@ -1392,8 +1430,8 @@ process_pre_vote(FsmState, #pre_vote_rpc{term = Term,
                                          candidate_id = _Cand},
                 #{current_term := CurTerm} = State)
   when Term < CurTerm ->
-    ?INFO("~w declining pre-vote to ~w for term ~b, current term ~b~n",
-          [id(State), _Cand, Term, CurTerm]),
+    ?DEBUG("~w declining pre-vote to ~w for term ~b, current term ~b~n",
+           [id(State), _Cand, Term, CurTerm]),
     {FsmState, State,
      [{reply, pre_vote_result(CurTerm, Token, false)}]}.
 
@@ -1592,8 +1630,8 @@ apply_with(_Machine,
            {Idx, _, {'$ra_cluster_change', #{from := From}, _New,
                         ReplyType}},
            {_, State0, MacSt, Effects0, Notifys0}) ->
-    ?INFO("~w: applying ra cluster change to ~w~n",
-          [id(State0), maps:keys(_New)]),
+    ?DEBUG("~w: applying ra cluster change to ~w~n",
+           [id(State0), maps:keys(_New)]),
     {Effects, Notifys} = add_reply(From, ok, ReplyType,
                                    Effects0, Notifys0),
     State = State0#{cluster_change_permitted => true},
@@ -1603,7 +1641,7 @@ apply_with(_Machine,
 apply_with(_, % Machine
            {Idx, Term, noop}, % Idx
            {_, State0 = #{current_term := Term}, MacSt, Effects, Notifys}) ->
-    ?INFO("~w: enabling ra cluster changes in ~b~n", [id(State0), Term]),
+    ?DEBUG("~w: enabling ra cluster changes in ~b~n", [id(State0), Term]),
     State = State0#{cluster_change_permitted => true},
     {Idx, State, MacSt, Effects, Notifys};
 apply_with(_, {Idx, _, noop},

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1355,7 +1355,7 @@ log_fold(#{log := Log} = RaState, Fun, State) ->
 call_for_election(candidate, #{id := Id,
                                current_term := CurrentTerm} = State0) ->
     NewTerm = CurrentTerm + 1,
-    ?INFO("~w: election called for in term ~b~n", [Id, NewTerm]),
+    ?DEBUG("~w: election called for in term ~b~n", [Id, NewTerm]),
     PeerIds = peer_ids(State0),
     % increment current term
     {LastIdx, LastTerm} = last_idx_term(State0),

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -222,8 +222,8 @@ callback_mode() -> [state_functions, state_enter].
 %%%===================================================================
 %%% State functions
 %%%===================================================================
-recover(enter, _OldState, State0) ->
-    {State, Actions} = handle_enter(?FUNCTION_NAME, State0),
+recover(enter, OldState, State0) ->
+    {State, Actions} = handle_enter(?FUNCTION_NAME, OldState, State0),
     {keep_state, State, Actions};
 recover(_EventType, go, State = #state{server_state = ServerState0}) ->
     ServerState = ra_server:recover(ServerState0),
@@ -239,8 +239,8 @@ recover(_, _, State) ->
 
 %% this is a passthrough state to allow state machines to emit node local
 %% effects post recovery
-recovered(enter, _OldState, State0) ->
-    {State, Actions} = handle_enter(?FUNCTION_NAME, State0),
+recovered(enter, OldState, State0) ->
+    {State, Actions} = handle_enter(?FUNCTION_NAME, OldState, State0),
     {keep_state, State, Actions};
 recovered(internal, next, #state{server_state = ServerState} = State) ->
     % New cluster starts should be coordinated and elections triggered
@@ -256,8 +256,8 @@ recovered(internal, next, #state{server_state = ServerState} = State) ->
               end,
     {next_state, follower, State, set_tick_timer(State, Actions)}.
 
-leader(enter, _, State0) ->
-    {State, Actions} = handle_enter(?FUNCTION_NAME, State0),
+leader(enter, OldState, State0) ->
+    {State, Actions} = handle_enter(?FUNCTION_NAME, OldState, State0),
     {keep_state, State, Actions};
 leader(EventType, {leader_call, Msg}, State) ->
     %  no need to redirect
@@ -411,8 +411,8 @@ leader(EventType, Msg, State0) ->
             end
     end.
 
-candidate(enter, _, State0) ->
-    {State, Actions} = handle_enter(?FUNCTION_NAME, State0),
+candidate(enter, OldState, State0) ->
+    {State, Actions} = handle_enter(?FUNCTION_NAME, OldState, State0),
     {keep_state, State, Actions};
 candidate({call, From}, {leader_call, Msg},
           #state{pending_commands = Pending} = State) ->
@@ -463,8 +463,8 @@ candidate(EventType, Msg, #state{pending_commands = Pending} = State0) ->
     end.
 
 
-pre_vote(enter, _, State0) ->
-    {State, Actions} = handle_enter(?FUNCTION_NAME, State0),
+pre_vote(enter, OldState, State0) ->
+    {State, Actions} = handle_enter(?FUNCTION_NAME, OldState, State0),
     {keep_state, State, Actions};
 pre_vote({call, From}, {leader_call, Msg},
           State = #state{pending_commands = Pending}) ->
@@ -495,8 +495,6 @@ pre_vote(EventType, Msg, State0) ->
             {keep_state, State, Actions};
         {follower, State1, Effects} ->
             {State, Actions} = ?HANDLE_EFFECTS(Effects, EventType, State1),
-            ?INFO("~w pre_vote -> follower term: ~b~n",
-                  [id(State), current_term(State)]),
             {next_state, follower, State,
              % always set an election timeout here to ensure an unelectable
              % node doesn't cause an electable one not to trigger
@@ -504,14 +502,12 @@ pre_vote(EventType, Msg, State0) ->
              [election_timeout_action(long, State) | Actions]};
         {candidate, State1, Effects} ->
             {State, Actions} = ?HANDLE_EFFECTS(Effects, EventType, State1),
-            ?INFO("~w pre_vote -> candidate term: ~b~n",
-                  [id(State), current_term(State)]),
             {next_state, candidate, State,
              [election_timeout_action(long, State) | Actions]}
     end.
 
-follower(enter, _, State0) ->
-    {State, Actions} = handle_enter(?FUNCTION_NAME, State0),
+follower(enter, OldState, State0) ->
+    {State, Actions} = handle_enter(?FUNCTION_NAME, OldState, State0),
     {keep_state, State, Actions};
 follower({call, From}, {leader_call, Msg}, State) ->
     maybe_redirect(From, Msg, State);
@@ -539,14 +535,14 @@ follower({call, From}, {local_query, QueryFun},
     Reply = perform_local_query(QueryFun, follower, ServerState),
     {keep_state, State, [{reply, From, Reply}]};
 follower({call, From}, trigger_election, State) ->
-    ?INFO("~w: election triggered by ~w", [id(State), element(1, From)]),
+    ?DEBUG("~w: election triggered by ~w", [id(State), element(1, From)]),
     {keep_state, State, [{reply, From, ok},
                          {next_event, cast, election_timeout}]};
 follower({call, From}, ping, State) ->
     {keep_state, State, [{reply, From, {pong, follower}}]};
 follower(info, {'DOWN', MRef, process, _Pid, Info},
          #state{leader_monitor = MRef} = State) ->
-    ?WARN("~w: Leader monitor down with ~W, setting election timeout~n",
+    ?INFO("~w: Leader monitor down with ~W, setting election timeout~n",
           [id(State), Info, 8]),
     case Info of
         noconnection ->
@@ -594,34 +590,26 @@ follower(EventType, Msg, #state{await_condition_timeout = AwaitCondTimeout,
             {keep_state, State, maybe_set_election_timeout(State, Actions)};
         {pre_vote, State1, Effects} ->
             {State, Actions} = ?HANDLE_EFFECTS(Effects, EventType, State1),
-            ?INFO("~w follower -> pre_vote in term: ~b~n",
-                  [id(State), current_term(State)]),
             _ = stop_monitor(MRef),
             {next_state, pre_vote, State#state{leader_monitor = undefined},
              [election_timeout_action(long, State) | Actions]};
         {await_condition, State1, Effects} ->
             {State2, Actions} = ?HANDLE_EFFECTS(Effects, EventType, State1),
             State = follower_leader_change(State0, State2),
-            ?INFO("~w follower -> await_condition term: ~b~n",
-                  [id(State), current_term(State)]),
             {next_state, await_condition, State,
              [{state_timeout, AwaitCondTimeout, await_condition_timeout}
               | Actions]};
         {receive_snapshot, State1, Effects} ->
             {State, Actions} = ?HANDLE_EFFECTS(Effects, EventType, State1),
-            ?INFO("~w follower -> receive_snapshot in term: ~b~n",
-                  [id(State), current_term(State)]),
             {next_state, receive_snapshot, State, Actions};
         {delete_and_terminate, State1, Effects} ->
-            ?INFO("~w follower -> terminating_follower term: ~b~n",
-                  [id(State1), current_term(State1)]),
             {State, Actions} = ?HANDLE_EFFECTS(Effects, EventType, State1),
             {next_state, terminating_follower, State, Actions}
     end.
 
 %% TODO: handle leader down abort snapshot and revert to follower
-receive_snapshot(enter, _, State0) ->
-    {State, Actions} = handle_enter(?FUNCTION_NAME, State0),
+receive_snapshot(enter, OldState, State0) ->
+    {State, Actions} = handle_enter(?FUNCTION_NAME, OldState, State0),
     {keep_state, State,
      [{state_timeout, receive_snapshot_timeout(), receive_snapshot_timeout}
       | Actions]};
@@ -638,8 +626,8 @@ receive_snapshot(EventType, Msg, State0) ->
             {next_state, follower, State, Actions}
     end.
 
-terminating_leader(enter, _, State0) ->
-    {State, Actions} = handle_enter(?FUNCTION_NAME, State0),
+terminating_leader(enter, OldState, State0) ->
+    {State, Actions} = handle_enter(?FUNCTION_NAME, OldState, State0),
     {keep_state, State, Actions};
 terminating_leader(_EvtType, {command, _, _}, State0) ->
     % do not process any further commands
@@ -657,8 +645,8 @@ terminating_leader(EvtType, Msg, State0) ->
             {keep_state, send_rpcs(State), Actions}
     end.
 
-terminating_follower(enter, _OldState, State0) ->
-    {State, Actions} = handle_enter(?FUNCTION_NAME, State0),
+terminating_follower(enter, OldState, State0) ->
+    {State, Actions} = handle_enter(?FUNCTION_NAME, OldState, State0),
     {keep_state, State, Actions};
 terminating_follower(EvtType, Msg, State0) ->
     % only process ra_log_events
@@ -697,23 +685,19 @@ await_condition(info, {node_event, Node, down}, State) ->
         _ ->
             {keep_state, State}
     end;
-await_condition(enter, _OldState, State0) ->
-    {State, Actions} = handle_enter(?FUNCTION_NAME, State0),
+await_condition(enter, OldState, State0) ->
+    {State, Actions} = handle_enter(?FUNCTION_NAME, OldState, State0),
     {keep_state, State, Actions};
 await_condition(EventType, Msg, #state{leader_monitor = MRef} = State0) ->
     case handle_await_condition(Msg, State0) of
         {follower, State1, Effects} ->
             {State, Actions} = ?HANDLE_EFFECTS(Effects, EventType, State1),
             NewState = follower_leader_change(State0, State),
-            ?INFO("~w await_condition -> follower in term: ~b~n",
-                  [id(State), current_term(State)]),
             {next_state, follower, NewState,
              [{state_timeout, infinity, await_condition_timeout} |
               maybe_set_election_timeout(State, Actions)]};
         {pre_vote, State1, Effects} ->
             {State, Actions} = ?HANDLE_EFFECTS(Effects, EventType, State1),
-            ?INFO("~w await_condition -> pre_vote in term: ~b~n",
-                  [id(State), current_term(State1)]),
             _ = stop_monitor(MRef),
             {next_state, pre_vote, State#state{leader_monitor = undefined},
              [election_timeout_action(long, State) | Actions]};
@@ -722,12 +706,12 @@ await_condition(EventType, Msg, #state{leader_monitor = MRef} = State0) ->
     end.
 
 handle_event(_EventType, EventContent, StateName, State) ->
-    ?WARN("~p: handle_event unknown ~p~n", [id(State), EventContent]),
+    ?WARN("~w: handle_event unknown ~P~n", [id(State), EventContent, 10]),
     {next_state, StateName, State}.
 
 terminate(Reason, StateName,
           #state{name = Key, server_state = ServerState} = State) ->
-    ?WARN("ra: ~w terminating with ~w in state ~w~n",
+    ?INFO("ra: ~w terminating with ~w in state ~w~n",
           [id(State), Reason, StateName]),
     UId = uid(State),
     _ = ra_server:terminate(ServerState, Reason),
@@ -777,11 +761,15 @@ format_status(Opt, [_PDict, StateName, #state{server_state = NS}]) ->
 %%% Internal functions
 %%%===================================================================
 
-handle_enter(RaftState, #state{name = Name,
-                               server_state = ServerState0} = State) ->
+handle_enter(RaftState, OldRaftState,
+             #state{name = Name,
+                    server_state = ServerState0} = State) ->
     true = ets:insert(ra_state, {Name, RaftState}),
     {ServerState, Effects} = ra_server:handle_state_enter(RaftState,
                                                           ServerState0),
+    ?INFO("~w ~s -> ~s in term: ~b~n",
+          [id(State), OldRaftState, RaftState,
+           current_term(State)]),
     handle_effects(RaftState, Effects, cast,
                    State#state{server_state = ServerState}).
 
@@ -1077,10 +1065,8 @@ uid(#state{server_state = ServerState}) ->
 leader_id(#state{server_state = ServerState}) ->
     ra_server:leader_id(ServerState).
 
--ifdef(info).
 current_term(#state{server_state = ServerState}) ->
     ra_server:current_term(ServerState).
--endif.
 
 maybe_set_election_timeout(#state{leader_monitor = LeaderMon},
                            Actions) when LeaderMon =/= undefined ->
@@ -1176,7 +1162,7 @@ maybe_redirect(From, Msg, #state{pending_commands = Pending,
     Leader = leader_id(State),
     case LeaderMon of
         undefined ->
-            ?WARN("~w leader call - leader not known. "
+            ?INFO("~w leader call - leader not known. "
                   "Command will be forwarded once leader is known.~n",
                   [id(State)]),
             {keep_state,

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -992,9 +992,11 @@ handle_effect(_, {monitor, node, Node}, _,
                 true ->
                     %% as effects get evaluated on state enter we cannot use
                     %% next_events
-                    self() ! {nodeup, Node};
+                    self() ! {nodeup, Node},
+                    ok;
                 false ->
-                    self() ! {nodedown, Node}
+                    self() ! {nodedown, Node},
+                    ok
             end,
             {State#state{monitors = Monitors#{Node => undefined}}, Actions0}
     end;

--- a/src/ra_server_sup_sup.erl
+++ b/src/ra_server_sup_sup.erl
@@ -99,12 +99,12 @@ delete_server(NodeId) ->
     Name = ra_lib:ra_server_id_to_local_name(NodeId),
     case stop_server(NodeId) of
         ok ->
-            ?INFO("Deleting node ~w and all it's data.~n", [NodeId]),
             rpc:call(Node, ?MODULE, delete_server_rpc, [Name]);
         {error, _} = Err -> Err
     end.
 
 delete_server_rpc(RaName) ->
+    ?INFO("Deleting server ~w and all it's data.~n", [RaName]),
     %% TODO: better handle and report errors
     UId = ra_directory:uid_of(RaName),
     Pid = ra_directory:where_is(RaName),

--- a/src/ra_sup.erl
+++ b/src/ra_sup.erl
@@ -18,6 +18,10 @@ init([]) ->
     _ = [ets:new(Table, [named_table, public, {write_concurrency, true}])
          || Table <- ?TABLES],
 
+    %% configure the logger module from the application config
+    Logger = application:get_env(ra, logger_module, logger),
+    ok = ra_env:configure_logger(Logger),
+
     SupFlags = #{strategy => one_for_one, intensity => 1, period => 5},
     RaLogFileMetrics = #{id => ra_metrics_ets,
                          start => {ra_metrics_ets, start_link, []}},

--- a/test/coordination_SUITE.erl
+++ b/test/coordination_SUITE.erl
@@ -38,6 +38,8 @@ groups() ->
     ].
 
 init_per_suite(Config) ->
+    %% as we're not starting the ra application and we want the logs
+    ra_env:configure_logger(logger),
     Config.
 
 end_per_suite(_Config) ->

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -49,6 +49,8 @@ groups() ->
 suite() -> [{timetrap, {seconds, 30}}].
 
 init_per_suite(Config) ->
+
+    % ok = logger:set_primary_config(level, debug),
     Config.
 
 end_per_suite(Config) ->
@@ -64,6 +66,7 @@ init_per_group(_G, Config) ->
     PrivDir = ?config(priv_dir, Config),
     DataDir = filename:join([PrivDir, "data"]),
     ok = restart_ra(DataDir),
+    ok = logger:set_application_level(ra, all),
     Config.
 
 end_per_group(_, Config) ->


### PR DESCRIPTION
This change allows the logging backend to be configured. Changes the default to use the standard erlang OTP logger and reviews logging levels as well as handles a few previously unhandled ra protocol messages. 