### PR TITLE
Allow followers to apply entries before fully written

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1358,7 +1358,7 @@ evaluate_commit_index_follower(#{commit_index := CommitIndex,
     %% from the log
     {Idx, _} = ra_log:last_index_term(Log),
     ApplyTo = min(Idx, CommitIndex),
-    % neet catch termination throw
+    % need to catch a termination throw
     case catch apply_to(ApplyTo, State0, Effects0) of
         {delete_and_terminate, State1, Effects} ->
             Reply = append_entries_reply(Term, true, State1),

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -196,7 +196,7 @@
 
 -define(AER_CHUNK_SIZE, 25).
 -define(FOLD_LOG_BATCH_SIZE, 25).
-% TODO: test what is a good defult here
+% TODO: test what is a good default here
 % TODO: make configurable
 -define(MAX_PIPELINE_DISTANCE, 10000).
 

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -638,6 +638,8 @@ contains(Match, Entries) ->
               end, Entries).
 
 follower_catchup(Config) ->
+
+    ok = logger:set_primary_config(level, all),
     meck:new(ra_server_proc, [passthrough]),
     meck:expect(ra_server_proc, send_rpc,
                 fun(P, #append_entries_rpc{entries = Entries} = T) ->


### PR DESCRIPTION
As long as the commit index has been incremented and the entries are
there followers should be able to apply them rather than waiting for the
WAL to return.