### PR TITLE
Fix bug where cluster changes were not recovered

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -415,7 +415,7 @@ leave_and_delete_server(ServerRef, ServerId, Timeout) ->
         {error, no_proc} = Err ->
             Err;
         {ok, _, _} ->
-            ?INFO("We (Ra node ~p) have succesfully left the cluster. Terminating.", [ServerId]),
+            ?INFO("We (Ra node ~w) have succesfully left the cluster. Terminating.", [ServerId]),
             force_delete_server(ServerId)
     end.
 

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -245,7 +245,7 @@ write([{Idx, _, _} | _], #?MODULE{uid = UId, last_index = LastIdx}) ->
 -spec take(ra_index(), non_neg_integer(), ra_log()) ->
     {[log_entry()], ra_log()}.
 take(Start, Num, #?MODULE{uid = UId, first_index = FirstIdx,
-                        last_index = LastIdx} = State)
+                          last_index = LastIdx} = State)
   when Start >= FirstIdx andalso Start =< LastIdx ->
     % 0. Check that the request isn't outside of first_index and last_index
     % 1. Check the local cache for any unflushed entries, carry reminders


### PR DESCRIPTION
After a cluster restart.

This change also optimises the recovery phase by only scanning the log
once.

[#162782789]
