### PR TITLE
Add a "pre init" phase that recovers the ra_log_snapshot_state table

### DIFF
--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -3,7 +3,8 @@
 
 -compile([inline_list_funcs]).
 
--export([init/1,
+-export([pre_init/1,
+         init/1,
          close/1,
          append/2,
          write/2,
@@ -107,6 +108,17 @@
               event_body/0,
               effect/0
              ]).
+
+pre_init(#{uid := UId} = Conf) ->
+    Dir = case Conf of
+              #{data_dir := D} -> D;
+              _ ->
+                  ra_env:server_data_dir(UId)
+          end,
+    SnapModule = maps:get(snapshot_module, Conf, ?DEFAULT_SNAPSHOT_MODULE),
+    SnapshotsDir = filename:join(Dir, "snapshots"),
+    _ = ra_snapshot:init(UId, SnapModule, SnapshotsDir),
+    ok.
 
 -spec init(ra_log_init_args()) -> state().
 init(#{uid := UId} = Conf) ->

--- a/src/ra_log_pre_init.erl
+++ b/src/ra_log_pre_init.erl
@@ -1,0 +1,62 @@
+-module(ra_log_pre_init).
+
+-behaviour(gen_server).
+
+-include("ra.hrl").
+%% API functions
+-export([start_link/1]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(state, {}).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+start_link(DataDir) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [DataDir], []).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([_DataDir]) ->
+    %% ra_log:pre_init ensures that the ra_log_snapshot_state table is
+    %% populated before WAL recovery begins to avoid writing unnecessary
+    %% indexes to segment files.
+    Regd = ra_directory:list_registered(),
+    _ = [catch(pre_init(Name)) || {Name, _U} <- Regd],
+    {ok, #state{} , hibernate}.
+
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+pre_init(Name) ->
+    {ok, #{log_init_args := Log}} = ra_server_sup_sup:prepare_restart_rpc(Name),
+    _ = ra_log:pre_init(Log),
+    ok.
+

--- a/src/ra_log_sup.erl
+++ b/src/ra_log_sup.erl
@@ -15,9 +15,10 @@ start_link(DataDir) ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, [DataDir]).
 
 init([DataDir]) ->
+    PreInit = #{id => ra_log_pre_init,
+                start => {ra_log_pre_init, start_link, [DataDir]}},
     Meta = #{id => ra_log_meta,
              start => {ra_log_meta, start_link, [DataDir]}},
-
     SegmentMaxEntries = application:get_env(ra, segment_max_entries, 4096),
     SegWriterConf = #{data_dir => DataDir,
                       segment_conf => #{max_count => SegmentMaxEntries}},
@@ -29,4 +30,4 @@ init([DataDir]) ->
     WalSup = #{id => ra_log_wal_sup,
                type => supervisor,
                start => {ra_log_wal_sup, start_link, [WalConf]}},
-    {ok, {SupFlags, [Meta, SegWriter, WalSup]}}.
+    {ok, {SupFlags, [PreInit, Meta, SegWriter, WalSup]}}.


### PR DESCRIPTION
...so that the segment writer does not end up writing unnecessary data to
disk.

Fixes #143 