### PR TITLE
early commit for gen batch server 0.8.0 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ PROJECT = ra
 ESCRIPT_NAME = ra_fifo_cli
 ESCRIPT_EMU_ARGS = -noinput -setcookie ra_fifo_cli
 
-dep_gen_batch_server = hex 0.7.0
+# dep_gen_batch_server = hex 0.7.0
+dep_gen_batch_server = git git@github.com:rabbitmq/gen-batch-server.git garbage-collect-action
 dep_aten = hex 0.5.2
 DEPS = aten gen_batch_server
 

--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -532,7 +532,7 @@ complete_batch(#state{batch = #batch{waiting = Waiting,
                          Pid ! {ra_log_event, {written, WrittenInfo}},
                          ok
                  end, Waiting),
-    {ok, State}.
+    {ok, [garbage_collect], State}.
 
 incr_batch(#batch{writes = Writes,
                   waiting = Waiting0,

--- a/test/ra_log_wal_SUITE.erl
+++ b/test/ra_log_wal_SUITE.erl
@@ -155,6 +155,9 @@ write_many(Config) ->
            "Reductions: ~b",
            [NumWrites, Taken / 1000, Reds]),
 
+    % assert memory use after isn't absurdly larger than before
+    ?assert(MemAfter < (MemBefore * 2)),
+
     % assert we aren't regressing on reductions used
     ?assert(Reds < 52023339 * 1.1),
     % stop_profile(Config),


### PR DESCRIPTION
early test commit to ensure gc is collected in a timely manner in the wal when gen batch server 0.8.0 is released.  see: https://github.com/rabbitmq/gen-batch-server/pull/13
