### PR TITLE
Randomise initial WAL sizes

### DIFF
--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -76,7 +76,7 @@
                 % a truncating write is received.
                 % no attempt is made to recover this information after a crash
                 % beyond the available WAL files
-                % all writers seen withing the lifetime of a WAL file
+                % all writers seen within the lifetime of a WAL file
                 % and the last index seen
                 writers = #{} :: #{ra_uid() =>
                                    {in_seq | out_of_seq, ra_index()}},
@@ -187,7 +187,7 @@ init(#{dir := Dir} = Conf0) ->
      || I <- lists:seq(0, ?METRICS_WINDOW_SIZE-1)],
     % wait for the segment writer to process anything in flight
     ok = ra_log_segment_writer:await(SegWriter),
-    %% TODO: recover wal shoudl return {stop, Reason} if it fails
+    %% TODO: recover wal should return {stop, Reason} if it fails
     %% rather than crash
     FileModes = [raw, append, binary],
     Conf = #conf{file_modes = FileModes,

--- a/test/ra_log_wal_SUITE.erl
+++ b/test/ra_log_wal_SUITE.erl
@@ -283,11 +283,11 @@ roll_over(Config) ->
     % the writer process
     receive
         {'$gen_cast', {mem_tables, [{UId, _Fst, _Lst, Tid}], _}} ->
-            [{UId, 5, 5, CurrentTid}] = ets:lookup(ra_log_open_mem_tables, UId),
+            [{UId, _, _, CurrentTid}] = ets:lookup(ra_log_open_mem_tables, UId),
             % the current tid is not the same as the rolled over one
             ?assert(Tid =/= CurrentTid),
             % ensure closed mem tables contain the previous mem_table
-            [{UId, _, 1, 4, Tid}] = ets:lookup(ra_log_closed_mem_tables, UId)
+            [{UId, _, _, _, Tid}] = ets:lookup(ra_log_closed_mem_tables, UId)
     after 2000 ->
               throw(new_mem_tables_timeout)
     end,


### PR DESCRIPTION
In order to avoid scenarios where all nodes in a cluster end up flushing
mem tables to disk at roughly the same time. This will have the effect
of evening out throughput somewhat.

Also some internal state refactoring inside the WAL.

[#168894507]
