### PR TITLE
Named timer effects

### DIFF
--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -117,8 +117,8 @@
     {monitor, node, node()} |
     {demonitor, process, pid()} |
     {demonitor, node, node()} |
-    {timer, non_neg_integer() | infinity} |
-    {log, ra_index(), fun((term()) -> maybe(effect()))} |
+    {timer, term(), non_neg_integer() | infinity} |
+    {log, ra_index(), fun((user_command()) -> maybe(effect()))} |
     {release_cursor, ra_index(), state()} |
     {aux, term()} |
     garbage_collection.

--- a/test/ra_machine_version_SUITE.erl
+++ b/test/ra_machine_version_SUITE.erl
@@ -233,11 +233,7 @@ server_applies_with_new_module(Config) ->
     % applied. The wal fsync could take a few ms causing the race
     {ok, ok, _} = ra:process_command(ServerId, dummy),
     %% assert state_v1
-    {ok, {_, init_state}, _} = ra:leader_query(ServerId,
-                                             fun (S) ->
-                                                    ct:pal("leader_query ~w", [S]),
-                                                   S
-                                             end),
+    {ok, {_, init_state}, _} = ra:leader_query(ServerId, fun (S) -> S end),
 
     ok = ra:stop_server(ServerId),
     %% simulate module upgrade
@@ -262,11 +258,11 @@ server_applies_with_new_module(Config) ->
     ok = ra:restart_server(ServerId),
     %% increment version
     {ok, ok, _} = ra:process_command(ServerId, dummy2),
-    {ok, {_, state_v1}, _} = ra:leader_query(ServerId, fun ra_lib:id/1),
+    {ok, state_v1, _} = ra:consistent_query(ServerId, fun ra_lib:id/1),
     ok = ra:stop_server(ServerId),
     ok = ra:restart_server(ServerId),
     _ = ra:members(ServerId),
-    {ok, {_, state_v1}, _} = ra:leader_query(ServerId, fun ra_lib:id/1),
+    {ok, state_v1, _} = ra:consistent_query(ServerId, fun ra_lib:id/1),
     ok.
 
 lower_version_does_not_apply_until_upgraded(Config) ->


### PR DESCRIPTION
so that machines can use multiple timers rather than just a single one

also fixes issue where the timer effect used `state_timeout` instead of just `timeout` (!)