### PR TITLE
Extend ra_machine:handle_aux to support monitor effects

### DIFF
--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -229,7 +229,11 @@
                      LogState,
                      MacState :: state()) ->
     {reply, Reply :: term(), AuxState, LogState} |
-    {no_reply, AuxState, LogState}
+    {reply, Reply :: term(), AuxState, LogState,
+     [{monitor, process, aux, pid()}]} |
+    {no_reply, AuxState, LogState} |
+    {no_reply, AuxState, LogState,
+     [{monitor, process, aux, pid()}]}
       when AuxState :: term(),
            LogState :: ra_log:state().
 
@@ -287,13 +291,20 @@ which_module({machine, Mod, _}, Version) ->
 init_aux(Mod, Name) ->
     ?OPT_CALL(Mod:init_aux(Name), undefined).
 
--spec handle_aux(module(), ra_server:ra_state(),
+-spec handle_aux(module(),
+                 ra_server:ra_state(),
                  {call, From :: from()} | cast,
-                 Command :: term(), AuxState,
-                 LogState, MacState :: state()) ->
+                 Command :: term(),
+                 AuxState,
+                 LogState,
+                 MacState :: state()) ->
+    undefined |
     {reply, Reply :: term(), AuxState, LogState} |
+    {reply, Reply :: term(), AuxState, LogState,
+     [{monitor, process, aux, pid()}]} |
     {no_reply, AuxState, LogState} |
-    undefined
+    {no_reply, AuxState, LogState,
+     [{monitor, process, aux, pid()}]}
       when AuxState :: term(),
            LogState :: ra_log:state().
 handle_aux(Mod, RaftState, Type, Cmd, Aux, Log, MacState) ->

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1253,8 +1253,13 @@ handle_aux(RaftState, Type, Cmd, #{aux_state := Aux0, log := Log0,
         {reply, Reply, Aux, Log} ->
             {RaftState, State0#{log => Log, aux_state => Aux},
              [{reply, Reply}]};
+        {reply, Reply, Aux, Log, Effects} ->
+            {RaftState, State0#{log => Log, aux_state => Aux},
+             [{reply, Reply} | Effects]};
         {no_reply, Aux, Log} ->
             {RaftState, State0#{log => Log, aux_state => Aux}, []};
+        {no_reply, Aux, Log, Effects} ->
+            {RaftState, State0#{log => Log, aux_state => Aux}, Effects};
         undefined ->
             {RaftState, State0, []}
     end.
@@ -1597,6 +1602,8 @@ handle_down(RaftState, snapshot_writer, Pid, Info,
     SnapState = ra_snapshot:handle_down(Pid, Info, SnapState0),
     Log = ra_log:set_snapshot_state(SnapState, Log0),
     {RaftState, State#{log => Log}, []};
+handle_down(RaftState, aux, Pid, Info, State) ->
+    handle_aux(RaftState, cast, {down, Pid, Info}, State);
 handle_down(RaftState, Type, Pid, Info, #{id := {_, _, LogId}} = State) ->
     ?DEBUG("~s: handle_down: unexpected ~w ~w exited with ~W~n",
           [LogId, Type, Pid, Info, 10]),


### PR DESCRIPTION
So that aux machines can monitor processes and be notified when they
go down.
