### PR TITLE
Make low priority command flush size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ A directory name where `ra` will store it's data.
 
 * `wal_max_size_bytes`:
 
-The maximum size of the WAL (Write Ahead Log). Default: 128Mb.
+The maximum size of the WAL (Write Ahead Log) in bytes. Default: 512Mb.
 
 * `wal_compute_checksums`:
 
@@ -121,6 +121,11 @@ that takes a format not the variant that takes a fun).
 
 Metrics key. The key used to write metrics into the `ra_metrics` table.
 
+* `low_priority_commands_flush_size`:
+
+When commands are pipelined using the low priority mode Ra tries to hold them
+back in favour of normal priority commands. This setting determines the number
+of low priority commands that are added to the log each flush cycle. Default: 25
 
 ```
 [{data_dir, "/tmp/ra-data"},

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -173,6 +173,7 @@
                               % and persisting last_applied index
                               tick_timeout => non_neg_integer(), % ms
                               await_condition_timeout => non_neg_integer(),
+                              low_priority_commands_flush_size => non_neg_integer(),
                               ra_event_formatter => {module(), atom(), [term()]}}.
 
 -type config() :: ra_server_config().


### PR DESCRIPTION
also includes some ra_server_proc state refactoring that should have some minor allocation benefits.

Fixes #27 