### PR TITLE
Ensure snapshots are synced

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -123,10 +123,13 @@ restart_server(ServerId) ->
 stop_server(ServerId) ->
     try ra_server_sup_sup:stop_server(ServerId) of
         ok -> ok;
-        {error, not_found} -> ok
+        {error, not_found} -> ok;
+        {error, {badrpc, nodedown}} ->
+            {error, nodedown}
     catch
         exit:noproc -> ok;
-        exit:{{nodedown, _}, _} -> {error, nodedown}
+        exit:{{nodedown, _}, _} ->
+            {error, nodedown}
     end.
 
 %% @doc Deletes a ra server

--- a/src/ra_lib.erl
+++ b/src/ra_lib.erl
@@ -29,7 +29,8 @@
          derive_safe_string/2,
          validate_base64uri/1,
          partition_parallel/2,
-         retry/2
+         retry/2,
+         write_file/2
         ]).
 
 ceiling(X) when X < 0 ->
@@ -277,6 +278,27 @@ retry(Func, Attempt) ->
             ok;
         _ ->
             retry(Func, Attempt - 1)
+    end.
+
+
+write_file(Name, IOData) ->
+    case file:open(Name, [binary, write, raw]) of
+        {ok, Fd} ->
+            case file:write(Fd, IOData) of
+                ok ->
+                    case file:sync(Fd) of
+                        ok ->
+                            file:close(Fd);
+                        Err ->
+                            _ = file:close(Fd),
+                            Err
+                    end;
+                Err ->
+                    _ = file:close(Fd),
+                    Err
+            end;
+        Err ->
+            Err
     end.
 
 -ifdef(TEST).

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -591,8 +591,8 @@ write_config(Config0, #?MODULE{directory = Dir}) ->
     ConfigPath = filename:join(Dir, "config"),
     % clean config of potentially unserialisable data
     Config = maps:without([parent], Config0),
-    ok = file:write_file(ConfigPath,
-                         list_to_binary(io_lib:format("~p.", [Config]))),
+    ok = ra_lib:write_file(ConfigPath,
+                           list_to_binary(io_lib:format("~p.", [Config]))),
     ok.
 
 read_config(Dir) ->

--- a/src/ra_log_snapshot.erl
+++ b/src/ra_log_snapshot.erl
@@ -48,10 +48,10 @@ write(Dir, Meta, MacState) ->
     Data = [<<(size(MetaBin)):32/unsigned>>, MetaBin, Bin],
     Checksum = erlang:crc32(Data),
     File = filename(Dir),
-    file:write_file(File, [<<?MAGIC,
-                             ?VERSION:8/unsigned,
-                             Checksum:32/integer>>,
-                           Data]).
+    ra_lib:write_file(File, [<<?MAGIC,
+                               ?VERSION:8/unsigned,
+                               Checksum:32/integer>>,
+                             Data]).
 
 begin_accept(SnapDir, Meta) ->
     File = filename(SnapDir),

--- a/test/coordination_SUITE.erl
+++ b/test/coordination_SUITE.erl
@@ -90,7 +90,7 @@ start_stop_restart_delete_on_remote(Config) ->
     ok = ra:stop_server(NodeId),
     ok = ra:force_delete_server(NodeId),
     % idempotency
-    {error, _} = ra:force_delete_server(NodeId),
+    ok = ra:force_delete_server(NodeId),
     timer:sleep(500),
     slave:stop(S1),
     ok.


### PR DESCRIPTION
To do so we had to write our own version of file:write_file/2 that
fsyncs before closing the file handle.

Fixes #109 

Thanks to @skypexu for finding this issue in #107 