### PR TITLE
Segment writer simplification

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -819,8 +819,9 @@ handle_follower(#append_entries_rpc{term = _Term, leader_id = LeaderId},
                   current_term := CurTerm} = State) ->
     % the term is lower than current term
     Reply = append_entries_reply(CurTerm, false, State),
-    ?DEBUG("~s: follower request_vote_rpc in ~b but current term ~b~n",
-          [LogId, _Term, CurTerm]),
+    ?DEBUG("~s: follower got append_entries_rpc from ~w in"
+           " ~b but current term is: ~b~n",
+          [LogId, LeaderId, _Term, CurTerm]),
     {follower, State, [cast_reply(Id, LeaderId, Reply)]};
 handle_follower({ra_log_event, {written, _} = Evt},
                 State0 = #{log := Log0}) ->

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -728,8 +728,6 @@ terminate(Reason, StateName,
     Parent = ra_directory:where_is_parent(UId),
     case Reason of
         {shutdown, delete} ->
-            catch ra_log_segment_writer:release_segments(
-                    ra_log_segment_writer, UId),
             catch ra_directory:unregister_name(UId),
             catch ra_log_meta:delete_sync(UId),
             catch ets:delete(ra_state, UId),

--- a/src/ra_server_sup_sup.erl
+++ b/src/ra_server_sup_sup.erl
@@ -111,8 +111,6 @@ delete_server_rpc(RaName) ->
     Pid = ra_directory:where_is(RaName),
     ra_log_meta:delete(UId),
     Dir = ra_env:server_data_dir(UId),
-    ok = ra_log_segment_writer:release_segments(
-           ra_log_segment_writer, UId),
     _ = supervisor:terminate_child(?MODULE, UId),
     % TODO: move into separate retrying process
     try ra_lib:recursive_delete(Dir) of

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -591,8 +591,9 @@ update_release_cursor(Config) ->
 
     [{UId, 149}] = ets:lookup(ra_log_snapshot_state, UId),
 
-    % no segments should remain
-    [] =  find_segments(Config),
+    % only one segment should remain as the segment writer always keeps
+    % at least one segment for each
+    [_] =  find_segments(Config),
 
     % append a few more items
     Log6 = append_and_roll(150, 155, 2, Log5),
@@ -663,7 +664,7 @@ missed_closed_tables_are_deleted_at_next_opportunity(Config) ->
                                              1, initial_state, Log5),
     _Log = deliver_all_log_events(Log6, 500),
 
-    [] = find_segments(Config),
+    [_] = find_segments(Config),
     ok.
 
 transient_writer_is_handled(Config) ->


### PR DESCRIPTION
Refactor segment writer
So that it no longer keeps files open as this is a likely pre-mature
optimisation that only increases complexity. The segment writer will now
also always keep at least one segment to ensure segment names are never
re-used.