### PR TITLE
Store "Cluster Name" information

### DIFF
--- a/src/ra_directory.erl
+++ b/src/ra_directory.erl
@@ -108,7 +108,7 @@ name_of(UId) ->
         [] -> undefined
     end.
 
--spec cluster_name_of(ra_uid()) -> ra_cluster_name().
+-spec cluster_name_of(ra_uid()) -> maybe(ra_cluster_name()).
 cluster_name_of(UId) ->
     case ets:lookup(?MODULE, UId) of
 	[{_, _, _, _, ClusterName}] -> ClusterName;

--- a/src/ra_directory.erl
+++ b/src/ra_directory.erl
@@ -3,12 +3,14 @@
 -export([
          init/1,
          deinit/0,
-         register_name/4,
          register_name/3,
+         register_name/4,
+         register_name/5,
          unregister_name/1,
          where_is/1,
          where_is_parent/1,
          name_of/1,
+         cluster_name_of/1,
          pid_of/1,
          uid_of/1,
          send/2,
@@ -46,12 +48,17 @@ deinit() ->
     _ = dets:close(?REVERSE_TBL),
     ok.
 
--spec register_name(ra_uid(), pid(), maybe(pid()), atom()) ->
-    yes | no.
-register_name(UId, Pid, ParentPid, RaServerName) ->
-    true = ets:insert(?MODULE, {UId, Pid, ParentPid, RaServerName}),
+-spec register_name(ra_uid(), pid(), maybe(pid()), atom(),
+		    ra_cluster_name()) -> yes | no.
+register_name(UId, Pid, ParentPid, RaServerName, ClusterName) ->
+    true = ets:insert(?MODULE, {UId, Pid, ParentPid, RaServerName,
+				ClusterName}),
     ok = dets:insert(?REVERSE_TBL, {RaServerName, UId}),
     yes.
+
+-spec register_name(ra_uid(), pid(), maybe(pid()), atom()) -> yes | no.
+register_name(UId, Pid, ParentPid, RaServerName) ->
+    register_name(UId, Pid, ParentPid, RaServerName, undefined).
 
 -spec register_name(ra_uid(), pid(), atom()) -> yes | no.
 register_name(UId, Pid, RaServerName) ->
@@ -60,7 +67,7 @@ register_name(UId, Pid, RaServerName) ->
 -spec unregister_name(ra_uid()) -> ra_uid().
 unregister_name(UId) ->
     case ets:take(?MODULE, UId) of
-        [{_, _, _, ServerName}] ->
+        [{_, _, _, ServerName, _}] ->
             _ = ets:take(?MODULE, UId),
             ok = dets:delete(?REVERSE_TBL, ServerName),
             UId;
@@ -77,7 +84,7 @@ where_is(ServerName) when is_atom(ServerName) ->
     end;
 where_is(UId) when is_binary(UId) ->
     case ets:lookup(?MODULE, UId) of
-        [{_, Pid, _, _}] -> Pid;
+        [{_, Pid, _, _, _}] -> Pid;
         [] -> undefined
     end.
 
@@ -90,21 +97,29 @@ where_is_parent(ServerName) when is_atom(ServerName) ->
     end;
 where_is_parent(UId) when is_binary(UId) ->
     case ets:lookup(?MODULE, UId) of
-        [{_, _, Pid, _}] -> Pid;
+        [{_, _, Pid, _, _}] -> Pid;
         [] -> undefined
     end.
 
 -spec name_of(ra_uid()) -> maybe(atom()).
 name_of(UId) ->
     case ets:lookup(?MODULE, UId) of
-        [{_, _, _, Node}] -> Node;
+        [{_, _, _, Node, _}] -> Node;
         [] -> undefined
     end.
+
+-spec cluster_name_of(ra_uid()) -> ra_cluster_name().
+cluster_name_of(UId) ->
+    case ets:lookup(?MODULE, UId) of
+	[{_, _, _, _, ClusterName}] -> ClusterName;
+	[] -> undefined
+    end.
+
 
 -spec pid_of(ra_uid()) -> maybe(pid()).
 pid_of(UId) ->
     case ets:lookup(?MODULE, UId) of
-        [{_, Pid, _, _}] -> Pid;
+        [{_, Pid, _, _, _}] -> Pid;
         [] -> undefined
     end.
 
@@ -126,17 +141,18 @@ send(UIdOrName, Msg) ->
     end.
 
 overview() ->
-    Dir = ets:tab2list(ra_directory),
+    Dir = ets:tab2list(?MODULE),
     States = maps:from_list(ets:tab2list(ra_state)),
     Snaps = maps:from_list(ets:tab2list(ra_log_snapshot_state)),
-    lists:foldl(fun ({UId, Pid, Parent, Node}, Acc) ->
+    lists:foldl(fun ({UId, Pid, Parent, Node, ClusterName}, Acc) ->
                         Acc#{Node =>
-                             #{uid => UId,
-                               pid => Pid,
-                               parent => Parent,
-                               state => maps:get(Node, States, undefined),
-                               snapshot_state => maps:get(UId, Snaps,
-                                                          undefined)}}
+				 #{uid => UId,
+				   pid => Pid,
+				   parent => Parent,
+				   state => maps:get(Node, States, undefined),
+				   cluster_name => ClusterName,
+				   snapshot_state => maps:get(UId, Snaps,
+							      undefined)}}
                 end, #{}, Dir).
 
 -spec list_registered() -> [{atom(), ra_uid()}].

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -192,16 +192,17 @@ statem_call(ServerRef, Msg, Timeout) ->
 %%% gen_statem callbacks
 %%%===================================================================
 
-init(Config0 = #{id := Id}) ->
+init(Config0 = #{id := Id, cluster_name := ClusterName}) ->
     process_flag(trap_exit, true),
     Config = maps:merge(config_defaults(), Config0),
     #{uid := UId,
       log_id := LogId,
       cluster := Cluster} = ServerState = ra_server:init(Config),
     Key = ra_lib:ra_server_id_to_local_name(Id),
-    % ensure ra_directory has the new pid
+						% ensure ra_directory has the new pid
     yes = ra_directory:register_name(UId, self(),
-                                     maps:get(parent, Config, undefined), Key),
+                                     maps:get(parent, Config, undefined), Key,
+				     ClusterName),
 
     % ensure each relevant erlang node is connected
     Peers = maps:keys(maps:remove(Id, Cluster)),

--- a/test/ra_directory_SUITE.erl
+++ b/test/ra_directory_SUITE.erl
@@ -56,7 +56,8 @@ basics(Config) ->
     ok = ra_directory:init(Dir),
     UId = <<"test1">>,
     Self = self(),
-    yes = ra_directory:register_name(UId, Self, test1),
+    yes = ra_directory:register_name(UId, Self, undefined,
+				     test1, <<"test_cluster_name">>),
     % registrations should always succeed - no negative test
     % no = register_name(Name, spawn(fun() -> ok end), test1),
     Self = ra_directory:where_is(UId),
@@ -69,6 +70,7 @@ basics(Config) ->
           end),
     receive done -> ok after 500 -> exit(timeout) end,
     test1 = ra_directory:name_of(UId),
+    <<"test_cluster_name">> = ra_directory:cluster_name_of(UId),
     _ = ra_directory:send(UId, hi_Name),
     receive
         hi_Name -> ok
@@ -78,6 +80,7 @@ basics(Config) ->
     UId = ra_directory:unregister_name(UId),
     undefined = ra_directory:where_is(UId),
     undefined = ra_directory:name_of(UId),
+    undefined = ra_directory:cluster_name_of(UId),
     undefined = ra_directory:uid_of(test1),
     ok.
 


### PR DESCRIPTION
## Proposed Changes

With this feature is it possible to store and retrieve the cluster name.
Add also the information on the `overview()` function.

Currently, it is not possible to query the cluster name

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
output:
```
(node3@GaS)2> ra:start_server(atom_cluster_name, {kv1, node()}, {module, raft_kv_sm, #{}}, []).
ok
(node3@GaS)3> ra:start_server("string_cluster_name", {kv2, node()}, {module, raft_kv_sm, #{}}, []).
ok
(node3@GaS)4> ra:start_server(<<"binary_cluster_name">>, {kv3, node()}, {module, raft_kv_sm, #{}}, []).
ok
(search)`over': ra:overview().
#{node => node3@GaS,
  segment_writer =>
      #{data_dir => "/home/gabriele/git/Personal/ra_name/node3@GaS",
        segment_conf => #{max_count => 4096}},
  servers =>
      #{kv1 =>
            #{cluster_name => atom_cluster_name,parent => <0.475.0>,
              pid => <0.476.0>,snapshot_state => undefined,
              state => follower,uid => <<"ATOM_CPI72VD1Q3DFW">>},
        kv2 =>
            #{cluster_name => "string_cluster_name",parent => <0.498.0>,
              pid => <0.499.0>,snapshot_state => undefined,
              state => follower,uid => <<"STRINGGHGAS0AL3CBU">>},
        kv3 =>
            #{cluster_name => <<"binary_cluster_name">>,
              parent => <0.523.0>,pid => <0.524.0>,
              snapshot_state => undefined,state => follower,
              uid => <<"BINARYXJ97XC3L9MTZ">>}},
  wal =>
      #{closed_mem_tables => 0,max_batch_size => 99,
        open_mem_tables => 3,
        status =>
            [{header,"Status for batching server ra_log_wal"},
             {data,[{"Status",running},
                    {"Parent",<0.452.0>},
                    {"Logged Events",[]}]},
             #{compute_checksums => true,current_size => 177,
               filename => "00000003.wal",max_size_bytes => 536870912,
               write_strategy => default,writers => 3}]}}
```
