### PR TITLE
Add log and timer effects

### DIFF
--- a/docs/internals/INTERNALS.md
+++ b/docs/internals/INTERNALS.md
@@ -141,6 +141,29 @@ It is recommended that expensive operations are done in another process.
 The `mod_call` effect is useful for e.g. updating an ETS table of committed entries
 or similar.
 
+### Setting a timer
+
+The `{timer, Time :: non_neg_integer() | infinity}}` effects asks the Ra leader
+to maintain a timer on behalf of the state machine and commit a `timeout` command
+when the timer triggers.
+
+The timer is relative and setting another timer before the current timer runs
+out results in the current timer being reset. 
+
+### Reading a log
+
+Use `{log, Index :: ra_index(), fun((term()) -> effect() | undefined}` to read a
+command from the log at the specified index and optionally return an effect.
+
+Effectively this effect transforms a log entry to an effect.
+
+Potential use cases could be when a command contains large binary data and you
+don't want to keep this in memory but load it on demand when needed for a side-effect.
+
+This is an advanced feature and will only work as long as the command is still
+in the log. If a release_cursor has been emitted with an index higher than this
+the command may not longer be in the log and the function will not be called.
+
 ### Updating the Release Cursor (Snapshotting)
 
 The `{release_cursor, RaftIndex, MachineState}`

--- a/docs/internals/INTERNALS.md
+++ b/docs/internals/INTERNALS.md
@@ -132,6 +132,10 @@ it will commit a `{nodeup | nodedown, node()}` command to the log.
 Use `{demonitor, process | node, pid() | node()}` to stop monitoring a process
 or a node.
 
+All monitors are invalidated when the leader changes. State machines should
+re-issue monitor effects when becoming leader using the `state_enter/2`
+callback.
+
 ### Calling a function
 
 The `{mod_call, module(), function(), Args :: [term()]}` to call an arbitrary
@@ -149,6 +153,10 @@ when the timer triggers.
 
 The timer is relative and setting another timer before the current timer runs
 out results in the current timer being reset. 
+
+All timers are invalidated when the leader changes. State machines should
+re-issue timer effects when becoming leader using the `state_enter/2`
+callback.
 
 ### Reading a log
 

--- a/docs/ra_machine.html
+++ b/docs/ra_machine.html
@@ -35,11 +35,12 @@
   -callback state_enter(ra_server:ra_state() | eol, state()) -&gt; effects().
   </code></p>
  
-  <p>Optional. Called when the ra server enters a new state. Called for all states
-  in the ra_server_proc gen_statem implementation not just for the standard
-  Raft states (follower, candidate, leader). If implemented it is sensible
-  to include a catch all clause as new states may be implemented in the future.
- <br>
+  <p>Optional. Called when the ra server enters a new state. Called for all states  
+in the ra_server_proc gen_statem implementation not just for the standard  
+Raft states (follower, candidate, leader). If implemented it is sensible  
+to include a catch all clause as new states may be implemented in the future.</p>
+ 
+ <p><br>
   <code>-callback tick(TimeMs :: milliseconds(), state()) -&gt; effects().</code></p>
  
   <p>Optional. Called periodically.  
@@ -53,7 +54,7 @@ Suitable for issuing periodic side effects such as updating metrics systems.</p>
 
 <h3 class="typedecl"><a name="type-builtin_command">builtin_command()</a></h3>
 <p><pre>builtin_command() = 
-    {down, pid(), term()} | {nodeup | nodedown, node()}</pre></p>
+    {down, pid(), term()} | {nodeup | nodedown, node()} | timeout</pre></p>
 <p>  These commands may be passed to the <a href="#apply-2"><code>apply/2</code></a> function in reaction
   to monitor effects</p>
 
@@ -80,6 +81,8 @@ Suitable for issuing periodic side effects such as updating metrics systems.</p>
     {monitor, node, node()} |
     {demonitor, process, pid()} |
     {demonitor, node, node()} |
+    {timer, non_neg_integer() | infinity} |
+    {log, <a href="#type-ra_index">ra_index()</a>, fun((term()) -&gt; <a href="#type-maybe">maybe</a>(<a href="#type-effect">effect()</a>))} |
     {release_cursor, <a href="#type-ra_index">ra_index()</a>, <a href="#type-state">state()</a>} |
     {aux, term()} |
     garbage_collection</pre></p>

--- a/docs/ra_server.html
+++ b/docs/ra_server.html
@@ -208,6 +208,7 @@
 <tr><td valign="top"><a href="#handle_down-5">handle_down/5</a></td><td></td></tr>
 <tr><td valign="top"><a href="#terminate-2">terminate/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#log_fold-3">log_fold/3</a></td><td></td></tr>
+<tr><td valign="top"><a href="#read_at-2">read_at/2</a></td><td></td></tr>
 </table>
 
 <h2><a name="functions">Function Details</a></h2>
@@ -384,6 +385,13 @@
          State) -&gt;
             {ok, State, <a href="#type-ra_server_state">ra_server_state()</a>} |
             {error, term(), <a href="#type-ra_server_state">ra_server_state()</a>}</pre></p>
+</div>
+
+<h3 class="function"><a name="read_at-2">read_at/2</a></h3>
+<div class="spec">
+<p><pre>read_at(Idx :: <a href="#type-ra_index">ra_index()</a>, RaState :: <a href="#type-ra_server_state">ra_server_state()</a>) -&gt;
+           {ok, term(), <a href="#type-ra_server_state">ra_server_state()</a>} |
+           {error, <a href="#type-ra_server_state">ra_server_state()</a>}</pre></p>
 </div>
 <hr>
 

--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -24,8 +24,10 @@
 %% in the ra_server_proc gen_statem implementation not just for the standard
 %% Raft states (follower, candidate, leader). If implemented it is sensible
 %% to include a catch all clause as new states may be implemented in the future.
+%%
 %%<br></br>
 %% <code>-callback tick(TimeMs :: milliseconds(), state()) -> effects().</code>
+%%
 %%
 %% Optional. Called periodically.
 %% Suitable for issuing periodic side effects such as updating metrics systems.

--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -70,7 +70,8 @@
 -type milliseconds() :: non_neg_integer().
 
 -type builtin_command() :: {down, pid(), term()} |
-                           {nodeup | nodedown, node()}.
+                           {nodeup | nodedown, node()} |
+                           timeout.
 %% These commands may be passed to the {@link apply/2} function in reaction
 %% to monitor effects
 
@@ -91,6 +92,8 @@
     {monitor, node, node()} |
     {demonitor, process, pid()} |
     {demonitor, node, node()} |
+    {timer, non_neg_integer() | infinity} |
+    {log, ra_index(), fun((term()) -> maybe(effect()))} |
     {release_cursor, ra_index(), state()} |
     {aux, term()} |
     garbage_collection.

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -34,6 +34,7 @@
          handle_down/5,
          terminate/2,
          log_fold/3,
+         read_at/2,
          recover/1
         ]).
 
@@ -1372,6 +1373,16 @@ log_fold(#{log := Log} = RaState, Fun, State) ->
             {error, Reason, RaState#{log => Log1}}
     end.
 
+-spec read_at(ra_index(), ra_server_state()) ->
+    {ok, term(), ra_server_state()} |
+    {error, ra_server_state()}.
+read_at(Idx, #{log := Log0} = RaState) ->
+    case ra_log:fetch(Idx, Log0) of
+        {{Idx, _, {'$usr', _, Data, _}}, Log} ->
+            {ok, Data, RaState#{log => Log}};
+        {undefined, Log} ->
+            {error, RaState#{log => Log}}
+    end.
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1041,7 +1041,7 @@ handle_effect(_, {incr_metrics, Table, Ops}, _,
     {State, Actions};
 handle_effect(_, {timer, T}, _, State, Actions) ->
     {State, [{state_timeout, T, machine_timeout} | Actions]};
-handle_effect(X, {log, Idx, Fun}, Y,
+handle_effect(RaftState, {log, Idx, Fun}, EvtType,
               State = #state{server_state = SS0}, Actions) ->
     case ra_server:read_at(Idx, SS0) of
         {ok, Data, SS} ->
@@ -1050,7 +1050,7 @@ handle_effect(X, {log, Idx, Fun}, Y,
                     {State#state{server_state = SS}, Actions};
                 Effect ->
                     %% recurse with the new effect
-                    handle_effect(X, Effect, Y,
+                    handle_effect(RaftState, Effect, EvtType,
                                   State#state{server_state = SS}, Actions)
             end;
         {error, SS} ->


### PR DESCRIPTION
The timer effect asks the Ra leader to maintain a single relative timer
and commit a `timeout` command when it triggers.

The log effect allows the effect system to read and entry from the log
and turn it into an effect. Useful for when the machine doesn't want to
keep large data in memory but instead prefers to read it from the log
when needed for a side effect.
