### PR TITLE
Change confusing variable name.

### DIFF
--- a/src/ra_directory.erl
+++ b/src/ra_directory.erl
@@ -104,7 +104,7 @@ where_is_parent(UId) when is_binary(UId) ->
 -spec name_of(ra_uid()) -> maybe(atom()).
 name_of(UId) ->
     case ets:lookup(?MODULE, UId) of
-        [{_, _, _, Node, _}] -> Node;
+        [{_, _, _, ServerName, _}] -> ServerName;
         [] -> undefined
     end.
 


### PR DESCRIPTION
## Proposed Changes

ets table ra_directory stores tuple {UID, PID, PPID, ServerName, ClusterName},
not {UID, PID, PPID, Node, ClusterName}.
using variable name Node is confusing.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
