### PR TITLE
Metrics tweaks and meta data optimisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ The module must implement a function of the same signature
 as [logger:log/4](http://erlang.org/doc/man/logger.html#log-4) (the variant
 that takes a format not the variant that takes a fun).
 
+* `metrics_key`:
+
+Metrics key. The key used to write metrics into the `ra_metrics` table.
+
+
 ```
 [{data_dir, "/tmp/ra-data"},
  {wal_max_size_bytes, 134217728},

--- a/src/noop.erl
+++ b/src/noop.erl
@@ -41,12 +41,20 @@ apply(#{index := I}, {noop, _}, State) ->
 
 
 start(Nodes) ->
-    Servers = [begin
+    ServerIds = [{noop, N} || N <- Nodes],
+    Configs = [begin
                    rpc:call(N, ?MODULE, prepare, []),
-                   {noop, N}
+                   Id = {noop, N},
+                   UId = ra:new_uid(ra_lib:to_binary(noop)),
+                   #{id => Id,
+                     uid => UId,
+                     cluster_name => noop,
+                     metrics_key => "the noop",
+                     log_init_args => #{uid => UId},
+                     initial_members => ServerIds,
+                     machine => {module, ?MODULE, #{}}}
                end || N <- Nodes],
-    {ra:start_cluster(noop, {module, ?MODULE, #{}}, Servers),
-     Servers}.
+    {ra:start_cluster(Configs), ServerIds}.
 
 prepare() ->
     _ = application:ensure_all_started(ra),

--- a/src/ra_directory.erl
+++ b/src/ra_directory.erl
@@ -52,7 +52,7 @@ deinit() ->
 		    ra_cluster_name()) -> yes | no.
 register_name(UId, Pid, ParentPid, RaServerName, ClusterName) ->
     true = ets:insert(?MODULE, {UId, Pid, ParentPid, RaServerName,
-				ClusterName}),
+                                ClusterName}),
     ok = dets:insert(?REVERSE_TBL, {RaServerName, UId}),
     yes.
 
@@ -146,13 +146,13 @@ overview() ->
     Snaps = maps:from_list(ets:tab2list(ra_log_snapshot_state)),
     lists:foldl(fun ({UId, Pid, Parent, Node, ClusterName}, Acc) ->
                         Acc#{Node =>
-				 #{uid => UId,
-				   pid => Pid,
-				   parent => Parent,
-				   state => maps:get(Node, States, undefined),
-				   cluster_name => ClusterName,
-				   snapshot_state => maps:get(UId, Snaps,
-							      undefined)}}
+                             #{uid => UId,
+                               pid => Pid,
+                               parent => Parent,
+                               state => maps:get(Node, States, undefined),
+                               cluster_name => ClusterName,
+                               snapshot_state => maps:get(UId, Snaps,
+                                                          undefined)}}
                 end, #{}, Dir).
 
 -spec list_registered() -> [{atom(), ra_uid()}].

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -180,7 +180,7 @@ init(#{uid := UId} = Conf) ->
                            end,
     LastTerm = ra_lib:default(LastTerm0, -1),
     State0 = State00#?MODULE{last_term = LastTerm,
-                           last_written_index_term = {LastIdx, LastTerm}},
+                             last_written_index_term = {LastIdx, LastTerm}},
 
     % initialized with a default 0 index 0 term dummy value
     % and an empty meta data map

--- a/src/ra_log_meta.erl
+++ b/src/ra_log_meta.erl
@@ -24,7 +24,7 @@
 
 -define(TBL_NAME, ?MODULE).
 -define(TIMEOUT, 30000).
--define(SYNC_INTERVAL, 500).
+-define(SYNC_INTERVAL, 5).
 
 -record(?MODULE, {ref :: reference()}).
 

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -45,7 +45,6 @@
 -type ra_server_state() ::
     #{id := {ra_server_id(), ra_uid(), unicode:chardata()},
       leader_id => maybe(ra_server_id()),
-      config => ra_server_config(),
       cluster := ra_cluster(),
       cluster_change_permitted := boolean(),
       cluster_index_term := ra_idxterm(),

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -140,7 +140,7 @@ cast_command(ServerRef, Priority, Cmd) ->
     gen_statem:cast(ServerRef, {command, Priority, Cmd}).
 
 -spec query(ra_server_id(), query_fun(),
-            local | consistent | leader | command, timeout()) ->
+            local | consistent | leader, timeout()) ->
     ra_server_proc:ra_leader_call_ret(term())
     | {ok, Reply :: term(), ra_server_id() | not_known}.
 query(ServerRef, QueryFun, local, Timeout) ->
@@ -148,10 +148,7 @@ query(ServerRef, QueryFun, local, Timeout) ->
 query(ServerRef, QueryFun, leader, Timeout) ->
     leader_call(ServerRef, {local_query, QueryFun}, Timeout);
 query(ServerRef, QueryFun, consistent, Timeout) ->
-    leader_call(ServerRef, {consistent_query, QueryFun}, Timeout);
-query(ServerRef, QueryFun, command, Timeout) ->
-    % TODO: timeout
-    command(ServerRef, {'$ra_query', QueryFun, await_consensus}, Timeout).
+    leader_call(ServerRef, {consistent_query, QueryFun}, Timeout).
 
 -spec log_fold(ra_server_id(), fun(), term(), integer()) -> term().
 log_fold(ServerRef, Fun, InitialState, Timeout) ->

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -192,8 +192,7 @@ statem_call(ServerRef, Msg, Timeout) ->
 init(Config0 = #{id := Id, cluster_name := ClusterName}) ->
     process_flag(trap_exit, true),
     Config = maps:merge(config_defaults(), Config0),
-    #{uid := UId,
-      log_id := LogId,
+    #{id := {_, UId, LogId},
       cluster := Cluster} = ServerState = ra_server:init(Config),
     Key = ra_lib:ra_server_id_to_local_name(Id),
 						% ensure ra_directory has the new pid

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -454,6 +454,7 @@ candidate(info, {node_event, _Node, _Evt}, State) ->
     {keep_state, State};
 candidate(_, tick_timeout, State0) ->
     State = maybe_persist_last_applied(State0),
+    _ = ets:insert(ra_metrics, ra_server:metrics(State#state.server_state)),
     {keep_state, State, set_tick_timer(State, [])};
 candidate({call, From}, trigger_election, State) ->
     {keep_state, State, [{reply, From, ok}]};
@@ -504,6 +505,7 @@ pre_vote(info, {node_event, _Node, _Evt}, State) ->
     {keep_state, State};
 pre_vote(_, tick_timeout, State0) ->
     State = maybe_persist_last_applied(State0),
+    _ = ets:insert(ra_metrics, ra_server:metrics(State#state.server_state)),
     {keep_state, State, set_tick_timer(State, [])};
 pre_vote({call, From}, trigger_election, State) ->
     {keep_state, State, [{reply, From, ok}]};
@@ -612,6 +614,7 @@ follower(info, {node_event, _Node, up}, State) ->
     end;
 follower(_, tick_timeout, State) ->
     true = erlang:garbage_collect(),
+    _ = ets:insert(ra_metrics, ra_server:metrics(State#state.server_state)),
     {keep_state, State, set_tick_timer(State, [])};
 follower({call, From}, {log_fold, Fun, Term}, State) ->
     fold_log(From, Fun, Term, State);

--- a/test/ra_log_SUITE.erl
+++ b/test/ra_log_SUITE.erl
@@ -241,7 +241,7 @@ init_close_init(Config) ->
     Log0 = ?config(ra_log, Config),
     Log1 = append_in(1, "entry1", Log0),
     Log2 = append_in(2, "entry2", Log1),
-    ok = ra_log_meta:store(?config(uid, Config), current_term, 2),
+    ok = ra_log_meta:store_sync(?config(uid, Config), current_term, 2),
     ok = ra_log:close(Log2),
     LogA = InitFun(init_close_init),
     {2, 2} = ra_log:last_index_term(LogA),

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1611,6 +1611,7 @@ leader_received_append_entries_reply_with_stale_last_index(_Config) ->
                               initial_state => <<>>}},
                 machine_version => 0,
                 machine_versions => [{0, 0}],
+                metrics_key => n1,
                 effective_machine_version => 0,
                 effective_machine_module =>  ra_machine_simple,
                 machine_state => [{4,apple}],
@@ -1661,6 +1662,7 @@ leader_receives_install_snapshot_result(_Config) ->
                machine_state => [{4,apple}],
                machine_version => 0,
                machine_versions => [{0, 0}],
+               metrics_key => n1,
                effective_machine_version => 1,
                effective_machine_module => ra_machine_simple,
                query_index => 0,
@@ -2256,6 +2258,7 @@ base_state(NumServers, MacMod) ->
       machine_state => <<"hi3">>, % last entry has been applied
       machine_version => 0,
       machine_versions => [{0, 0}],
+      metrics_key => n1,
       effective_machine_version => 0,
       effective_machine_module => MacMod,
       log => Log,

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -160,8 +160,7 @@ setup_log() ->
     ok.
 
 init_test(_Config) ->
-    #{id := Id,
-      uid := UId,
+    #{id := {Id, UId, _},
       cluster := Cluster,
       current_term := CurrentTerm,
       log := Log0} = base_state(3, ?FUNCTION_NAME),
@@ -219,16 +218,17 @@ recover_restores_cluster_changes(_Config) ->
     {leader, #{cluster := Cluster,
                log := Log0}, _} =
         ra_server:handle_leader({command, {'$ra_join', meta(),
-                                         n2, await_consensus}}, State),
+                                           n2, await_consensus}}, State),
     ?assert(maps:size(Cluster) =:= 2),
     % intercept ra_log:init call to simulate persisted log data
     % ok = meck:new(ra_log, [passthrough]),
     meck:expect(ra_log, init, fun (_) -> Log0 end),
-    meck:expect(ra_log_meta, fetch, fun (_, last_applied, 0) ->
-                                            element(1, ra_log:last_index_term(Log0));
-                                        (_, _, Def) ->
-                                            Def
-                                    end),
+    meck:expect(ra_log_meta, fetch,
+                fun (_, last_applied, 0) ->
+                        element(1, ra_log:last_index_term(Log0));
+                    (_, _, Def) ->
+                        Def
+                end),
 
     #{cluster := #{n1 := _, n2 := _}} = ra_server_init(InitConf),
     ok.
@@ -950,7 +950,7 @@ leader_does_not_abdicate_to_unknown_peer(_Config) ->
 
 
 leader_replies_to_append_entries_rpc_with_lower_term(_Config) ->
-    State = #{id := Id,
+    State = #{id := {Id, _, _},
               current_term := CTerm} = base_state(3, ?FUNCTION_NAME),
     AERpc = #append_entries_rpc{term = CTerm - 1,
                                 leader_id = n3,
@@ -1186,7 +1186,7 @@ follower_cluster_change(_Config) ->
     OldCluster = #{n1 => new_peer_with(#{next_index => 4, match_index => 3}),
                    n2 => new_peer_with(#{next_index => 4, match_index => 3}),
                    n3 => new_peer_with(#{next_index => 4, match_index => 3})},
-    State = (base_state(3, ?FUNCTION_NAME))#{id => n2,
+    State = (base_state(3, ?FUNCTION_NAME))#{id => {n2, <<"n2">>, "n2"},
                              cluster => OldCluster},
     NewCluster = #{n1 => new_peer_with(#{next_index => 4, match_index => 3}),
                    n2 => new_peer_with(#{next_index => 4, match_index => 3}),
@@ -1217,7 +1217,7 @@ leader_applies_new_cluster(_Config) ->
                    n2 => new_peer_with(#{next_index => 4, match_index => 3}),
                    n3 => new_peer_with(#{next_index => 4, match_index => 3})},
 
-    State = (base_state(3, ?FUNCTION_NAME))#{id => n1, cluster => OldCluster},
+    State = (base_state(3, ?FUNCTION_NAME))#{cluster => OldCluster},
     Command = {command, {'$ra_join', meta(), n4, await_consensus}},
     % cluster records index and term it was applied to determine whether it has
     % been applied
@@ -1269,7 +1269,7 @@ leader_appends_cluster_change_then_steps_before_applying_it(_Config) ->
                    n2 => new_peer_with(#{next_index => 4, match_index => 3}),
                    n3 => new_peer_with(#{next_index => 4, match_index => 3})},
 
-    State = (base_state(3, ?FUNCTION_NAME))#{id => n1, cluster => OldCluster},
+    State = (base_state(3, ?FUNCTION_NAME))#{cluster => OldCluster},
     Command = {command, {'$ra_join', meta(), n4, await_consensus}},
     % cluster records index and term it was applied to determine whether it has
     % been applied
@@ -1601,9 +1601,7 @@ leader_received_append_entries_reply_with_stale_last_index(_Config) ->
                 cluster_index_term => {0,0},
                 commit_index => 3,
                 current_term => Term,
-                id => n1,
-                uid => <<"n1">>,
-                log_id => <<"n1">>,
+                id => {n1, <<"n1">>, <<"n1">>},
                 last_applied => 4,
                 log => Log,
                 machine => {machine, ra_machine_simple,
@@ -1653,9 +1651,7 @@ leader_receives_install_snapshot_result(_Config) ->
                cluster_index_term => {0,0},
                commit_index => 4,
                current_term => Term,
-               id => n1,
-               uid => <<"n1">>,
-               log_id => <<"n1">>,
+               id => {n1, <<"n1">>, <<"n1">>},
                last_applied => 4,
                log => Log0,
                machine => {machine, ?FUNCTION_NAME, #{}},
@@ -1688,7 +1684,7 @@ follower_heartbeat(_Config) ->
     #{current_term := Term,
       query_index := QIndex,
       cluster := Cluster,
-      id := Id,
+      id := {Id, _, _},
       leader_id := LeaderId} = State,
     #{Id := _} = Cluster,
     NewQueryIndex = QIndex + 1,
@@ -1731,7 +1727,7 @@ follower_heartbeat(_Config) ->
 
 follower_heartbeat_reply(_Config) ->
     State = base_state(3, ?FUNCTION_NAME),
-    #{current_term := Term, leader_id := LeaderId, id := Id} = State,
+    #{current_term := Term, leader_id := LeaderId, id := {Id, _, _}} = State,
     HeartbeatReply = #heartbeat_reply{term = Term, query_index = 2},
 
     %% Ignore lower or same term
@@ -1752,7 +1748,7 @@ candidate_heartbeat(_Config) ->
     State = base_state(3, ?FUNCTION_NAME),
     #{current_term := Term,
       leader_id := LeaderId,
-      id := Id,
+      id := {Id, _, _},
       query_index := QueryIndex} = State,
     NewQueryIndex = QueryIndex + 1,
     Heartbeat = #heartbeat_rpc{query_index = NewQueryIndex,
@@ -1785,7 +1781,7 @@ candidate_heartbeat(_Config) ->
 
 candidate_heartbeat_reply(_Config) ->
     State = base_state(3, ?FUNCTION_NAME),
-    #{current_term := Term, id := Id} = State,
+    #{current_term := Term, id := {Id, _, _}} = State,
 
     HeartbeatReply = #heartbeat_reply{term = Term, query_index = 2},
     %% Same term is ignored
@@ -1810,7 +1806,7 @@ pre_vote_heartbeat(_Config) ->
     #{current_term := Term,
       query_index := QueryIndex,
       leader_id := LeaderId,
-      id := Id} = State,
+      id := {Id, _, _}} = State,
     NewQueryIndex = QueryIndex + 1,
     Heartbeat = #heartbeat_rpc{query_index = NewQueryIndex,
                                term = Term,
@@ -1843,7 +1839,7 @@ pre_vote_heartbeat(_Config) ->
 
 pre_vote_heartbeat_reply(_Config) ->
     State = base_state(3, ?FUNCTION_NAME),
-    #{current_term := Term, id := Id} = State,
+    #{current_term := Term, id := {Id, _, _}} = State,
 
     HeartbeatReply = #heartbeat_reply{term = Term,
                                       query_index = 2},
@@ -1874,7 +1870,7 @@ leader_heartbeat(_Config) ->
     State = base_state(3, ?FUNCTION_NAME),
     #{current_term := Term,
       leader_id := LeaderId,
-      id := Id,
+      id := {Id, _, _},
       query_index := QueryIndex} = State,
     NewQueryIndex = QueryIndex + 1,
     Heartbeat = #heartbeat_rpc{query_index = NewQueryIndex,
@@ -1912,7 +1908,7 @@ leader_heartbeat(_Config) ->
 leader_heartbeat_reply_same_term(_Config) ->
     BaseState = base_state(3, ?FUNCTION_NAME),
     #{current_term := Term,
-      id := Id,
+      id := {Id, _, _},
       commit_index := CommitIndex} = BaseState,
     QueryIndex = 10,
     QueryRef1 = {from1, fun(_) -> query_result1 end, CommitIndex},
@@ -1992,7 +1988,7 @@ leader_consistent_query_delay(_Config) ->
     #{commit_index := CommitIndex,
       query_index := QueryIndex,
       current_term := Term,
-      id := Id} = State,
+      id := {Id, _, _}} = State,
 
     %% If cluster changes are not permitted - delay the heartbeats
     Fun = fun(_) -> query_result end,
@@ -2041,7 +2037,7 @@ leader_consistent_query(_Config) ->
     #{commit_index := CommitIndex,
       query_index := QueryIndex,
       current_term := Term,
-      id := Id} = State,
+      id := {Id, _, _}} = State,
 
     Fun = fun(_) -> query_result end,
     Query1 = {from1, Fun, CommitIndex},
@@ -2088,7 +2084,7 @@ await_condition_heartbeat_dropped(_Config) ->
     State = (base_state(3, ?FUNCTION_NAME))#{condition => fun(_,S) -> {false, S} end},
     #{current_term := Term,
       query_index := QueryIndex,
-      id := Id} = State,
+      id := {Id, _, _}} = State,
 
     Heartbeat = #heartbeat_rpc{term = Term,
                                query_index = QueryIndex,
@@ -2124,7 +2120,7 @@ receive_snapshot_heartbeat_dropped(_Config) ->
     State = base_state(3, ?FUNCTION_NAME),
     #{current_term := Term,
       query_index := QueryIndex,
-      id := Id} = State,
+      id := {Id, _, _}} = State,
 
     Heartbeat = #heartbeat_rpc{term = Term,
                                query_index = QueryIndex,
@@ -2243,9 +2239,7 @@ base_state(NumServers, MacMod) ->
                                                      match_index => 3})}
                         end, #{}, lists:seq(1, NumServers)),
     mock_machine(MacMod),
-    #{id => n1,
-      uid => <<"n1">>,
-      log_id => <<"n1">>,
+    #{id => {n1, <<"n1">>, <<"n1">>},
       leader_id => n1,
       cluster => Servers,
       cluster_index_term => {0, 0},


### PR DESCRIPTION
Allow the metrics key to be specified through config.

Also a commit to reduce cpu use of the meta data store in low/medium throughput scenarios.