### PR TITLE
Default commit latency to -1 in all cases

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1847,7 +1847,7 @@ apply_to(ApplyTo, ApplyFun, Notifys0, Effects0,
                             Entries),
             CommitLatency = case LastTs of
                                 undefined ->
-                                    undefined;
+                                    -1;
                                 _ when is_integer(LastTs) ->
                                     os:system_time(millisecond) - LastTs
                             end,

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -41,7 +41,8 @@ all_tests() ->
      leader_steps_down_after_replicating_new_cluster,
      stop_leader_and_wait_for_elections,
      follower_catchup,
-     post_partition_liveness
+     post_partition_liveness,
+     all_metrics_are_integers
     ].
 
 groups() ->
@@ -395,6 +396,17 @@ consistent_query_stale(Config) ->
     {ok, {{IndexAfter, _}, _}, _} = ra:local_query(Leader, fun(S) -> S end),
     ?assertMatch(Index, IndexAfter),
     terminate_cluster(Cluster).
+
+all_metrics_are_integers(Config) ->
+    ok = logger:set_primary_config(level, all),
+    Name = ?config(test_name, Config),
+    N1 = nn(Config, 1),
+    ok = ra:start_server(Name, N1, add_machine(), []),
+    ok = ra:trigger_election(N1),
+    {ok, 5, _} = ra:process_command({N1, node()}, 5, 2000),
+    [{_, M1, M2, M3, M4, M5, M6}] = ets:lookup(ra_metrics, N1),
+    ?assert(lists:all(fun(I) -> is_integer(I) end, [M1, M2, M3, M4, M5, M6])),
+    terminate_cluster([N1]).
 
 wait_for_applied(Msg) ->
     receive {ra_event, _, {applied, Applied}} ->


### PR DESCRIPTION
Even though a -1 latency does not make sense, from a metrics API point of view they all should be integers. It already defaults to -1 `in ra_server:metrics/1`

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
