### PR TITLE
Liveness

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1109,10 +1109,10 @@ follower_catchup_cond(OriginalReason,
         {entry_ok, Log} ->
             {true, State0#{log => Log}};
         {term_mismatch, _, Log} ->
-            %% if the original reason to enter catchup was a missing entry
+            %% if the original reason to enter catch-up was a missing entry
             %% the next entry _could_ result in a term_mismatch if so we
-            %% exit await_condition temporarily to process the AER that resulted
-            %% in the term_mismatch
+            %% exit await_condition temporarily to process the AppendEntriesRpc
+            %% that resulted in the term_mismatch
             {OriginalReason == missing, State0#{log => Log}};
         {missing, Log} ->
             {false, State0#{log => Log}}

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -44,8 +44,8 @@
 -export([send_rpc/2]).
 
 -define(SERVER, ?MODULE).
--define(DEFAULT_BROADCAST_TIME, 50).
--define(DEFAULT_ELECTION_MULT, 3).
+-define(DEFAULT_BROADCAST_TIME, 100).
+-define(DEFAULT_ELECTION_MULT, 5).
 -define(TICK_INTERVAL_MS, 1000).
 -define(DEFAULT_STOP_FOLLOWER_ELECTION, false).
 -define(DEFAULT_AWAIT_CONDITION_TIMEOUT, 30000).
@@ -449,11 +449,10 @@ candidate(EventType, Msg, #state{pending_commands = Pending} = State0) ->
         {follower, State1, Effects} ->
             {State, Actions} = ?HANDLE_EFFECTS(Effects, EventType, State1),
             {next_state, follower, State,
-             % always set an election timeout here to ensure an unelectable
+             % set an election timeout here to ensure an unelectable
              % node doesn't cause an electable one not to trigger
              % another election when not using follower timeouts
-             % TODO: only set this is leader was not detected
-             [election_timeout_action(long, State) | Actions]};
+             [maybe_set_election_timeout(long, State) | Actions]};
         {leader, State1, Effects} ->
             {State2, Actions0} = ?HANDLE_EFFECTS(Effects, EventType, State1),
             State = State2#state{pending_commands = []},
@@ -585,8 +584,15 @@ follower(info, {node_event, Node, down}, State) ->
             {keep_state, State}
     end;
 follower(info, {node_event, _Node, up}, State) ->
-    %% we never use this but don't want it to be logged
-    {keep_state, State};
+    case leader_id(State) of
+        {_, Node} ->
+            ?WARN("~s: Leader node ~w is back up, cancelling pre-vote timeout",
+                  [log_id(State), Node]),
+            {keep_state, State,
+             [{state_timeout, infinity, election_timeout}]};
+        _ ->
+            {keep_state, State}
+    end;
 follower(_, tick_timeout, State) ->
     true = erlang:garbage_collect(),
     {keep_state, State, set_tick_timer(State, [])};
@@ -1127,13 +1133,14 @@ maybe_set_election_timeout(State, Actions) ->
     [election_timeout_action(short, State) | Actions].
 
 election_timeout_action(really_short, #state{broadcast_time = Timeout}) ->
-    T = rand:uniform(Timeout * ?DEFAULT_ELECTION_MULT),
+    T = rand:uniform(Timeout),
     {state_timeout, T, election_timeout};
 election_timeout_action(short, #state{broadcast_time = Timeout}) ->
-    T = rand:uniform(Timeout * ?DEFAULT_ELECTION_MULT) + (Timeout * 2),
+    T = rand:uniform(Timeout * ?DEFAULT_ELECTION_MULT) + Timeout,
     {state_timeout, T, election_timeout};
 election_timeout_action(long, #state{broadcast_time = Timeout}) ->
-    T = rand:uniform(Timeout * ?DEFAULT_ELECTION_MULT) + (Timeout * 4),
+    %% this should be longer than aten detection poll interval
+    T = rand:uniform(Timeout * ?DEFAULT_ELECTION_MULT * 2) + 1000,
     {state_timeout, T, election_timeout}.
 
 % sets the tick timer for periodic actions such as sending rpcs to servers

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -452,7 +452,7 @@ candidate(EventType, Msg, #state{pending_commands = Pending} = State0) ->
              % set an election timeout here to ensure an unelectable
              % node doesn't cause an electable one not to trigger
              % another election when not using follower timeouts
-             [maybe_set_election_timeout(long, State) | Actions]};
+             maybe_set_election_timeout(State, Actions)};
         {leader, State1, Effects} ->
             {State2, Actions0} = ?HANDLE_EFFECTS(Effects, EventType, State1),
             State = State2#state{pending_commands = []},


### PR DESCRIPTION
Various fixes to better handle busy election scenarios and ensure progress can be made.

Tweak timeouts so that the longest timeout is longer than the aten poll interval and thus allows a false positive to be cancelled out.

Better handle scenarios where a follower asks the leader to resend from a prior index and that prior index has the wrong term.