### PR TITLE
A function to execute a query on the (reasonably) current leader.

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -19,6 +19,8 @@
          members/2,
          local_query/2,
          local_query/3,
+         leader_query/2,
+         leader_query/3,
          consistent_query/2,
          consistent_query/3,
          % cluster operations
@@ -509,6 +511,19 @@ local_query(ServerRef, QueryFun) ->
     {ok, {ra_idxterm(), term()}, ra_server_id() | not_known}.
 local_query(ServerRef, QueryFun, Timeout) ->
     ra_server_proc:query(ServerRef, QueryFun, local, Timeout).
+
+-spec leader_query(ServerId :: ra_server_id(),
+                   QueryFun :: fun((term()) -> term())) ->
+    {ok, {ra_idxterm(), term()}, ra_server_id() | not_known}.
+leader_query(ServerRef, QueryFun) ->
+    leader_query(ServerRef, QueryFun, ?DEFAULT_TIMEOUT).
+
+-spec leader_query(ServerId :: ra_server_id(),
+                   QueryFun :: fun((term()) -> term()),
+                   Timeout :: timeout()) ->
+    {ok, {ra_idxterm(), term()}, ra_server_id() | not_known}.
+leader_query(ServerRef, QueryFun, Timeout) ->
+    ra_server_proc:query(ServerRef, QueryFun, leader, Timeout).
 
 %% @doc Query the state machine
 %% This allows a caller to query the state machine by appending the query

--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -236,9 +236,17 @@ handle_aux({machine, Mod, _}, RaftState, Type, Cmd, Aux, Log, MacState) ->
 -spec query(module(), fun((state()) -> Result), state()) ->
     Result when Result :: term().
 query(Mod, Fun, State) when Mod =/= ra_machine_simple ->
-    Fun(State);
+    apply_fun(Fun, State);
 query(ra_machine_simple, Fun, {simple, _, State}) ->
-    Fun(State).
+    apply_fun(Fun, State).
+
+apply_fun(Fun, State) ->
+    case Fun of
+        F when is_function(F, 1) ->
+            Fun(State);
+        {M, F, A} ->
+            erlang:apply(M, F, A ++ [State])
+    end.
 
 -spec module(machine()) -> module().
 module({machine, Mod, _}) -> Mod.


### PR DESCRIPTION
Works similar to local_query, but redirects the request to the
current leader.
There is no guarantee that the leader will bot be superceeded by
another node or is not already.
There is no guarantee that the state is the most up-to-date.

This query may return stale results.

The purpose of this query is to return slightly up-to date data,
as leader applies commands before followers.