### PR TITLE
Retry on server data directory deletion

### DIFF
--- a/src/ra_lib.erl
+++ b/src/ra_lib.erl
@@ -28,7 +28,8 @@
          make_dir/1,
          derive_safe_string/2,
          validate_base64uri/1,
-         partition_parallel/2
+         partition_parallel/2,
+         retry/2
         ]).
 
 ceiling(X) when X < 0 ->
@@ -266,6 +267,17 @@ collect([{{Pid, MRef}, E} | Next], {Left, Right}, Timeout) ->
     exit(partition_parallel_timeout)
   end.
 
+retry(_Func, 0) ->
+    exhausted;
+retry(Func, Attempt) ->
+    % do not retry immediately
+    timer:sleep(5000),
+    case Func() of
+        ok ->
+            ok;
+        _ ->
+            retry(Func, Attempt - 1)
+    end.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/ra_server_sup_sup.erl
+++ b/src/ra_server_sup_sup.erl
@@ -144,7 +144,7 @@ delete_data_directory(Directory) ->
                   end)
     end.
 
-retry(Func, 0) ->
+retry(_Func, 0) ->
     exhausted;
 retry(Func, Attempt) ->
     % do not retry immediately

--- a/src/ra_server_sup_sup.erl
+++ b/src/ra_server_sup_sup.erl
@@ -140,22 +140,9 @@ delete_data_directory(Directory) ->
             ok;
         _ ->
             spawn(fun() ->
-                      retry(DeleteFunction, 2)
+                      ra_lib:retry(DeleteFunction, 2)
                   end)
     end.
-
-retry(_Func, 0) ->
-    exhausted;
-retry(Func, Attempt) ->
-    % do not retry immediately
-    timer:sleep(100),
-    case Func() of
-        ok ->
-            ok;
-        _ ->
-            retry(Func, Attempt - 1)
-    end.
-
 
 remove_all() ->
     _ = [begin

--- a/test/ra_2_SUITE.erl
+++ b/test/ra_2_SUITE.erl
@@ -103,7 +103,7 @@ server_is_force_deleted(Config) ->
 
     validate_ets_table_deletes([UId], [Pid], [ServerId]),
     % start a node with the same nodeid but different uid
-    % simulatin the case where a queue got deleted then re-declared shortly
+    % simulating the case where a queue got deleted then re-declared shortly
     % afterwards
     UId2 = ?config(uid2, Config),
     ok = ra:start_server(Conf#{uid => UId2,


### PR DESCRIPTION
Retry attempts take place in a different process. ETS table cleaning is
done even if the data directory deletion fails.

There were some spurious failures on CI, this commit tries to fix this.