### PR TITLE
Add timestamp to user command meta data

### DIFF
--- a/docs/ra.html
+++ b/docs/ra.html
@@ -26,6 +26,12 @@
     {wal_write_strategy, default | o_sync}</pre></p>
 
 
+<h3 class="typedecl"><a name="type-query_fun">query_fun()</a></h3>
+<p><pre>query_fun() = 
+    fun((term()) -&gt; term()) |
+    {M :: module(), F :: atom(), A :: list()}</pre></p>
+
+
 <h3 class="typedecl"><a name="type-ra_cmd_ret">ra_cmd_ret()</a></h3>
 <p><pre>ra_cmd_ret() = <a href="ra_server_proc.html#type-ra_cmd_ret">ra_server_proc:ra_cmd_ret()</a></pre></p>
 
@@ -34,14 +40,15 @@
 <table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#start-0">start/0</a></td><td>Starts the ra application.</td></tr>
 <tr><td valign="top"><a href="#start-1">start/1</a></td><td>Starts the ra application.</td></tr>
 <tr><td valign="top"><a href="#start_in-1">start_in/1</a></td><td>Starts the ra application with a provided data directory.</td></tr>
-<tr><td valign="top"><a href="#start_server-1">start_server/1</a></td><td>Starts a ra server.</td></tr>
 <tr><td valign="top"><a href="#restart_server-1">restart_server/1</a></td><td>Restarts a previously succesfully started ra server.</td></tr>
 <tr><td valign="top"><a href="#stop_server-1">stop_server/1</a></td><td>Stops a ra server.</td></tr>
-<tr><td valign="top"><a href="#delete_server-1">delete_server/1</a></td><td>Deletes a ra server
+<tr><td valign="top"><a href="#force_delete_server-1">force_delete_server/1</a></td><td>Deletes a ra server
   The server is forcefully deleted.</td></tr>
 <tr><td valign="top"><a href="#start_or_restart_cluster-3">start_or_restart_cluster/3</a></td><td>Starts or restarts a ra cluster.</td></tr>
 <tr><td valign="top"><a href="#start_cluster-3">start_cluster/3</a></td><td>Starts a new distributed ra cluster.</td></tr>
+<tr><td valign="top"><a href="#start_cluster-1">start_cluster/1</a></td><td>Starts a new distributed ra cluster.</td></tr>
 <tr><td valign="top"><a href="#start_server-4">start_server/4</a></td><td></td></tr>
+<tr><td valign="top"><a href="#start_server-1">start_server/1</a></td><td>Starts a ra server.</td></tr>
 <tr><td valign="top"><a href="#delete_cluster-1">delete_cluster/1</a></td><td>Deletes a ra cluster in an orderly fashion
   This function commits and end of life command which after each server applies
   it will cause that server to shut down and delete all it's data.</td></tr>
@@ -62,6 +69,8 @@
 <tr><td valign="top"><a href="#leave_and_delete_server-1">leave_and_delete_server/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#leave_and_delete_server-2">leave_and_delete_server/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#leave_and_delete_server-3">leave_and_delete_server/3</a></td><td></td></tr>
+<tr><td valign="top"><a href="#new_uid-1">new_uid/1</a></td><td>generates a random uid using the provided source material for the first
+  6 characters.</td></tr>
 <tr><td valign="top"><a href="#overview-0">overview/0</a></td><td>return a map of overview data of the ra system on the current erlang
   node.</td></tr>
 <tr><td valign="top"><a href="#process_command-3">process_command/3</a></td><td>Submits a command to a ra server.</td></tr>
@@ -74,6 +83,10 @@ an optional process scoped term as correlation identifier.</td></tr>
   This allows you to run the QueryFun over the server machine state and
   return the result.</td></tr>
 <tr><td valign="top"><a href="#local_query-3">local_query/3</a></td><td></td></tr>
+<tr><td valign="top"><a href="#leader_query-2">leader_query/2</a></td><td>Query the current leader state
+  This function works like local_query, but redirects to the current
+  leader node.</td></tr>
+<tr><td valign="top"><a href="#leader_query-3">leader_query/3</a></td><td></td></tr>
 <tr><td valign="top"><a href="#consistent_query-2">consistent_query/2</a></td><td>Query the state machine
   This allows a caller to query the state machine by appending the query
   to the log and returning the result once applied.</td></tr>
@@ -106,15 +119,6 @@ an optional process scoped term as correlation identifier.</td></tr>
   The same as ra:start([{data_dir, dir}])
   If the application is running it will be stopped and restarted.</p>
 
-<h3 class="function"><a name="start_server-1">start_server/1</a></h3>
-<div class="spec">
-<p><pre>start_server(Conf :: <a href="ra_server.html#type-ra_server_config">ra_server:ra_server_config()</a>) -&gt;
-                ok | {error, term()}</pre></p>
-<p><tt>Conf</tt>: a ra_server_config() configuration map.<br>
-</p>
-<p>returns: <code>{ok | error, Error}</code></p>
-</div><p>Starts a ra server</p>
-
 <h3 class="function"><a name="restart_server-1">restart_server/1</a></h3>
 <div class="spec">
 <p><pre>restart_server(ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>) -&gt; ok | {error, term()}</pre></p>
@@ -133,9 +137,10 @@ an optional process scoped term as correlation identifier.</td></tr>
 <p>returns: <code>{ok | error, nodedown}</code></p>
 </div><p>Stops a ra server</p>
 
-<h3 class="function"><a name="delete_server-1">delete_server/1</a></h3>
+<h3 class="function"><a name="force_delete_server-1">force_delete_server/1</a></h3>
 <div class="spec">
-<p><pre>delete_server(ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>) -&gt; ok | {error, term()}</pre></p>
+<p><pre>force_delete_server(ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>) -&gt;
+                       ok | {error, term()}</pre></p>
 <p><tt>ServerId</tt>: the ra_server_id() of the server<br>
 </p>
 <p>returns: <code>{ok | error, nodedown}</code></p>
@@ -193,6 +198,26 @@ an optional process scoped term as correlation identifier.</td></tr>
 </div><p>Starts a new distributed ra cluster.
  </p>
 
+<h3 class="function"><a name="start_cluster-1">start_cluster/1</a></h3>
+<div class="spec">
+<p><pre>start_cluster(ServerConfigs :: [<a href="ra_server.html#type-ra_server_config">ra_server:ra_server_config()</a>]) -&gt;
+                 {ok, [<a href="#type-ra_server_id">ra_server_id()</a>], [<a href="#type-ra_server_id">ra_server_id()</a>]} |
+                 {error, cluster_not_formed}</pre></p>
+<p><tt>ServerConfigs</tt>: a list of initial server configurations<br>
+</p>
+<p>returns: <p>
+  <code>{ok, Started, NotStarted}</code>  if a cluster could be successfully
+  started. A cluster can be successfully started if more than half of the
+  servers provided could be started. Servers that could not be started need to
+  be retried periodically using <a href="#start_server-1"><code>start_server/1</code></a></p>
+ 
+  <p><code>{error, cluster_not_formed}</code> if a cluster could not be started.</p>
+ 
+  If a cluster could not be formed any servers that did manage to start are
+  forcefully deleted.</p>
+</div><p>Starts a new distributed ra cluster.
+ </p>
+
 <h3 class="function"><a name="start_server-4">start_server/4</a></h3>
 <div class="spec">
 <p><pre>start_server(ClusterName :: <a href="#type-ra_cluster_name">ra_cluster_name()</a>,
@@ -201,6 +226,15 @@ an optional process scoped term as correlation identifier.</td></tr>
              ServerIds :: [<a href="#type-ra_server_id">ra_server_id()</a>]) -&gt;
                 ok | {error, term()}</pre></p>
 </div>
+
+<h3 class="function"><a name="start_server-1">start_server/1</a></h3>
+<div class="spec">
+<p><pre>start_server(Conf :: <a href="ra_server.html#type-ra_server_config">ra_server:ra_server_config()</a>) -&gt;
+                ok | {error, term()}</pre></p>
+<p><tt>Conf</tt>: a ra_server_config() configuration map.<br>
+</p>
+<p>returns: <code>{ok | error, Error}</code></p>
+</div><p>Starts a ra server</p>
 
 <h3 class="function"><a name="delete_cluster-1">delete_cluster/1</a></h3>
 <div class="spec">
@@ -325,6 +359,12 @@ an optional process scoped term as correlation identifier.</td></tr>
                            ok | timeout | {error, no_proc}</pre></p>
 </div>
 
+<h3 class="function"><a name="new_uid-1">new_uid/1</a></h3>
+<div class="spec">
+<p><tt>new_uid(Source) -&gt; any()</tt></p>
+</div><p>generates a random uid using the provided source material for the first
+  6 characters</p>
+
 <h3 class="function"><a name="overview-0">overview/0</a></h3>
 <div class="spec">
 <p><pre>overview() -&gt; map()</pre></p>
@@ -400,7 +440,7 @@ and result tuples.</p>
 structure will be returned informing the caller that it cannot process the  
 message including the current leader, if known:</p>
  
-  <p><code>{ra_event, CurrentLeader, {rejected, {not_leader, Leader | undefined, Correlation}}}</code>  
+  <p><code>{ra_event, CurrentLeader, {rejected, {not_leader, Leader, Correlation}}}</code>  
 The caller can then redirect the command for the correlation identifier to  
 the correct ra server.</p>
  
@@ -434,8 +474,7 @@ the correct ra server.</p>
 
 <h3 class="function"><a name="local_query-2">local_query/2</a></h3>
 <div class="spec">
-<p><pre>local_query(ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>,
-            QueryFun :: fun((term()) -&gt; term())) -&gt;
+<p><pre>local_query(ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>, QueryFun :: <a href="#type-query_fun">query_fun()</a>) -&gt;
                {ok,
                 {<a href="#type-ra_idxterm">ra_idxterm()</a>, term()},
                 <a href="#type-ra_server_id">ra_server_id()</a> | not_known}</pre></p>
@@ -447,17 +486,40 @@ the correct ra server.</p>
 <h3 class="function"><a name="local_query-3">local_query/3</a></h3>
 <div class="spec">
 <p><pre>local_query(ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>,
-            QueryFun :: fun((term()) -&gt; term()),
+            QueryFun :: <a href="#type-query_fun">query_fun()</a>,
             Timeout :: timeout()) -&gt;
                {ok,
                 {<a href="#type-ra_idxterm">ra_idxterm()</a>, term()},
                 <a href="#type-ra_server_id">ra_server_id()</a> | not_known}</pre></p>
 </div>
 
+<h3 class="function"><a name="leader_query-2">leader_query/2</a></h3>
+<div class="spec">
+<p><pre>leader_query(ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>, QueryFun :: <a href="#type-query_fun">query_fun()</a>) -&gt;
+                {ok,
+                 {<a href="#type-ra_idxterm">ra_idxterm()</a>, term()},
+                 <a href="#type-ra_server_id">ra_server_id()</a> | not_known}</pre></p>
+</div><p>Query the current leader state
+  This function works like local_query, but redirects to the current
+  leader node.
+  The leader state may be more up-to-date compared to local.
+  This function may still return stale results as it reads the current state
+  and does not wait for commands to be applied.</p>
+
+<h3 class="function"><a name="leader_query-3">leader_query/3</a></h3>
+<div class="spec">
+<p><pre>leader_query(ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>,
+             QueryFun :: <a href="#type-query_fun">query_fun()</a>,
+             Timeout :: timeout()) -&gt;
+                {ok,
+                 {<a href="#type-ra_idxterm">ra_idxterm()</a>, term()},
+                 <a href="#type-ra_server_id">ra_server_id()</a> | not_known}</pre></p>
+</div>
+
 <h3 class="function"><a name="consistent_query-2">consistent_query/2</a></h3>
 <div class="spec">
 <p><pre>consistent_query(Server :: <a href="#type-ra_server_id">ra_server_id()</a>,
-                 QueryFun :: fun((term()) -&gt; term())) -&gt;
+                 QueryFun :: <a href="#type-query_fun">query_fun()</a>) -&gt;
                     {ok,
                      Reply :: term(),
                      <a href="#type-ra_server_id">ra_server_id()</a> | not_known}</pre></p>
@@ -469,7 +531,7 @@ the correct ra server.</p>
 <h3 class="function"><a name="consistent_query-3">consistent_query/3</a></h3>
 <div class="spec">
 <p><pre>consistent_query(Server :: <a href="#type-ra_server_id">ra_server_id()</a>,
-                 QueryFun :: fun((term()) -&gt; term()),
+                 QueryFun :: <a href="#type-query_fun">query_fun()</a>,
                  Timeout :: timeout()) -&gt;
                     {ok,
                      Reply :: term(),

--- a/docs/ra_directory.html
+++ b/docs/ra_directory.html
@@ -16,9 +16,11 @@
 <h2><a name="index">Function Index</a></h2>
 <table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#init-1">init/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#deinit-0">deinit/0</a></td><td></td></tr>
+<tr><td valign="top"><a href="#register_name-4">register_name/4</a></td><td></td></tr>
 <tr><td valign="top"><a href="#register_name-3">register_name/3</a></td><td></td></tr>
 <tr><td valign="top"><a href="#unregister_name-1">unregister_name/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#where_is-1">where_is/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#where_is_parent-1">where_is_parent/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#name_of-1">name_of/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#pid_of-1">pid_of/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#uid_of-1">uid_of/1</a></td><td></td></tr>
@@ -39,6 +41,15 @@
 <p><pre>deinit() -&gt; ok</pre></p>
 </div>
 
+<h3 class="function"><a name="register_name-4">register_name/4</a></h3>
+<div class="spec">
+<p><pre>register_name(UId :: <a href="#type-ra_uid">ra_uid()</a>,
+              Pid :: pid(),
+              ParentPid :: <a href="#type-maybe">maybe</a>(pid()),
+              RaServerName :: atom()) -&gt;
+                 yes | no</pre></p>
+</div>
+
 <h3 class="function"><a name="register_name-3">register_name/3</a></h3>
 <div class="spec">
 <p><pre>register_name(UId :: <a href="#type-ra_uid">ra_uid()</a>,
@@ -55,6 +66,12 @@
 <h3 class="function"><a name="where_is-1">where_is/1</a></h3>
 <div class="spec">
 <p><pre>where_is(ServerName :: <a href="#type-ra_uid">ra_uid()</a> | atom()) -&gt; pid() | undefined</pre></p>
+</div>
+
+<h3 class="function"><a name="where_is_parent-1">where_is_parent/1</a></h3>
+<div class="spec">
+<p><pre>where_is_parent(ServerName :: <a href="#type-ra_uid">ra_uid()</a> | atom()) -&gt;
+                   pid() | undefined</pre></p>
 </div>
 
 <h3 class="function"><a name="name_of-1">name_of/1</a></h3>

--- a/docs/ra_env.html
+++ b/docs/ra_env.html
@@ -17,6 +17,7 @@
 <table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#data_dir-0">data_dir/0</a></td><td></td></tr>
 <tr><td valign="top"><a href="#server_data_dir-1">server_data_dir/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#wal_data_dir-0">wal_data_dir/0</a></td><td></td></tr>
+<tr><td valign="top"><a href="#configure_logger-1">configure_logger/1</a></td><td></td></tr>
 </table>
 
 <h2><a name="functions">Function Details</a></h2>
@@ -34,6 +35,11 @@
 <h3 class="function"><a name="wal_data_dir-0">wal_data_dir/0</a></h3>
 <div class="spec">
 <p><tt>wal_data_dir() -&gt; any()</tt></p>
+</div>
+
+<h3 class="function"><a name="configure_logger-1">configure_logger/1</a></h3>
+<div class="spec">
+<p><tt>configure_logger(Module) -&gt; any()</tt></p>
 </div>
 <hr>
 

--- a/docs/ra_machine.html
+++ b/docs/ra_machine.html
@@ -63,8 +63,9 @@ Suitable for issuing periodic side effects such as updating metrics systems.</p>
 
 <h3 class="typedecl"><a name="type-command_meta_data">command_meta_data()</a></h3>
 <p><pre>command_meta_data() = 
-    <a href="ra_server.html#type-command_meta">ra_server:command_meta()</a> |
-    #{index := <a href="#type-ra_index">ra_index()</a>, term := <a href="#type-ra_term">ra_term()</a>}</pre></p>
+    #{system_time := integer(),
+      index := <a href="#type-ra_index">ra_index()</a>,
+      term := <a href="#type-ra_term">ra_term()</a>}</pre></p>
 <p>  extensible command meta data map</p>
 
 <h3 class="typedecl"><a name="type-effect">effect()</a></h3>

--- a/docs/ra_server.html
+++ b/docs/ra_server.html
@@ -29,14 +29,14 @@
 
 
 <h3 class="typedecl"><a name="type-command_meta">command_meta()</a></h3>
-<p><pre>command_meta() = #{from := <a href="#type-maybe">maybe</a>(<a href="#type-from">from()</a>), ts := integer()}</pre></p>
+<p><pre>command_meta() = #{from =&gt; <a href="#type-from">from()</a>, ts := integer()}</pre></p>
 
 
 <h3 class="typedecl"><a name="type-command_reply_mode">command_reply_mode()</a></h3>
 <p><pre>command_reply_mode() = 
     after_log_append |
     await_consensus |
-    {notify_on_consensus, <a href="#type-command_correlation">command_correlation()</a>, pid()} |
+    {notify, <a href="#type-command_correlation">command_correlation()</a>, pid()} |
     noreply</pre></p>
 
 

--- a/docs/ra_server.html
+++ b/docs/ra_server.html
@@ -29,7 +29,7 @@
 
 
 <h3 class="typedecl"><a name="type-command_meta">command_meta()</a></h3>
-<p><pre>command_meta() = #{from := <a href="#type-maybe">maybe</a>(<a href="#type-from">from()</a>)}</pre></p>
+<p><pre>command_meta() = #{from := <a href="#type-maybe">maybe</a>(<a href="#type-from">from()</a>), ts := integer()}</pre></p>
 
 
 <h3 class="typedecl"><a name="type-command_reply_mode">command_reply_mode()</a></h3>
@@ -126,6 +126,7 @@
       log_init_args := <a href="ra_log.html#type-ra_log_init_args">ra_log:ra_log_init_args()</a>,
       initial_members := [<a href="#type-ra_server_id">ra_server_id()</a>],
       machine := <a href="#type-machine_conf">machine_conf()</a>,
+      friendly_name =&gt; <a href="unicode.html#type-chardata">unicode:chardata()</a>,
       broadcast_time =&gt; non_neg_integer(),
       tick_timeout =&gt; non_neg_integer(),
       await_condition_timeout =&gt; non_neg_integer()}</pre></p>
@@ -135,6 +136,7 @@
 <p><pre>ra_server_state() = 
     #{id := <a href="#type-ra_server_id">ra_server_id()</a>,
       uid := <a href="#type-ra_uid">ra_uid()</a>,
+      log_id := <a href="unicode.html#type-chardata">unicode:chardata()</a>,
       leader_id =&gt; <a href="#type-maybe">maybe</a>(<a href="#type-ra_server_id">ra_server_id()</a>),
       cluster := <a href="#type-ra_cluster">ra_cluster()</a>,
       cluster_change_permitted := boolean(),

--- a/docs/ra_snapshot.html
+++ b/docs/ra_snapshot.html
@@ -41,13 +41,14 @@
 <tr><td valign="top"><a href="#last_index_for-1">last_index_for/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#begin_snapshot-3">begin_snapshot/3</a></td><td></td></tr>
 <tr><td valign="top"><a href="#complete_snapshot-2">complete_snapshot/2</a></td><td></td></tr>
-<tr><td valign="top"><a href="#begin_accept-4">begin_accept/4</a></td><td></td></tr>
-<tr><td valign="top"><a href="#accept_chunk-3">accept_chunk/3</a></td><td></td></tr>
+<tr><td valign="top"><a href="#begin_accept-2">begin_accept/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#accept_chunk-4">accept_chunk/4</a></td><td></td></tr>
 <tr><td valign="top"><a href="#abort_accept-1">abort_accept/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#handle_down-3">handle_down/3</a></td><td></td></tr>
 <tr><td valign="top"><a href="#delete-2">delete/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#save-4">save/4</a></td><td></td></tr>
-<tr><td valign="top"><a href="#read-2">read/2</a></td><td></td></tr>
+<tr><td valign="top"><a href="#begin_read-1">begin_read/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#read_chunk-3">read_chunk/3</a></td><td></td></tr>
 <tr><td valign="top"><a href="#recover-1">recover/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#read_meta-2">read_meta/2</a></td><td></td></tr>
 </table>
@@ -106,19 +107,16 @@
                      <a href="#type-state">state()</a></pre></p>
 </div>
 
-<h3 class="function"><a name="begin_accept-4">begin_accept/4</a></h3>
+<h3 class="function"><a name="begin_accept-2">begin_accept/2</a></h3>
 <div class="spec">
-<p><pre>begin_accept(Crc :: non_neg_integer(),
-             Meta :: <a href="#type-meta">meta()</a>,
-             NumChunks :: non_neg_integer(),
-             State :: <a href="#type-state">state()</a>) -&gt;
-                {ok, <a href="#type-state">state()</a>}</pre></p>
+<p><pre>begin_accept(Meta :: <a href="#type-meta">meta()</a>, State :: <a href="#type-state">state()</a>) -&gt; {ok, <a href="#type-state">state()</a>}</pre></p>
 </div>
 
-<h3 class="function"><a name="accept_chunk-3">accept_chunk/3</a></h3>
+<h3 class="function"><a name="accept_chunk-4">accept_chunk/4</a></h3>
 <div class="spec">
 <p><pre>accept_chunk(Chunk :: term(),
              Num :: non_neg_integer(),
+             ChunkFlag :: <a href="#type-chunk_flag">chunk_flag()</a>,
              State :: <a href="#type-state">state()</a>) -&gt;
                 {ok, <a href="#type-state">state()</a>}</pre></p>
 </div>
@@ -148,17 +146,21 @@
         ok | {error, <a href="#type-file_err">file_err()</a> | term()}</pre></p>
 </div>
 
-<h3 class="function"><a name="read-2">read/2</a></h3>
+<h3 class="function"><a name="begin_read-1">begin_read/1</a></h3>
 <div class="spec">
-<p><pre>read(ChunkSizeBytes :: non_neg_integer(), State :: <a href="#type-state">state()</a>) -&gt;
-        {ok,
-         Crc :: non_neg_integer(),
-         Meta :: <a href="#type-meta">meta()</a>,
-         ChunkState,
-         [ChunkThunk ::
-              fun((ChunkState) -&gt; {binary(), ChunkState})]} |
-        {error, term()}</pre>
-<ul class="definitions"><li><pre>ChunkState = term()</pre></li></ul></p>
+<p><pre>begin_read(State :: <a href="#type-state">state()</a>) -&gt;
+              {ok, Meta :: <a href="#type-meta">meta()</a>, ReadState} | {error, term()}</pre>
+<ul class="definitions"><li><pre>ReadState = term()</pre></li></ul></p>
+</div>
+
+<h3 class="function"><a name="read_chunk-3">read_chunk/3</a></h3>
+<div class="spec">
+<p><pre>read_chunk(ReadState,
+           ChunkSizeBytes :: non_neg_integer(),
+           State :: <a href="#type-state">state()</a>) -&gt;
+              {ok, Data :: term(), {next, ReadState} | last} |
+              {error, term()}</pre>
+<ul class="definitions"><li><pre>ReadState = term()</pre></li></ul></p>
 </div>
 
 <h3 class="function"><a name="recover-1">recover/1</a></h3>

--- a/src/noop.erl
+++ b/src/noop.erl
@@ -1,3 +1,4 @@
+%% @hidden
 -module(noop).
 
 -behaviour(ra_machine).

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -514,7 +514,7 @@ process_command(ServerId, Command) ->
     ok.
 pipeline_command(ServerId, Command, Correlation, Priority)
   when Correlation /= no_correlation ->
-    Cmd = usr(Command, {notify_on_consensus, Correlation, self()}),
+    Cmd = usr(Command, {notify, Correlation, self()}),
     ra_server_proc:cast_command(ServerId, Priority, Cmd);
 pipeline_command(ServerId, Command, no_correlation, Priority) ->
     Cmd = usr(Command, noreply),

--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -139,7 +139,7 @@
 -type command() :: user_command() | builtin_command().
 
 -type command_meta_data() :: ra_server:command_meta() | #{index := ra_index(),
-                                                         term := ra_term()}.
+                                                          term := ra_term()}.
 %% extensible command meta data map
 
 

--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -138,8 +138,9 @@
 
 -type command() :: user_command() | builtin_command().
 
--type command_meta_data() :: ra_server:command_meta() | #{index := ra_index(),
-                                                          term := ra_term()}.
+-type command_meta_data() :: #{system_time := integer(),
+                               index := ra_index(),
+                               term := ra_term()}.
 %% extensible command meta data map
 
 

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -87,7 +87,7 @@
 
 -type command_reply_mode() :: after_log_append |
                               await_consensus |
-                              {notify_on_consensus,
+                              {notify,
                                command_correlation(), pid()} |
                               noreply.
 
@@ -1714,7 +1714,7 @@ add_next_cluster_change(Effects, State) ->
 
 add_reply(#{from := From}, Reply, await_consensus, Effects, Notifys) ->
     {[{reply, From, {machine_reply, Reply}} | Effects], Notifys};
-add_reply(_, Reply, {notify_on_consensus, Corr, Pid},
+add_reply(_, Reply, {notify, Corr, Pid},
           Effects, Notifys) ->
     % notify are casts and thus have to include their own pid()
     % reply with the supplied correlation so that the sending can do their

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -79,12 +79,6 @@
 
 -type command_correlation() :: integer() | reference().
 
--define(AFTER_LOG_APPEND, ala).
--define(AWAIT_CONSENSUS, ac).
--define(NOTIFY_ON_CONSENSUS, noc).
--define(NOREPLY, nr).
--define(NIL, '').
-
 -type command_reply_mode() :: after_log_append |
                               await_consensus |
                               {notify,

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1636,10 +1636,13 @@ make_notify_effects(Nots, Prior) ->
               end, Prior, Nots).
 
 apply_with(Machine,
-           {Idx, Term, {'$usr', #{from := From} = Meta0, Cmd, ReplyType}},
+           {Idx, Term, {'$usr', #{from := From,
+                                  ts := Ts}, Cmd, ReplyType}},
            {_, State, MacSt, Effects, Notifys0}) ->
     %% augment the meta data structure with index and term
-    Meta = Meta0#{index => Idx, term => Term},
+    Meta = #{index => Idx,
+             term => Term,
+             system_time => Ts},
     case ra_machine:apply(Machine, Meta, Cmd, MacSt) of
         {NextMacSt, Reply, AppEffs} ->
             {ReplyEffs, Notifys} = add_reply(From, Reply, ReplyType,

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -74,10 +74,16 @@
 -type command_type() :: '$usr' | '$ra_query' | '$ra_join' | '$ra_leave' |
                         '$ra_cluster_change' | '$ra_cluster'.
 
--type command_meta() :: #{from := maybe(from()),
+-type command_meta() :: #{from => from(),
                           ts := integer()}.
 
 -type command_correlation() :: integer() | reference().
+
+-define(AFTER_LOG_APPEND, ala).
+-define(AWAIT_CONSENSUS, ac).
+-define(NOTIFY_ON_CONSENSUS, noc).
+-define(NOREPLY, nr).
+-define(NIL, '').
 
 -type command_reply_mode() :: after_log_append |
                               await_consensus |
@@ -404,8 +410,6 @@ handle_leader({command, Cmd}, State00 = #{log_id := LogId}) ->
             % TODO: refactor - can this be made a bit nicer/more explicit?
             Effects = case Cmd of
                           {_, _, _, await_consensus} ->
-                              Effects1;
-                          {_, #{from := undefined}, _, _} ->
                               Effects1;
                           {_, #{from := From}, _, _} ->
                               [{reply, From, {Idx, Term}} | Effects1];
@@ -1323,8 +1327,7 @@ peer_snapshot_process_exited(SnapshotPid, #{cluster := Peers} = State) ->
     {ra_state(), ra_server_state(), ra_effects()}.
 handle_down(leader, machine, Pid, Info, State) ->
     %% commit command to be processed by state machine
-    handle_leader({command,  {'$usr', #{from => undefined,
-                                        ts => os:system_time(millisecond)},
+    handle_leader({command,  {'$usr', #{ts => os:system_time(millisecond)},
                              {down, Pid, Info}, noreply}},
                   State);
 handle_down(leader, snapshot_sender, Pid, Info, #{log_id := LogId} = State) ->
@@ -1636,8 +1639,7 @@ make_notify_effects(Nots, Prior) ->
               end, Prior, Nots).
 
 apply_with(Machine,
-           {Idx, Term, {'$usr', #{from := From,
-                                  ts := Ts}, Cmd, ReplyType}},
+           {Idx, Term, {'$usr', #{ts := Ts} = CmdMeta, Cmd, ReplyType}},
            {_, State, MacSt, Effects, Notifys0}) ->
     %% augment the meta data structure with index and term
     Meta = #{index => Idx,
@@ -1645,27 +1647,29 @@ apply_with(Machine,
              system_time => Ts},
     case ra_machine:apply(Machine, Meta, Cmd, MacSt) of
         {NextMacSt, Reply, AppEffs} ->
-            {ReplyEffs, Notifys} = add_reply(From, Reply, ReplyType,
+            {ReplyEffs, Notifys} = add_reply(CmdMeta, Reply, ReplyType,
                                              Effects, Notifys0),
             {Idx, State, NextMacSt, [AppEffs | ReplyEffs], Notifys};
         {NextMacSt, Reply} ->
-            {ReplyEffs, Notifys} = add_reply(From, Reply, ReplyType,
+            {ReplyEffs, Notifys} = add_reply(CmdMeta, Reply, ReplyType,
                                              Effects, Notifys0),
             {Idx, State, NextMacSt, ReplyEffs, Notifys}
     end;
 apply_with({machine, MacMod, _}, % Machine
-           {Idx, _, {'$ra_query', #{from := From}, QueryFun, _}},
+           {Idx, _, {'$ra_query', CmdMeta, QueryFun, ReplyType}},
            {_, State, MacSt, Effects0, Notifys0}) ->
+    %% TODO: are all queries calls?
     Result = ra_machine:query(MacMod, QueryFun, MacSt),
-    Effects = [{reply, From, {machine_reply, Result}} | Effects0],
-    {Idx, State, MacSt, Effects, Notifys0};
+    {Effects, Notifys} = add_reply(CmdMeta, Result, ReplyType,
+                                   Effects0, Notifys0),
+    {Idx, State, MacSt, Effects, Notifys};
 apply_with(_Machine,
-           {Idx, _, {'$ra_cluster_change', #{from := From}, _New,
+           {Idx, _, {'$ra_cluster_change', CmdMeta, _New,
                      ReplyType}},
            {_, State0, MacSt, Effects0, Notifys0}) ->
     ?DEBUG("~s: applying ra cluster change to ~w~n",
            [log_id(State0), maps:keys(_New)]),
-    {Effects, Notifys} = add_reply(From, ok, ReplyType,
+    {Effects, Notifys} = add_reply(CmdMeta, ok, ReplyType,
                                    Effects0, Notifys0),
     State = State0#{cluster_change_permitted => true},
     % add pending cluster change as next event
@@ -1683,10 +1687,10 @@ apply_with(_, {Idx, _, noop},
     %% don't log these as unhandled
     {Idx, State, MacSt, Effects, Notifys};
 apply_with(Machine,
-           {Idx, _, {'$ra_cluster', #{from := From}, delete, ReplyType}},
+           {Idx, _, {'$ra_cluster', CmdMeta, delete, ReplyType}},
            {_, State0, MacSt, Effects0, Notifys0}) ->
     % cluster deletion
-    {Effects1, Notifys} = add_reply(From, ok, ReplyType, Effects0, Notifys0),
+    {Effects1, Notifys} = add_reply(CmdMeta, ok, ReplyType, Effects0, Notifys0),
     NotEffs = make_notify_effects(Notifys, []),
     %% virtual "eol" state
     EOLEffects = ra_machine:state_enter(Machine, eol, MacSt),
@@ -1708,9 +1712,9 @@ add_next_cluster_change(Effects,
 add_next_cluster_change(Effects, State) ->
     {Effects, State}.
 
-add_reply(From, Reply, await_consensus, Effects, Notifys) ->
+add_reply(#{from := From}, Reply, await_consensus, Effects, Notifys) ->
     {[{reply, From, {machine_reply, Reply}} | Effects], Notifys};
-add_reply(undefined, Reply, {notify_on_consensus, Corr, Pid},
+add_reply(_, Reply, {notify_on_consensus, Corr, Pid},
           Effects, Notifys) ->
     % notify are casts and thus have to include their own pid()
     % reply with the supplied correlation so that the sending can do their

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -418,7 +418,7 @@ candidate({call, From}, {leader_call, Msg},
           #state{pending_commands = Pending} = State) ->
     {keep_state, State#state{pending_commands = [{From, Msg} | Pending]}};
 candidate(cast, {command, _Priority,
-                 {_CmdType, _Data, {notify_on_consensus, Corr, Pid}}},
+                 {_CmdType, _Data, {notify, Corr, Pid}}},
           State) ->
     ok = reject_command(Pid, Corr, State),
     {keep_state, State, []};
@@ -466,7 +466,7 @@ pre_vote({call, From}, {leader_call, Msg},
           State = #state{pending_commands = Pending}) ->
     {keep_state, State#state{pending_commands = [{From, Msg} | Pending]}};
 pre_vote(cast, {command, _Priority,
-                {_CmdType, _Data, {notify_on_consensus, Corr, Pid}}},
+                {_CmdType, _Data, {notify, Corr, Pid}}},
          State) ->
     ok = reject_command(Pid, Corr, State),
     {keep_state, State, []};
@@ -522,7 +522,7 @@ follower(_, {command, Priority, {_CmdType, Data, noreply}},
             {keep_state, State, []}
     end;
 follower(cast, {command, _Priority,
-                {_CmdType, _Data, {notify_on_consensus, Corr, Pid}}},
+                {_CmdType, _Data, {notify, Corr, Pid}}},
          State) ->
     ok = reject_command(Pid, Corr, State),
     {keep_state, State, []};

--- a/src/ra_server_sup.erl
+++ b/src/ra_server_sup.erl
@@ -1,3 +1,4 @@
+%% @hidden
 -module(ra_server_sup).
 
 -behaviour(supervisor).

--- a/test/ra_fifo.erl
+++ b/test/ra_fifo.erl
@@ -1463,7 +1463,8 @@ purge_with_checkout_test() ->
     ok.
 
 meta(Idx) ->
-    #{index => Idx, term => 1}.
+    #{index => Idx, term => 1,
+      system_time => os:system_time(millisecond)}.
 
 enq(Idx, MsgSeq, Msg, State) ->
     apply(meta(Idx), {enqueue, self(), MsgSeq, Msg}, State).

--- a/test/ra_machine_int_SUITE.erl
+++ b/test/ra_machine_int_SUITE.erl
@@ -307,7 +307,7 @@ meta_data(Config) ->
     meck:expect(Mod, init, fun (_) -> the_state end),
     meck:expect(Mod, apply, fun (#{index := Idx,
                                    term := Term,
-                                   ts := Ts}, _, State) ->
+                                   system_time := Ts}, _, State) ->
                                     {State, {metadata, Idx, Term, Ts}}
                             end),
     ClusterName = ?config(cluster_name, Config),

--- a/test/ra_machine_int_SUITE.erl
+++ b/test/ra_machine_int_SUITE.erl
@@ -28,7 +28,8 @@ all_tests() ->
      leader_monitors,
      follower_takes_over_monitor,
      deleted_cluster_emits_eol_effect,
-     machine_state_enter_effects
+     machine_state_enter_effects,
+     meta_data
     ].
 
 groups() ->
@@ -148,6 +149,7 @@ send_msg_with_ra_event_and_cast_options(Config) ->
               exit(receive_msg_timeout)
     end,
     ok.
+
 machine_replies(Config) ->
     Mod = ?config(modname, Config),
     meck:new(Mod, [non_strict]),
@@ -297,6 +299,27 @@ machine_state_enter_effects(Config) ->
     ra:delete_cluster([ServerId]),
     validate_state_enters([recover, recovered, follower,
                            candidate, leader, eol]),
+    ok.
+
+meta_data(Config) ->
+    Mod = ?config(modname, Config),
+    meck:new(Mod, [non_strict]),
+    meck:expect(Mod, init, fun (_) -> the_state end),
+    meck:expect(Mod, apply, fun (#{index := Idx,
+                                   term := Term,
+                                   ts := Ts}, _, State) ->
+                                    {State, {metadata, Idx, Term, Ts}}
+                            end),
+    ClusterName = ?config(cluster_name, Config),
+    ServerId = ?config(server_id, Config),
+    T = os:system_time(millisecond),
+    ok = start_cluster(ClusterName, {module, Mod, #{}}, [ServerId]),
+    {ok, {metadata, Idx, Term, Ts}, ServerId} =
+        ra:process_command(ServerId, any_command),
+
+    ?assert(Ts > T),
+    ?assert(Idx > 0),
+    ?assert(Term > 0),
     ok.
 
 %% Utility

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1596,7 +1596,8 @@ usr(Data) ->
     {'$usr', meta(), Data, after_log_append}.
 
 meta() ->
-    #{from => {self(), make_ref()}}.
+    #{from => {self(), make_ref()},
+      ts => os:system_time(millisecond)}.
 
 dump(T) ->
     ct:pal("DUMP: ~p~n", [T]),


### PR DESCRIPTION
So that state machines can perform time based logic without always
including their own timestamps in all commands.
