### PR TITLE
External log readers

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -862,7 +862,7 @@ aux_command(ServerRef, Cmd) ->
 cast_aux_command(ServerRef, Cmd) ->
     gen_statem:cast(ServerRef, {aux_command, Cmd}).
 
-%% @doc Registers an external log reader. ServerId needs to be local
+%% @doc Registers an external log reader. ServerId needs to be local to the node.
 %% Returns an initiated ra_log_reader:state() state.
 %% @end
 -spec register_external_log_reader(ra_server_id()) ->

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -58,7 +58,8 @@
          %% rebalancing
          transfer_leadership/2,
          aux_command/2,
-         cast_aux_command/2
+         cast_aux_command/2,
+         register_external_log_reader/1
         ]).
 
 -define(START_TIMEOUT, ?DEFAULT_TIMEOUT).
@@ -612,9 +613,8 @@ new_uid(Source) when is_binary(Source) ->
 overview() ->
     #{node => node(),
       servers => ra_directory:overview(),
-      wal => #{max_batch_size =>
-               lists:max([X || {X, _} <- ets:tab2list(ra_log_wal_metrics)]),
-               status => lists:nth(5, element(4, sys:get_status(ra_log_wal))),
+      counters => ra_counters:overview(),
+      wal => #{status => lists:nth(5, element(4, sys:get_status(ra_log_wal))),
                open_mem_tables => ets:info(ra_log_open_mem_tables, size),
                closed_mem_tables => ets:info(ra_log_closed_mem_tables, size)},
       segment_writer => ra_log_segment_writer:overview()
@@ -861,6 +861,17 @@ aux_command(ServerRef, Cmd) ->
 -spec cast_aux_command(ra_server_id(), term()) -> ok.
 cast_aux_command(ServerRef, Cmd) ->
     gen_statem:cast(ServerRef, {aux_command, Cmd}).
+
+%% @doc Registers an external log reader. ServerId needs to be local
+%% Returns an initiated ra_log_reader:state() state.
+%% @end
+-spec register_external_log_reader(ra_server_id()) ->
+    ra_log_reader:state().
+register_external_log_reader({_, Node} = ServerId)
+ when Node =:= node() ->
+    {ok, UId, Idx, SegRefs} = gen_statem:call(ServerId,
+                                              {register_external_log_reader, self()}),
+    ra_log_reader:init(UId, Idx, 1, SegRefs).
 
 %% internal
 

--- a/src/ra_counters.erl
+++ b/src/ra_counters.erl
@@ -1,0 +1,46 @@
+-module(ra_counters).
+
+-export([
+         init/0,
+         new/2,
+         register/3,
+         overview/0
+         ]).
+
+%% holds static or rarely changing fields
+-record(cfg, {}).
+
+-record(?MODULE, {cfg :: #cfg{}}).
+
+-opaque state() :: #?MODULE{}.
+
+-export_type([
+              state/0
+              ]).
+
+init() ->
+    _ = ets:new(?MODULE, [set, named_table, public]),
+    ok.
+
+new(Name, Size) ->
+    CRef = counters:new(Size, []),
+    register(Name, CRef, Size),
+    CRef.
+
+
+register(Name, Ref, Size) ->
+    ets:insert(?MODULE, {Name, Ref, Size}).
+
+overview() ->
+    ets:foldl(
+      fun({Name, Ref, Size}, Acc) ->
+              Values = [counters:get(Ref, I) || I <- lists:seq(1, Size)],
+              Acc#{Name => Values}
+      end, #{}, ?MODULE).
+
+
+
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -33,7 +33,11 @@
          read_config/1,
 
          delete_everything/1,
-         release_resources/2
+         release_resources/2,
+
+         % external reader
+         register_reader/2,
+         readers/1
         ]).
 
 -include("ra.hrl").
@@ -55,16 +59,21 @@
                                  ToTerm :: ra_term()}} |
                       {segments, ets:tid(), [segment_ref()]} |
                       {resend_write, ra_index()} |
-                      {snapshot_written, ra_idxterm()}.
+                      {snapshot_written, ra_idxterm()} |
+                      {down, pid(), term()}.
 
 -type event() :: {ra_log_event, event_body()}.
 
--type effect() :: {delete_snapshot, Dir :: file:filename(), ra_idxterm()}.
+-type effect() ::
+    {delete_snapshot, Dir :: file:filename(), ra_idxterm()} |
+    {monitor, process, log, pid()} |
+    ra_snapshot:effect() |
+    ra_server:effect().
 %% logs can have effects too so that they can be coordinated with other state
 %% such as avoiding to delete old snapshots whilst they are still being
 %% replicated
 
--type effects() :: [effect() | ra_snapshot:effect()].
+-type effects() :: [effect()].
 
 -record(?MODULE,
         {uid :: ra_uid(),
@@ -79,14 +88,15 @@
          last_index = -1 :: -1 | ra_index(),
          last_term = 0 :: ra_term(),
          last_written_index_term = {0, 0} :: ra_idxterm(),
-         segment_refs = [] :: [segment_ref()],
-         open_segments = ra_flru:new(5, fun flru_handler/1) :: ra_flru:state(),
          snapshot_state :: ra_snapshot:state(),
          % if this is set a snapshot write is in progress for the
          % index specified
-         cache = #{} :: #{ra_index() => {ra_term(), log_entry()}},
-         last_resend_time :: maybe(integer())
+         cache = #{} :: #{ra_index() => {ra_index(), ra_term(), log_entry()}},
+         last_resend_time :: maybe(integer()),
+         reader :: ra_log_reader:state(),
+         readers = [] :: [pid()]
         }).
+
 
 -opaque state() :: #?MODULE{}.
 
@@ -100,6 +110,7 @@
                               snapshot_module => module()}.
 
 -export_type([state/0,
+              % reader/0,
               ra_log_init_args/0,
               ra_meta_key/0,
               segment_ref/0,
@@ -156,6 +167,7 @@ init(#{uid := UId} = Conf) ->
                                               {{-1, -1}, SRs};
                                           R ->  R
                                       end,
+    Reader = ra_log_reader:init(UId, FirstIdx, MaxOpen, SegRefs),
     % recover last snapshot file
     %% assert there is no gap between the snapshot
     %% and the first index in the log
@@ -170,12 +182,10 @@ init(#{uid := UId} = Conf) ->
                         log_id = LogId,
                         first_index = max(SnapIdx + 1, FirstIdx),
                         last_index = max(SnapIdx, LastIdx0),
-                        segment_refs = SegRefs,
+                        reader = Reader,
                         snapshot_state = SnapshotState,
                         snapshot_interval = SnapInterval,
                         wal = Wal,
-                        open_segments = ra_flru:new(MaxOpen,
-                                                    fun flru_handler/1),
                         resend_window_seconds = ResendWindow,
                         snapshot_module = SnapModule},
 
@@ -201,14 +211,14 @@ init(#{uid := UId} = Conf) ->
            [State#?MODULE.log_id,
             last_index_term(State),
             State#?MODULE.first_index]),
-    delete_segments(SnapIdx, State).
+    element(1, delete_segments(SnapIdx, State)).
 
 -spec close(state()) -> ok.
 close(#?MODULE{uid = UId,
-               open_segments = OpenSegs}) ->
+               reader = Reader}) ->
     % deliberately ignoring return value
     % close all open segments
-    _ = ra_flru:evict_all(OpenSegs),
+    _ = ra_log_reader:close(Reader),
     %% delete ra_log_metrics record
     catch ets:delete(ra_log_metrics, UId),
     %% inserted in ra_snapshot but it doesn't havea terminate callback so
@@ -266,6 +276,7 @@ write([{Idx, _, _} | _], #?MODULE{uid = UId, last_index = LastIdx}) ->
 -spec take(ra_index(), non_neg_integer(), state()) ->
     {[log_entry()], state()}.
 take(Start, Num, #?MODULE{uid = UId, first_index = FirstIdx,
+                          reader = Reader0,
                           last_index = LastIdx} = State)
   when Start >= FirstIdx andalso Start =< LastIdx andalso Num > 0 ->
     % 0. Check that the request isn't outside of first_index and last_index
@@ -277,27 +288,11 @@ take(Start, Num, #?MODULE{uid = UId, first_index = FirstIdx,
         {Entries, MetricOps0, undefined} ->
             ok = update_metrics(UId, MetricOps0),
             {Entries, State};
-        {Entries0, MetricOps0, Rem0} ->
-            case open_mem_tbl_take(UId, Rem0, MetricOps0, Entries0) of
-                {Entries1, MetricOps, undefined} ->
-                    ok = update_metrics(UId, MetricOps),
-                    {Entries1, State};
-                {Entries1, MetricOps1, Rem1} ->
-                    case closed_mem_tbl_take(UId, Rem1, MetricOps1, Entries1) of
-                        {Entries2, MetricOps, undefined} ->
-                            ok = update_metrics(UId, MetricOps),
-                            {Entries2, State};
-                        {Entries2, MetricOps2, {S, E} = Rem2} ->
-                            case catch segment_take(State, Rem2, Entries2) of
-                                {Open, undefined, Entries} ->
-                                    MOp = {?METRICS_SEGMENT_POS, E - S + 1},
-                                    ok = update_metrics(UId,
-                                                        [MOp | MetricOps2]),
-                                    {Entries,
-                                     State#?MODULE{open_segments = Open}}
-                            end
-                    end
-            end
+        {Entries0, MetricOps0, {S, F}} ->
+            {Entries, Metr, Reader} = ra_log_reader:read(S, F, Reader0),
+            ok = update_metrics(UId, MetricOps0 ++ Metr),
+            %% TODO: avoid concat
+            {Entries ++ Entries0, State#?MODULE{reader = Reader}}
     end;
 take(_, _, State) ->
     {[], State}.
@@ -384,41 +379,51 @@ handle_event({written, {FromIdx, _, _}},
     {resend_from(Expected, State0), []};
 handle_event({segments, Tid, NewSegs},
              #?MODULE{uid = UId,
-                      open_segments = Open0,
-                      segment_refs = SegmentRefs} = State0) ->
+                      reader = Reader0,
+                      readers = Readers} = State0) ->
     ClosedTables = closed_mem_tables(UId),
     Active = lists:takewhile(fun ({_, _, _, _, T}) -> T =/= Tid end,
                              ClosedTables),
+    Reader = ra_log_reader:update_segments(NewSegs, Reader0),
+    % compact seg ref list so that only the latest range for a segment
+    % file has an entry
+    State = State0#?MODULE{reader = Reader},
     % not fast but we rarely should have more than one or two closed tables
     % at any time
     Obsolete = ClosedTables -- Active,
 
-    TidsToDelete = [begin
-                        %% first delete the entry in the closed table lookup
-                        true = ets:delete_object(ra_log_closed_mem_tables,
-                                                 ClosedTbl),
-                        T
-                    end || {_, _, _, _, T} = ClosedTbl  <- Obsolete],
-    ok = ra_log_ets:delete_tables(TidsToDelete),
+    DeleteFun =
+    fun () ->
+            TidsToDelete = [begin
+                                %% first delete the entry in the
+                                %% closed table lookup
+                                true = ets:delete_object(ra_log_closed_mem_tables,
+                                                         ClosedTbl),
+                                T
+                            end || {_, _, _, _, T} = ClosedTbl <- Obsolete],
+            ok = ra_log_ets:delete_tables(TidsToDelete)
+    end,
 
-    %% check if any of the updated segrefs refer to open segments
-    %% we close these segments so that they can be re-opened with updated
-    %% indexes if needed
-    Open = lists:foldl(fun ({_, _, F}, Acc0) ->
-                               case ra_flru:evict(F, Acc0) of
-                                   {_, Acc} -> Acc;
-                                   error -> Acc0
-                               end
-                       end, Open0, SegmentRefs),
-
-    % compact seg ref list so that only the latest range for a segment
-    % file has an entry
-    {State0#?MODULE{segment_refs = compact_seg_refs(NewSegs ++ SegmentRefs),
-                    open_segments = Open}, []};
+    case Readers of
+        [] ->
+            %% delete immedately
+            DeleteFun(),
+            {State, []};
+        _ ->
+            %% HACK
+            %% TODO: replace with reader coordination
+            %% delay deletion until all readers confirmed they have received
+            %% the update
+            Pid = spawn(fun () ->
+                          ok = log_update_wait_n(length(Readers)),
+                          DeleteFun()
+                  end),
+            {State, log_update_effects(Readers, Pid, State)}
+    end;
 handle_event({snapshot_written, {Idx, _} = Snap},
              #?MODULE{snapshot_state = SnapState0} = State0) ->
     % delete any segments outside of first_index
-    State = delete_segments(Idx, State0),
+    {State, Effects0} = delete_segments(Idx, State0),
     SnapState = ra_snapshot:complete_snapshot(Snap, SnapState0),
     %% delete old snapshot files
     %% This is done as an effect
@@ -426,7 +431,7 @@ handle_event({snapshot_written, {Idx, _} = Snap},
     %% the cleanup can be delayed until it is safe
     Effects = [{delete_snapshot,
                 ra_snapshot:directory(SnapState),
-                ra_snapshot:current(SnapState0)}],
+                ra_snapshot:current(SnapState0)} | Effects0],
     %% do not set last written index here as the snapshot may
     %% be for a past index
     {State#?MODULE{first_index = Idx + 1,
@@ -434,7 +439,11 @@ handle_event({snapshot_written, {Idx, _} = Snap},
 handle_event({resend_write, Idx}, State) ->
     % resend missing entries from cache.
     % The assumption is they are available in the cache
-    {resend_from(Idx, State), []}.
+    {resend_from(Idx, State), []};
+handle_event({down, Pid, _Info},
+             #?MODULE{readers = Readers} =
+             State) ->
+    {State#?MODULE{readers = lists:delete(Pid, Readers)}, []}.
 
 -spec next_index(state()) -> ra_index().
 next_index(#?MODULE{last_index = LastIdx}) ->
@@ -456,23 +465,13 @@ fetch_term(Idx, #?MODULE{last_index = LastIdx,
                          first_index = FirstIdx} = State0)
   when Idx < FirstIdx orelse Idx > LastIdx ->
     {undefined, State0};
-fetch_term(Idx, #?MODULE{cache = Cache, uid = UId} = State0) ->
+fetch_term(Idx, #?MODULE{cache = Cache, reader = Reader0} = State0) ->
     case Cache of
-        #{Idx := {Term, _}} ->
+        #{Idx := {Idx, Term, _}} ->
             {Term, State0};
         _ ->
-            case ets:lookup(ra_log_open_mem_tables, UId) of
-                [{_, From, To, Tid}] when Idx >= From andalso Idx =< To ->
-                    Term = ets:lookup_element(Tid, Idx, 2),
-                    {Term, State0};
-                _ ->
-                    case closed_mem_table_term_query(Idx, UId) of
-                        undefined ->
-                            segment_term_query(Idx, State0);
-                        Term ->
-                            {Term, State0}
-                    end
-            end
+            {Term, Reader} = ra_log_reader:fetch_term(Idx, Reader0),
+            {Term, State0#?MODULE{reader = Reader}}
     end.
 
 -spec snapshot_state(State :: state()) -> ra_snapshot:state().
@@ -483,16 +482,18 @@ snapshot_state(State) ->
 set_snapshot_state(SnapState, State) ->
     State#?MODULE{snapshot_state = SnapState}.
 
--spec install_snapshot(ra_idxterm(), ra_snapshot:state(), state()) -> state().
+-spec install_snapshot(ra_idxterm(), ra_snapshot:state(), state()) ->
+    {state(), effects()}.
 install_snapshot({Idx, _} = IdxTerm, SnapState, State0) ->
-    State = delete_segments(Idx, State0),
-    %% TODO: truncate cache?
-    State#?MODULE{snapshot_state = SnapState,
+    {State, Effs} = delete_segments(Idx, State0),
+    {State#?MODULE{snapshot_state = SnapState,
                   first_index = Idx + 1,
                   last_index = Idx,
+                  %% TODO: update last_term too?
                   %% cache can go
                   cache = #{},
-                  last_written_index_term = IdxTerm}.
+                  last_written_index_term = IdxTerm},
+     Effs}.
 
 -spec recover_snapshot(State :: state()) ->
     maybe({ra_snapshot:meta(), term()}).
@@ -523,7 +524,7 @@ update_release_cursor(Idx, Cluster, MacVersion, MacState,
     end.
 
 update_release_cursor0(Idx, Cluster, MacVersion, MacState,
-                       #?MODULE{segment_refs = SegRefs,
+                       #?MODULE{reader = Reader,
                                 snapshot_state = SnapState,
                                 snapshot_interval = SnapInter} = State0) ->
     ClusterServerIds = maps:keys(Cluster),
@@ -537,8 +538,8 @@ update_release_cursor0(Idx, Cluster, MacVersion, MacState,
     % The release cursor index is the last entry _not_ contributing
     % to the current state. I.e. the last entry that can be discarded.
     % Check here if any segments can be release.
-    case lists:any(fun({_, To, _}) when To =< Idx -> true;
-                      (_) -> false end, SegRefs) of
+    case lists:any(fun({_, To, _}) -> To =< Idx end,
+                   ra_log_reader:segment_refs(Reader)) of
         true ->
             % segments can be cleared up
             % take a snapshot at the release_cursor
@@ -560,7 +561,7 @@ update_release_cursor0(Idx, Cluster, MacVersion, MacState,
                     write_snapshot(Meta#{term => Term}, MacState, State)
             end;
         false when Idx > SnapLimit ->
-            %% periodically take snapshots event if segments cannot be cleared
+            %% periodically take snapshots even if segments cannot be cleared
             %% up
             case fetch_term(Idx, State0) of
                 {undefined, State} ->
@@ -608,16 +609,16 @@ exists({Idx, Term}, Log0) ->
 overview(#?MODULE{last_index = LastIndex,
                   first_index = FirstIndex,
                   last_written_index_term = LWIT,
-                  segment_refs = Segs,
                   snapshot_state = SnapshotState,
-                  open_segments = OpenSegs,
+                  reader = Reader,
                   cache = Cache}) ->
     #{type => ?MODULE,
       last_index => LastIndex,
       first_index => FirstIndex,
       last_written_index_term => LWIT,
-      num_segments => length(Segs),
-      open_segments => ra_flru:size(OpenSegs),
+      num_segments => length(ra_log_reader:segment_refs(Reader)),
+      %%TODO: re-introduce open segment count
+      open_segments => ra_log_reader:num_open_segments(Reader),
       snapshot_index => case ra_snapshot:current(SnapshotState) of
                             undefined -> undefined;
                             {I, _} -> I
@@ -658,41 +659,61 @@ delete_everything(#?MODULE{directory = Dir} = Log) ->
 
 -spec release_resources(non_neg_integer(), state()) -> state().
 release_resources(MaxOpenSegments,
-                  #?MODULE{open_segments = OpenSegs} = State) ->
+                  #?MODULE{uid = UId,
+                           first_index = FstIdx,
+                           reader = Reader} = State) ->
+    ActiveSegs = ra_log_reader:segment_refs(Reader),
     % close all open segments
     % deliberately ignoring return value
-    _ = ra_flru:evict_all(OpenSegs),
+    _ = ra_log_reader:close(Reader),
     %% open a new segment with the new max open segment value
-    State#?MODULE{open_segments = ra_flru:new(MaxOpenSegments,
-                                              fun flru_handler/1)}.
+    State#?MODULE{reader = ra_log_reader:init(UId, FstIdx, MaxOpenSegments,
+                                              ActiveSegs)}.
+
+-spec register_reader(pid(), state()) ->
+    {state(), effects()}.
+register_reader(Pid, #?MODULE{uid = UId,
+                              first_index = Idx,
+                              reader = Reader,
+                              readers = Readers} = State) ->
+    SegRefs = ra_log_reader:segment_refs(Reader),
+    {State#?MODULE{readers = [Pid | Readers]},
+     [{reply, {ok, UId, Idx, SegRefs}},
+      {monitor, process, log, Pid}]}.
+
+readers(#?MODULE{readers = Readers}) ->
+    Readers.
+
 
 %%% Local functions
+
+log_update_effects(Pids, ReplyPid, #?MODULE{first_index = Idx,
+                                            reader = Reader}) ->
+    SegRefs = ra_log_reader:segment_refs(Reader),
+    [{send_msg, P, {ra_log_update, ReplyPid, Idx, SegRefs},
+      [ra_event, local]} || P <- Pids].
+
 
 %% deletes all segments where the last index is lower or equal to
 %% the Idx argumement
 delete_segments(Idx, #?MODULE{log_id = LogId,
                               uid = UId,
-                              open_segments = OpenSegs0,
-                              segment_refs = SegRefs0} = State0) ->
-    case lists:partition(fun({_, To, _}) when To > Idx -> true;
-                            (_) -> false
-                         end, SegRefs0) of
-        {_, []} ->
-            State0;
-        {Active, [Pivot | _] = Obsolete} ->
-            ObsoleteKeys = [element(3, O) || O <- Obsolete],
-            % close any open segments
-            OpenSegs = lists:foldl(fun (K, OS0) ->
-                                           case ra_flru:evict(K, OS0) of
-                                               {_, OS} -> OS;
-                                               error -> OS0
-                                           end
-                                   end, OpenSegs0, ObsoleteKeys),
-            ok = ra_log_segment_writer:truncate_segments(UId, Pivot),
+                              readers = Readers,
+                              reader = Reader0} = State0) ->
+    case ra_log_reader:update_first_index(Idx, Reader0) of
+        {Reader, []} ->
+            State = State0#?MODULE{reader = Reader},
+            {State, log_update_effects(Readers, undefined, State)};
+        {Reader, [Pivot | _] = Obsolete} ->
+            Pid = spawn(fun () ->
+                          ok = log_update_wait_n(length(Readers)),
+                          ok = ra_log_segment_writer:truncate_segments(UId, Pivot)
+                  end),
+            Active = ra_log_reader:segment_refs(Reader),
             ?DEBUG("~s: ~b obsolete segments at ~b - remaining: ~b",
-                   [LogId, length(ObsoleteKeys), Idx, length(Active)]),
-            State0#?MODULE{open_segments = OpenSegs,
-                           segment_refs = Active}
+                   [LogId, length(Obsolete), Idx, length(Active)]),
+            State = State0#?MODULE{reader = Reader},
+            {State, log_update_effects(Readers, Pid, State)}
     end.
 
 wal_truncate_write(#?MODULE{uid = UId, cache = Cache, wal = Wal} = State,
@@ -702,14 +723,14 @@ wal_truncate_write(#?MODULE{uid = UId, cache = Cache, wal = Wal} = State,
     % and that prior entries should be considered stale
     ok = ra_log_wal:truncate_write({UId, self()}, Wal, Idx, Term, Data),
     State#?MODULE{last_index = Idx, last_term = Term,
-                  cache = Cache#{Idx => {Term, Data}}}.
+                  cache = Cache#{Idx => {Idx, Term, Data}}}.
 
 wal_write(#?MODULE{uid = UId, cache = Cache, wal = Wal} = State,
           {Idx, Term, Data}) ->
     case ra_log_wal:write({UId, self()}, Wal, Idx, Term, Data) of
         ok ->
             State#?MODULE{last_index = Idx, last_term = Term,
-                          cache = Cache#{Idx => {Term, Data}}};
+                          cache = Cache#{Idx => {Idx, Term, Data}}};
         {error, wal_down} ->
             exit(wal_down)
     end.
@@ -720,7 +741,7 @@ wal_write_batch(#?MODULE{uid = UId, cache = Cache0, wal = Wal} = State,
     {WalCommands, Cache} =
         lists:foldl(fun ({Idx, Term, Data}, {WC, C0}) ->
                             WalC = {append, WriterId, Idx, Term, Data},
-                            {[WalC | WC], C0#{Idx => {Term, Data}}}
+                            {[WalC | WC], C0#{Idx => {Idx, Term, Data}}}
                     end, {[], Cache0}, Entries),
 
     [{_, _, LastIdx, LastTerm, _} | _] = WalCommands,
@@ -765,149 +786,6 @@ update_metrics(Id, Ops) ->
     _ = ets:update_counter(ra_log_metrics, Id, Ops),
     ok.
 
-open_mem_tbl_take(Id, {Start0, End}, MetricOps, Acc0) ->
-    case ets:lookup(ra_log_open_mem_tables, Id) of
-        [{_, TStart, TEnd, Tid}] ->
-            {Entries, Count, Rem} = mem_tbl_take({Start0, End}, TStart, TEnd,
-                                                 Tid, 0, Acc0),
-            {Entries, [{?METRICS_OPEN_MEM_TBL_POS, Count} | MetricOps], Rem};
-        [] ->
-            {Acc0, MetricOps, {Start0, End}}
-    end.
-
-closed_mem_tbl_take(Id, {Start0, End}, MetricOps, Acc0) ->
-    case closed_mem_tables(Id) of
-        [] ->
-            {Acc0, MetricOps, {Start0, End}};
-        Tables ->
-            {Entries, Count, Rem} =
-            lists:foldl(fun({_, _, TblSt, TblEnd, Tid}, {Ac, Count, Range}) ->
-                                mem_tbl_take(Range, TblSt, TblEnd,
-                                             Tid, Count, Ac)
-                        end, {Acc0, 0, {Start0, End}}, Tables),
-            {Entries, [{?METRICS_CLOSED_MEM_TBL_POS, Count} | MetricOps], Rem}
-    end.
-
-closed_mem_table_term_query(Idx, Id) ->
-    case closed_mem_tables(Id) of
-        [] ->
-            undefined;
-        Tables ->
-            closed_mem_table_term_query0(Idx, Tables)
-    end.
-
-closed_mem_table_term_query0(_Idx, []) ->
-    undefined;
-closed_mem_table_term_query0(Idx, [{_, _, From, To, Tid} | _Tail])
-  when Idx >= From andalso Idx =< To ->
-    ets:lookup_element(Tid, Idx, 2);
-closed_mem_table_term_query0(Idx, [_ | Tail]) ->
-    closed_mem_table_term_query0(Idx, Tail).
-
-closed_mem_tables(Id) ->
-    case ets:lookup(ra_log_closed_mem_tables, Id) of
-        [] ->
-            [];
-        Tables ->
-            lists:sort(fun (A, B) ->
-                               element(2, A) > element(2, B)
-                       end, Tables)
-    end.
-
-mem_tbl_take(undefined, _TblStart, _TblEnd, _Tid, Count, Acc0) ->
-    {Acc0, Count, undefined};
-mem_tbl_take({_Start0, End} = Range, TblStart, _TblEnd, _Tid, Count, Acc0)
-  when TblStart > End ->
-    % optimisation to bypass request that has no overlap
-    {Acc0, Count, Range};
-mem_tbl_take({Start0, End}, TblStart, TblEnd, Tid, Count, Acc0)
-  when TblEnd >= End ->
-    Start = max(TblStart, Start0),
-    Entries = lookup_range(Tid, Start, End, Acc0),
-    Remainder = case Start =:= Start0 of
-                    true ->
-                        % the range was fully covered by the mem table
-                        undefined;
-                    false ->
-                        {Start0, Start-1}
-                end,
-    {Entries, Count + (End - Start + 1), Remainder}.
-
-lookup_range(Tid, Start, Start, Acc) ->
-    [Entry] = ets:lookup(Tid, Start),
-    [Entry | Acc];
-lookup_range(Tid, Start, End, Acc) when End > Start ->
-    [Entry] = ets:lookup(Tid, End),
-    lookup_range(Tid, Start, End-1, [Entry | Acc]).
-
-
-segment_take(#?MODULE{segment_refs = SegRefs,
-                      open_segments = OpenSegs,
-                      directory = Dir},
-             Range, Entries0) ->
-    lists:foldl(
-      fun(_, {_, undefined, _} = Acc) ->
-              %% we're done reading
-              throw(Acc);
-         ({From, _, _}, {_, {_, End}, _} = Acc)
-           when From > End ->
-              Acc;
-         ({From, To, Fn}, {Open0, {Start0, End}, E0})
-           when To >= End ->
-              {Seg, Open} =
-                  case ra_flru:fetch(Fn, Open0) of
-                      {ok, S, Open1} ->
-                          {S, Open1};
-                      error ->
-                          AbsFn = filename:join(Dir, Fn),
-                          case ra_log_segment:open(AbsFn, #{mode => read}) of
-                              {ok, S} ->
-                                  {S, ra_flru:insert(Fn, S, Open0)};
-                              {error, Err} ->
-                                  exit({ra_log_failed_to_open_segment, Err,
-                                        AbsFn})
-                          end
-                  end,
-
-              % actual start point cannot be prior to first segment
-              % index
-              Start = max(Start0, From),
-              Num = End - Start + 1,
-              Entries = ra_log_segment:read_cons(Seg, Start, Num,
-                                                 fun binary_to_term/1,
-                                                 E0),
-              Rem = case Start of
-                        Start0 -> undefined;
-                        _ ->
-                            {Start0, Start-1}
-                    end,
-              {Open, Rem, Entries}
-      end, {OpenSegs, Range, Entries0}, SegRefs).
-
-segment_term_query(Idx, #?MODULE{segment_refs = SegRefs,
-                                 directory = Dir,
-                                 open_segments = OpenSegs} = State) ->
-    {Result, Open} = segment_term_query0(Idx, SegRefs, OpenSegs, Dir),
-    {Result, State#?MODULE{open_segments = Open}}.
-
-segment_term_query0(Idx, [{From, To, Filename} | _], Open0, Dir)
-  when Idx >= From andalso Idx =< To ->
-    case ra_flru:fetch(Filename, Open0) of
-        {ok, Seg, Open} ->
-            Term = ra_log_segment:term_query(Seg, Idx),
-            {Term, Open};
-        error ->
-            AbsFn = filename:join(Dir, Filename),
-            {ok, Seg} = ra_log_segment:open(AbsFn, #{mode => read}),
-            Term = ra_log_segment:term_query(Seg, Idx),
-            {Term, ra_flru:insert(Filename, Seg, Open0)}
-    end;
-segment_term_query0(Idx, [_ | Tail], Open, Dir) ->
-    segment_term_query0(Idx, Tail, Open, Dir);
-segment_term_query0(_Idx, [], Open, _) ->
-    {undefined, Open}.
-
-
 cache_take(Start, Num, #?MODULE{cache = Cache, last_index = LastIdx}) ->
     Highest = min(LastIdx, Start + Num - 1),
     % cache needs to be queried in reverse to ensure
@@ -930,8 +808,7 @@ cache_take0(Next, Last, _Cache, Acc)
 cache_take0(Next, Last, Cache, Acc) ->
     case Cache of
         #{Next := Entry} ->
-            cache_take0(Next-1, Last, Cache,
-                        [erlang:insert_element(1, Entry, Next) | Acc]);
+            cache_take0(Next-1, Last, Cache, [Entry | Acc]);
         _ ->
             Acc
     end.
@@ -961,8 +838,7 @@ resend_from0(Idx, #?MODULE{last_index = LastIdx,
     ?DEBUG("~s: ra_log: resending from ~b to ~b",
            [State#?MODULE.log_id, Idx, LastIdx]),
     lists:foldl(fun (I, Acc) ->
-                        X = maps:get(I, Cache),
-                        wal_write(Acc, erlang:insert_element(1, X, I))
+                        wal_write(Acc, maps:get(I, Cache))
                 end,
                 State#?MODULE{last_resend_time = erlang:system_time(seconds)},
                 % TODO: replace with recursive function
@@ -977,19 +853,6 @@ resend_from0(Idx, #?MODULE{last_resend_time = LastResend,
         false ->
             State
     end.
-
-
-compact_seg_refs(SegRefs) ->
-    lists:reverse(
-      lists:foldl(fun ({_, _, File} = S, Acc) ->
-                          case lists:any(fun({_, _, F}) when F =:= File ->
-                                                 true;
-                                            (_) -> false
-                                         end, Acc) of
-                              true -> Acc;
-                              false -> [S | Acc]
-                          end
-                  end, [], SegRefs)).
 
 verify_entries(_, []) ->
     ok;
@@ -1021,10 +884,6 @@ write_snapshot(Meta, MacRef,
                #?MODULE{snapshot_state = SnapState0} = State) ->
     {SnapState, Effects} = ra_snapshot:begin_snapshot(Meta, MacRef, SnapState0),
     {State#?MODULE{snapshot_state = SnapState}, Effects}.
-
-flru_handler({_, Seg}) ->
-    _ = ra_log_segment:close(Seg),
-    ok.
 
 recover_range(UId, _SnapIdx) ->
     % 0. check open mem_tables (this assumes wal has finished recovering
@@ -1081,70 +940,44 @@ await_written_idx(Idx, Term, Log0) ->
               throw(ra_log_append_timeout)
     end.
 
+closed_mem_tables(Id) ->
+    case ets:lookup(ra_log_closed_mem_tables, Id) of
+        [] ->
+            [];
+        Tables ->
+            lists:sort(fun (A, B) ->
+                               element(2, A) > element(2, B)
+                       end, Tables)
+    end.
+
+
+log_update_wait_n(0) ->
+    ok;
+log_update_wait_n(N) ->
+    receive
+        ra_log_update_processed ->
+            log_update_wait_n(N - 1)
+    after 1500 ->
+              %% just go ahead anyway
+              ok
+    end.
 
 %%%% TESTS
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
-compact_seg_refs_test() ->
-    % {From, To, File}
-    Refs = [{10, 100, "2"}, {10, 75, "2"}, {10, 50, "2"}, {1, 9, "1"}],
-    [{10, 100, "2"}, {1, 9, "1"}] = compact_seg_refs(Refs),
-    ok.
-
 cache_take0_test() ->
-    Cache = #{1 => {a}, 2 => {b}, 3 => {c}},
+    Cache = #{1 => {1, 9, a}, 2 => {2, 9, b}, 3 => {3, 9, c}},
     State = #?MODULE{cache = Cache, last_index = 3, first_index = 1},
     % no remainder
-    {[{2, b}], _, undefined} = cache_take(2, 1, State),
-    {[{2, b}, {3, c}], _,  undefined} = cache_take(2, 2, State),
-    {[{1, a}, {2, b}, {3, c}], _, undefined} = cache_take(1, 3, State),
+    {[{2, 9, b}], _, undefined} = cache_take(2, 1, State),
+    {[{2, 9, b}, {3, 9, c}], _,  undefined} = cache_take(2, 2, State),
+    {[{1, 9, a}, {2, 9, b}, {3, 9, c}], _, undefined} = cache_take(1, 3, State),
     % small remainder
-    {[{3, c}], _, {1, 2}} = cache_take(1, 3, State#?MODULE{cache = #{3 => {c}}}),
-    {[], _, {1, 3}} = cache_take(1, 3, State#?MODULE{cache = #{4 => {d}}}),
-    ok.
-
-open_mem_tbl_take_test() ->
-    _ = ets:new(ra_log_open_mem_tables, [named_table]),
-    Tid = ets:new(test_id, []),
-    true = ets:insert(ra_log_open_mem_tables, {test_id, 3, 7, Tid}),
-    Entries = [{3, 2, "3"}, {4, 2, "4"},
-               {5, 2, "5"}, {6, 2, "6"},
-               {7, 2, "7"}],
-    % seed the mem table
-    [ets:insert(Tid, E) || E <- Entries],
-
-    {Entries, _, undefined} = open_mem_tbl_take(test_id, {3, 7}, [], []),
-    EntriesPlus8 = Entries ++ [{8, 2, "8"}],
-    {EntriesPlus8, _, {1, 2}} = open_mem_tbl_take(test_id, {1, 7}, [],
-                                                  [{8, 2, "8"}]),
-    {[{6, 2, "6"}], _, undefined} = open_mem_tbl_take(test_id, {6, 6}, [], []),
-    {[], _, {1, 2}} = open_mem_tbl_take(test_id, {1, 2}, [], []),
-
-    ets:delete(Tid),
-    ets:delete(ra_log_open_mem_tables),
-
-    ok.
-
-closed_mem_tbl_take_test() ->
-    _ = ets:new(ra_log_closed_mem_tables, [named_table, bag]),
-    Tid1 = ets:new(test_id, []),
-    Tid2 = ets:new(test_id, []),
-    M1 = erlang:unique_integer([monotonic, positive]),
-    M2 = erlang:unique_integer([monotonic, positive]),
-    true = ets:insert(ra_log_closed_mem_tables, {test_id, M1, 5, 7, Tid1}),
-    true = ets:insert(ra_log_closed_mem_tables, {test_id, M2, 8, 10, Tid2}),
-    Entries1 = [{5, 2, "5"}, {6, 2, "6"}, {7, 2, "7"}],
-    Entries2 = [{8, 2, "8"}, {9, 2, "9"}, {10, 2, "10"}],
-    % seed the mem tables
-    [ets:insert(Tid1, E) || E <- Entries1],
-    [ets:insert(Tid2, E) || E <- Entries2],
-
-    {Entries1, _, undefined} = closed_mem_tbl_take(test_id, {5, 7}, [], []),
-    {Entries2, _, undefined} = closed_mem_tbl_take(test_id, {8, 10}, [], []),
-    {[{9, 2, "9"}], _, undefined} = closed_mem_tbl_take(test_id, {9, 9},
-                                                        [], []),
+    {[{3, 9, c}], _, {1, 2}} = cache_take(1, 3,
+                                             State#?MODULE{cache = #{3 => {3, 9, c}}}),
+    {[], _, {1, 3}} = cache_take(1, 3, State#?MODULE{cache = #{4 => {4, 9, d}}}),
     ok.
 
 pick_range_test() ->

--- a/src/ra_log_ets.erl
+++ b/src/ra_log_ets.erl
@@ -49,6 +49,8 @@ init([DataDir]) ->
     _ = ets:new(ra_log_open_mem_tables, [set | TableFlags]),
     _ = ets:new(ra_log_closed_mem_tables, [bag | TableFlags]),
 
+    _ = ra_counters:init(),
+
     %% Table for ra processes to record their current snapshot index so that
     %% other processes such as the segment writer can use this value to skip
     %% stale records and avoid flushing unnecessary data to disk.

--- a/src/ra_log_reader.erl
+++ b/src/ra_log_reader.erl
@@ -1,0 +1,402 @@
+-module(ra_log_reader).
+
+-compile(inline_list_funcs).
+
+-export([
+         init/4,
+         close/1,
+         update_segments/2,
+         handle_log_update/2,
+         segment_refs/1,
+         num_open_segments/1,
+         update_first_index/2,
+         read/3,
+         fetch_term/2
+         ]).
+
+-include("ra.hrl").
+
+-define(STATE, ?MODULE).
+
+%% TODO: these could be captured in a record
+-define(METRICS_OPEN_MEM_TBL_POS, 3).
+-define(METRICS_CLOSED_MEM_TBL_POS, 4).
+-define(METRICS_SEGMENT_POS, 5).
+
+%% holds static or rarely changing fields
+-record(cfg, {uid :: ra_uid(),
+              directory :: file:filename()}).
+
+-type segment_ref() :: {From :: ra_index(), To :: ra_index(),
+                        File :: string()}.
+-record(?STATE, {cfg :: #cfg{},
+                 first_index = 0 :: ra_index(),
+                 segment_refs = [] :: [segment_ref()],
+                 open_segments = ra_flru:new(1, fun flru_handler/1) :: ra_flru:state()
+                }).
+
+-opaque state() :: #?STATE{}.
+
+-export_type([
+              state/0
+              ]).
+
+%% PUBLIC
+
+-spec init(ra_uid(), ra_index(), non_neg_integer(), [segment_ref()]) -> state().
+init(UId, FirstIdx, MaxOpen, SegRefs) ->
+    #?STATE{cfg = #cfg{uid = UId,
+                       directory = ra_env:server_data_dir(UId)},
+            open_segments = ra_flru:new(MaxOpen, fun flru_handler/1),
+            first_index = FirstIdx,
+            segment_refs = SegRefs}.
+
+-spec close(state()) -> ok.
+close(#?STATE{open_segments = Open}) ->
+    _ = ra_flru:evict_all(Open),
+    ok.
+
+-spec update_segments([segment_ref()], state()) -> state().
+update_segments(NewSegmentRefs,
+                #?STATE{open_segments = Open0,
+                        segment_refs = SegmentRefs0} = State) ->
+    SegmentRefs = compact_seg_refs(NewSegmentRefs ++ SegmentRefs0),
+    %% check if any of the updated segrefs refer to open segments
+    %% we close these segments so that they can be re-opened with updated
+    %% indexes if needed
+    Open = lists:foldl(fun ({_, _, F}, Acc0) ->
+                               case ra_flru:evict(F, Acc0) of
+                                   {_, Acc} -> Acc;
+                                   error -> Acc0
+                               end
+                       end, Open0, SegmentRefs),
+    State#?MODULE{segment_refs = SegmentRefs,
+                  open_segments = Open}.
+
+-spec handle_log_update({ra_log_update, undefined | pid(), ra_index(),
+                         [segment_ref()]}, state()) -> state().
+handle_log_update({ra_log_update, From, FstIdx, SegRefs},
+                  #?STATE{open_segments = Open0} = State) ->
+    Open = ra_flru:evict_all(Open0),
+    case From of
+        undefined -> ok;
+        _ ->
+            %% reply to the updater process
+            From ! ra_log_update_processed
+    end,
+    State#?MODULE{segment_refs = SegRefs,
+                  first_index = FstIdx,
+                  open_segments = Open}.
+
+-spec update_first_index(ra_index(), state()) ->
+    {state(), [segment_ref()]}.
+update_first_index(Idx, #?STATE{segment_refs = SegRefs0,
+                                open_segments = OpenSegs0} = State) ->
+    case lists:partition(fun({_, To, _}) when To > Idx -> true;
+                            (_) -> false
+                         end, SegRefs0) of
+        {_, []} ->
+            {State, []};
+        {Active, Obsolete} ->
+            ObsoleteKeys = [element(3, O) || O <- Obsolete],
+            % close any open segments
+            OpenSegs = lists:foldl(fun (K, OS0) ->
+                                           case ra_flru:evict(K, OS0) of
+                                               {_, OS} -> OS;
+                                               error -> OS0
+                                           end
+                                   end, OpenSegs0, ObsoleteKeys),
+            {State#?STATE{open_segments = OpenSegs,
+                          first_index = Idx,
+                          segment_refs = Active},
+             Obsolete}
+    end.
+
+-spec segment_refs(state()) -> [segment_ref()].
+segment_refs(#?STATE{segment_refs = SegmentRefs}) ->
+    SegmentRefs.
+
+-spec num_open_segments(state()) -> non_neg_integer().
+num_open_segments(#?STATE{open_segments = Open}) ->
+     ra_flru:size(Open).
+
+-spec read(ra_index(), ra_index(), state()) ->
+    {[log_entry()], Metrics :: list(), state()}.
+read(From, To, State) when From =< To ->
+    retry_read(2, From, To, State);
+read(_From, _To, State) ->
+    {[], [], State}.
+
+retry_read(0, From, To, State) ->
+    exit({ra_log_reader_reader_retry_exhausted, From, To, State});
+retry_read(N, From, To, #?STATE{cfg = #cfg{uid = UId}} = State) ->
+    % 2. Check ra_log_open_mem_tables
+    % 3. Check ra_log_closed_mem_tables in turn
+    % 4. Check on disk segments in turn
+    case open_mem_tbl_take(UId, {From, To}, [], []) of
+        {Entries1, MetricOps, undefined} ->
+            {Entries1, MetricOps, State};
+        {Entries1, MetricOps1, Rem1} ->
+            case catch closed_mem_tbl_take(UId, Rem1, MetricOps1, Entries1) of
+                {Entries2, MetricOps, undefined} ->
+                    {Entries2, MetricOps, State};
+                {Entries2, MetricOps2, {S, E} = Rem2} ->
+                    case catch segment_take(State, Rem2, Entries2) of
+                        {Open, undefined, Entries} ->
+                            MOp = {?METRICS_SEGMENT_POS, E - S + 1},
+                            {Entries, [MOp | MetricOps2],
+                             State#?MODULE{open_segments = Open}}
+                    end;
+                {ets_miss, _Index} ->
+                    %% this would happend if a mem table was deleted after
+                    %% an external reader had read the range
+                    retry_read(N-1, From, To, State)
+            end
+    end.
+
+
+-spec fetch_term(ra_index(), state()) -> {ra_index(), state()}.
+fetch_term(Idx, #?STATE{cfg = #cfg{uid = UId}} = State0) ->
+    case ets:lookup(ra_log_open_mem_tables, UId) of
+        [{_, From, To, Tid}] when Idx >= From andalso Idx =< To ->
+            Term = ets:lookup_element(Tid, Idx, 2),
+            {Term, State0};
+        _ ->
+            case closed_mem_table_term_query(Idx, UId) of
+                undefined ->
+                    segment_term_query(Idx, State0);
+                Term ->
+                    {Term, State0}
+            end
+    end.
+
+%% LOCAL
+
+segment_term_query(Idx, #?MODULE{segment_refs = SegRefs,
+                                 cfg = #cfg{directory = Dir},
+                                 open_segments = OpenSegs} = State) ->
+    {Result, Open} = segment_term_query0(Idx, SegRefs, OpenSegs, Dir),
+    {Result, State#?MODULE{open_segments = Open}}.
+
+segment_term_query0(Idx, [{From, To, Filename} | _], Open0, Dir)
+  when Idx >= From andalso Idx =< To ->
+    case ra_flru:fetch(Filename, Open0) of
+        {ok, Seg, Open} ->
+            Term = ra_log_segment:term_query(Seg, Idx),
+            {Term, Open};
+        error ->
+            AbsFn = filename:join(Dir, Filename),
+            {ok, Seg} = ra_log_segment:open(AbsFn, #{mode => read}),
+            Term = ra_log_segment:term_query(Seg, Idx),
+            {Term, ra_flru:insert(Filename, Seg, Open0)}
+    end;
+segment_term_query0(Idx, [_ | Tail], Open, Dir) ->
+    segment_term_query0(Idx, Tail, Open, Dir);
+segment_term_query0(_Idx, [], Open, _) ->
+    {undefined, Open}.
+
+open_mem_tbl_take(Id, {Start0, End}, MetricOps, Acc0) ->
+    case ets:lookup(ra_log_open_mem_tables, Id) of
+        [{_, TStart, TEnd, Tid}] ->
+            {Entries, Count, Rem} = mem_tbl_take({Start0, End}, TStart, TEnd,
+                                                 Tid, 0, Acc0),
+            {Entries, [{?METRICS_OPEN_MEM_TBL_POS, Count} | MetricOps], Rem};
+        [] ->
+            {Acc0, MetricOps, {Start0, End}}
+    end.
+
+closed_mem_tbl_take(Id, {Start0, End}, MetricOps, Acc0) ->
+    case closed_mem_tables(Id) of
+        [] ->
+            {Acc0, MetricOps, {Start0, End}};
+        Tables ->
+            {Entries, Count, Rem} =
+            lists:foldl(fun({_, _, TblSt, TblEnd, Tid}, {Ac, Count, Range}) ->
+                                mem_tbl_take(Range, TblSt, TblEnd,
+                                             Tid, Count, Ac)
+                        end, {Acc0, 0, {Start0, End}}, Tables),
+            {Entries, [{?METRICS_CLOSED_MEM_TBL_POS, Count} | MetricOps], Rem}
+    end.
+
+mem_tbl_take(undefined, _TblStart, _TblEnd, _Tid, Count, Acc0) ->
+    {Acc0, Count, undefined};
+mem_tbl_take({_Start0, End} = Range, TblStart, _TblEnd, _Tid, Count, Acc0)
+  when TblStart > End ->
+    % optimisation to bypass request that has no overlap
+    {Acc0, Count, Range};
+mem_tbl_take({Start0, End}, TblStart, TblEnd, Tid, Count, Acc0)
+  when TblEnd >= End ->
+    Start = max(TblStart, Start0),
+    Entries = lookup_range(Tid, Start, End, Acc0),
+    Remainder = case Start =:= Start0 of
+                    true ->
+                        % the range was fully covered by the mem table
+                        undefined;
+                    false ->
+                        {Start0, Start-1}
+                end,
+    {Entries, Count + (End - Start + 1), Remainder};
+mem_tbl_take({Start0, End}, TblStart, TblEnd, Tid, Count, Acc0)
+  when TblEnd < End ->
+    %% defensive case - truncate the read to end at table end
+    mem_tbl_take({Start0, TblEnd}, TblStart, TblEnd, Tid, Count, Acc0).
+
+lookup_range(Tid, Start, Start, Acc) ->
+    try ets:lookup(Tid, Start) of
+        [Entry] ->
+            [Entry | Acc]
+    catch
+        error:badarg ->
+            throw({ets_miss, Start})
+    end;
+lookup_range(Tid, Start, End, Acc) when End > Start ->
+    try ets:lookup(Tid, End) of
+        [Entry] ->
+            lookup_range(Tid, Start, End-1, [Entry | Acc])
+    catch
+        error:badarg ->
+            throw({ets_miss, Start})
+    end.
+
+segment_take(#?STATE{segment_refs = [],
+                     open_segments = Open},
+             _Range, Entries0) ->
+    {Open, undefined, Entries0};
+segment_take(#?STATE{segment_refs = [{_From, SEnd, _Fn} | _] = SegRefs,
+                     open_segments = OpenSegs,
+                     cfg = #cfg{directory = Dir}},
+             {RStart, REnd}, Entries0) ->
+    Range = {RStart, min(SEnd, REnd)},
+    lists:foldl(
+      fun(_, {_, undefined, _} = Acc) ->
+              %% we're done reading
+              throw(Acc);
+         ({From, _, _}, {_, {_, End}, _} = Acc)
+           when From > End ->
+              Acc;
+         ({From, To, Fn}, {Open0, {Start0, End}, E0})
+           when To >= End ->
+              {Seg, Open} =
+                  case ra_flru:fetch(Fn, Open0) of
+                      {ok, S, Open1} ->
+                          {S, Open1};
+                      error ->
+                          AbsFn = filename:join(Dir, Fn),
+                          case ra_log_segment:open(AbsFn, #{mode => read}) of
+                              {ok, S} ->
+                                  {S, ra_flru:insert(Fn, S, Open0)};
+                              {error, Err} ->
+                                  exit({ra_log_failed_to_open_segment, Err,
+                                        AbsFn})
+                          end
+                  end,
+
+              % actual start point cannot be prior to first segment
+              % index
+              Start = max(Start0, From),
+              Num = End - Start + 1,
+              Entries = ra_log_segment:read_cons(Seg, Start, Num,
+                                                 fun binary_to_term/1,
+                                                 E0),
+              Rem = case Start of
+                        Start0 -> undefined;
+                        _ ->
+                            {Start0, Start-1}
+                    end,
+              {Open, Rem, Entries}
+      end, {OpenSegs, Range, Entries0}, SegRefs).
+
+flru_handler({_, Seg}) ->
+    _ = ra_log_segment:close(Seg),
+    ok.
+
+closed_mem_tables(Id) ->
+    case ets:lookup(ra_log_closed_mem_tables, Id) of
+        [] ->
+            [];
+        Tables ->
+            lists:sort(fun (A, B) ->
+                               element(2, A) > element(2, B)
+                       end, Tables)
+    end.
+
+closed_mem_table_term_query(Idx, Id) ->
+    case closed_mem_tables(Id) of
+        [] ->
+            undefined;
+        Tables ->
+            closed_mem_table_term_query0(Idx, Tables)
+    end.
+
+closed_mem_table_term_query0(_Idx, []) ->
+    undefined;
+closed_mem_table_term_query0(Idx, [{_, _, From, To, Tid} | _Tail])
+  when Idx >= From andalso Idx =< To ->
+    ets:lookup_element(Tid, Idx, 2);
+closed_mem_table_term_query0(Idx, [_ | Tail]) ->
+    closed_mem_table_term_query0(Idx, Tail).
+
+compact_seg_refs(SegRefs) ->
+    lists:reverse(
+      lists:foldl(
+        fun ({_, _, File} = S, Acc) ->
+                case lists:any(fun({_, _, F}) when F =:= File ->
+                                       true;
+                                  (_) -> false
+                               end, Acc) of
+                    true -> Acc;
+                    false -> [S | Acc]
+                end
+        end, [], SegRefs)).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+open_mem_tbl_take_test() ->
+    _ = ets:new(ra_log_open_mem_tables, [named_table]),
+    Tid = ets:new(test_id, []),
+    true = ets:insert(ra_log_open_mem_tables, {test_id, 3, 7, Tid}),
+    Entries = [{3, 2, "3"}, {4, 2, "4"},
+               {5, 2, "5"}, {6, 2, "6"},
+               {7, 2, "7"}],
+    % seed the mem table
+    [ets:insert(Tid, E) || E <- Entries],
+
+    {Entries, _, undefined} = open_mem_tbl_take(test_id, {3, 7}, [], []),
+    EntriesPlus8 = Entries ++ [{8, 2, "8"}],
+    {EntriesPlus8, _, {1, 2}} = open_mem_tbl_take(test_id, {1, 7}, [],
+                                                  [{8, 2, "8"}]),
+    {[{6, 2, "6"}], _, undefined} = open_mem_tbl_take(test_id, {6, 6}, [], []),
+    {[], _, {1, 2}} = open_mem_tbl_take(test_id, {1, 2}, [], []),
+
+    ets:delete(Tid),
+    ets:delete(ra_log_open_mem_tables),
+
+    ok.
+
+closed_mem_tbl_take_test() ->
+    _ = ets:new(ra_log_closed_mem_tables, [named_table, bag]),
+    Tid1 = ets:new(test_id, []),
+    Tid2 = ets:new(test_id, []),
+    M1 = erlang:unique_integer([monotonic, positive]),
+    M2 = erlang:unique_integer([monotonic, positive]),
+    true = ets:insert(ra_log_closed_mem_tables, {test_id, M1, 5, 7, Tid1}),
+    true = ets:insert(ra_log_closed_mem_tables, {test_id, M2, 8, 10, Tid2}),
+    Entries1 = [{5, 2, "5"}, {6, 2, "6"}, {7, 2, "7"}],
+    Entries2 = [{8, 2, "8"}, {9, 2, "9"}, {10, 2, "10"}],
+    % seed the mem tables
+    [ets:insert(Tid1, E) || E <- Entries1],
+    [ets:insert(Tid2, E) || E <- Entries2],
+
+    {Entries1, _, undefined} = closed_mem_tbl_take(test_id, {5, 7}, [], []),
+    {Entries2, _, undefined} = closed_mem_tbl_take(test_id, {8, 10}, [], []),
+    {[{9, 2, "9"}], _, undefined} = closed_mem_tbl_take(test_id, {9, 9},
+                                                        [], []),
+    ok.
+
+compact_seg_refs_test() ->
+    % {From, To, File}
+    Refs = [{10, 100, "2"}, {10, 75, "2"}, {10, 50, "2"}, {1, 9, "1"}],
+    [{10, 100, "2"}, {1, 9, "1"}] = compact_seg_refs(Refs),
+    ok.
+-endif.

--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -23,6 +23,7 @@
          ]).
 
 -record(state, {data_dir :: file:filename(),
+                counter :: counters:counters_ref(),
                 segment_conf = #{} :: ra_log_segment:ra_log_segment_options()}).
 
 -include("ra.hrl").
@@ -99,8 +100,10 @@ await(SegWriter)  ->
 
 init([#{data_dir := DataDir} = Conf]) ->
     process_flag(trap_exit, true),
+    CRef = ra_counters:new(?MODULE, 2),
     SegmentConf = maps:get(segment_conf, Conf, #{}),
     {ok, #state{data_dir = DataDir,
+                counter = CRef,
                 segment_conf = SegmentConf}}.
 
 handle_call(await, _From, State) ->
@@ -218,7 +221,11 @@ do_segment({ServerUId, StartIdx0, EndIdx, Tid},
 
                     % notify writerid of new segment update
                     % includes the full range of the segment
-                    ClosedSegRefs = [ra_log_segment:segref(S) || S <- Closed0],
+                    % filter out any undefined segrefs
+                    ClosedSegRefs = [ra_log_segment:segref(S)
+                                     || S <- Closed0,
+                                        %% ensure we don't send undefined seg refs
+                                        is_tuple(ra_log_segment:segref(S))],
                     SegRefs = case ra_log_segment:segref(Segment) of
                                   undefined ->
                                       ClosedSegRefs;

--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -44,9 +44,6 @@
 
 -record(batch, {writes = 0 :: non_neg_integer(),
                 waiting = #{} :: #{pid() => #batch_writer{}},
-                                   % {From :: ra_index(), To :: ra_index(),
-                                   %  Term :: ra_term()}},
-                start_time :: maybe(integer()),
                 pending = [] :: iolist()
                }).
 
@@ -66,7 +63,8 @@
                compute_checksums = false :: boolean(),
                max_size_bytes = ?MAX_SIZE_BYTES :: non_neg_integer(),
                write_strategy = default :: wal_write_strategy(),
-               sync_method = datasync :: sync | datasync
+               sync_method = datasync :: sync | datasync,
+               counter :: counters:counters_ref()
               }).
 
 -record(wal, {fd :: maybe(file:io_device()),
@@ -194,23 +192,21 @@ init(#{dir := Dir} = Conf0) ->
     % at times receive large number of messages from a large number of
     % writers
     process_flag(message_queue_data, off_heap),
-    _ = ets:new(ra_log_wal_metrics,
-                [set, named_table, {read_concurrency, true}, protected]),
+    CRef = ra_counters:new(?MODULE, 3),
     % seed metrics table with data
-    [true = ets:insert(ra_log_wal_metrics, {I, undefined})
-     || I <- lists:seq(0, ?METRICS_WINDOW_SIZE-1)],
     % wait for the segment writer to process anything in flight
     ok = ra_log_segment_writer:await(SegWriter),
     %% TODO: recover wal should return {stop, Reason} if it fails
     %% rather than crash
-    FileModes = [raw, append, binary],
+    FileModes = [raw, write, binary],
     Conf = #conf{file_modes = FileModes,
                  dir = Dir,
                  segment_writer = SegWriter,
                  compute_checksums = ComputeChecksums,
                  max_size_bytes = MaxWalSize,
                  write_strategy = WriteStrategy,
-                 sync_method = SyncMethod},
+                 sync_method = SyncMethod,
+                 counter = CRef},
     {ok, recover_wal(Dir, Conf)}.
 
 -spec handle_batch([wal_op()], state()) ->
@@ -489,6 +485,7 @@ roll_over(OpnMemTbls, #state{wal = Wal0, file_num = Num0,
                                           max_size_bytes = MaxBytes,
                                           segment_writer = SegWriter} = Conf0}
           = State0) ->
+    counters:add(Conf0#conf.counter, 3, 1),
     Num = Num0 + 1,
     Fn = ra_lib:zpad_filename("", "wal", Num),
     NextFile = filename:join(Dir, Fn),
@@ -520,7 +517,6 @@ open_wal(File, Max, #conf{write_strategy = o_sync,
                 ok = write_header(Fd),
                 % many platforms implement O_SYNC a bit like O_DSYNC
                 % perform a manual sync here to ensure metadata is flushed
-                ok = ra_file_handle:sync(Fd),
                 {Conf, #wal{fd = Fd,
                             max_size = Max,
                             filename = File}};
@@ -532,6 +528,7 @@ open_wal(File, Max, #conf{write_strategy = o_sync,
 open_wal(File, Max, #conf{file_modes = Modes} = Conf) ->
     {ok, Fd} = ra_file_handle:open(File, Modes),
     ok = write_header(Fd),
+    ok = ra_file_handle:sync(Fd),
     {Conf, #wal{fd = Fd,
                 max_size = Max,
                 filename = File}}.
@@ -588,8 +585,9 @@ open_mem_table(UId) ->
     true = ra_log_ets:give_away(Tid),
     Tid.
 
-start_batch(State) ->
-    State#state{batch = #batch{start_time = os:system_time(microsecond)}}.
+start_batch(#state{conf = #conf{counter = CRef}} = State) ->
+    ok = counters:add(CRef, 2, 1),
+    State#state{batch = #batch{}}.
 
 
 flush_pending(#state{wal = #wal{fd = Fd},
@@ -609,15 +607,14 @@ flush_pending(#state{wal = #wal{fd = Fd},
 complete_batch(#state{batch = undefined} = State) ->
     State;
 complete_batch(#state{batch = #batch{waiting = Waiting,
-                                     writes = NumWrites,
-                                     start_time = ST},
-                      metrics_cursor = Cursor
+                                     writes = NumWrites},
+                      metrics_cursor = Cursor,
+                      conf = Cfg
                       } = State00) ->
-    TS = os:system_time(microsecond),
+    % TS = os:system_time(microsecond),
     State0 = flush_pending(State00),
-    SyncTS = os:system_time(microsecond),
-    _ = ets:update_element(ra_log_wal_metrics, Cursor,
-                           {2, {NumWrites, TS-ST, SyncTS-TS}}),
+    % SyncTS = os:system_time(microsecond),
+    counters:add(Cfg#conf.counter, 1, NumWrites),
     NextCursor = (Cursor + 1) rem ?METRICS_WINDOW_SIZE,
     State = State0#state{metrics_cursor = NextCursor,
                          batch = undefined},

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -397,7 +397,7 @@ leader(_, tick_timeout, State0) ->
     ServerState = State1#state.server_state,
     Effects = ra_server:tick(ServerState),
     {State, Actions} = ?HANDLE_EFFECTS(RpcEffs ++ Effects ++ [{aux, tick}],
-                                        cast, State1),
+                                       cast, State1),
     {keep_state, handle_tick_metrics(State),
      set_tick_timer(State, Actions)};
 leader({timeout, Name}, machine_timeout,
@@ -1030,8 +1030,8 @@ handle_effect(RaftState, {aux, Cmd}, EventType, State0, Actions0) ->
     {_, ServerState, Effects} = ra_server:handle_aux(RaftState, cast, Cmd,
                                                      State0#state.server_state),
     {State, Actions} =
-        ?HANDLE_EFFECTS(Effects, EventType,
-                        State0#state{server_state = ServerState}),
+        handle_effects(RaftState, Effects,  EventType,
+                       State0#state{server_state = ServerState}),
     {State, Actions0 ++ Actions};
 handle_effect(_, {notify, Who, Correlations}, _, State, Actions) ->
     %% should only be done by leader
@@ -1448,9 +1448,9 @@ handle_node_status_change(Node, Status, InfoList, RaftState,
                                                            S0),
                   {R, S, E0 ++ E}
           end, {RaftState, ServerState0, []}, Comps),
-    {State, Actions} = ?HANDLE_EFFECTS(Effects, cast,
-                                       State0#state{server_state = ServerState,
-                                                    monitors = Monitors}),
+    {State, Actions} = handle_effects(RaftState, Effects, cast,
+                                      State0#state{server_state = ServerState,
+                                                   monitors = Monitors}),
     {keep_state, State, Actions}.
 
 handle_process_down(Pid, Info, RaftState,
@@ -1466,7 +1466,7 @@ handle_process_down(Pid, Info, RaftState,
       end, {ServerState0, []}, Comps),
 
     {State, Actions} =
-    ?HANDLE_EFFECTS(Effects, cast,
-                    State0#state{server_state = ServerState,
-                                 monitors = Monitors}),
+        handle_effects(RaftState, Effects, cast,
+                       State0#state{server_state = ServerState,
+                                    monitors = Monitors}),
     {keep_state, State, Actions}.

--- a/test/ra_log_segment_writer_SUITE.erl
+++ b/test/ra_log_segment_writer_SUITE.erl
@@ -46,6 +46,7 @@ init_per_testcase(TestCase, Config) ->
     PrivDir = ?config(priv_dir, Config),
     Dir = filename:join(PrivDir, TestCase),
     ra_directory:init(PrivDir),
+    ra_counters:init(),
     UId = atom_to_binary(TestCase, utf8),
     yes = ra_directory:register_name(UId, self(), TestCase),
     ok = ra_lib:make_dir(Dir),

--- a/test/ra_log_wal_SUITE.erl
+++ b/test/ra_log_wal_SUITE.erl
@@ -43,6 +43,7 @@ init_per_group(Group, Config) ->
     application:load(ra),
     ok = application:set_env(ra, data_dir, ?config(priv_dir, Config)),
     ra_directory:init(?config(priv_dir, Config)),
+    ra_counters:init(),
     % application:ensure_all_started(lg),
     {SyncMethod, WriteStrat} = case Group of
                                    fsync -> {sync, default};
@@ -196,8 +197,6 @@ test_write_many(Name, NumWrites, ComputeChecksums, BatchSize, DataSize, Config) 
     % assert we aren't regressing on reductions used
     ?assert(Reds < 52023339 * 1.1),
     % stop_profile(Config),
-    % Metrics = [M || {_, V} = M <- lists:sort(ets:tab2list(ra_log_wal_metrics)),
-    %                 V =/= undefined],
     % ct:pal("Metrics: ~p~n", [Metrics]),
     proc_lib:stop(WalPid),
     {Taken div 1000, Reds}.
@@ -264,9 +263,6 @@ write_many_by_many(Config) ->
     % % assert we aren't regressing on reductions used
     % ?assert(Reds < 52023339 * 1.1),
     % stop_profile(Config),
-    Metrics = [M || {_, V} = M <- lists:sort(ets:tab2list(ra_log_wal_metrics)),
-                    V =/= undefined],
-    ct:pal("Metrics: ~p~n", [Metrics]),
     proc_lib:stop(WalPid),
     ok.
 

--- a/test/ra_machine_int_SUITE.erl
+++ b/test/ra_machine_int_SUITE.erl
@@ -431,9 +431,9 @@ aux_command(Config) ->
                     (RaftState, {call, _From}, emit, AuxState, Log, _MacState) ->
                         %% emits aux state
                         {reply, {RaftState, AuxState}, AuxState, Log};
-                    (_RaftState, cast, eval, _AuxState, Log, MacState) ->
+                    (_RaftState, cast, eval, AuxState, Log, _MacState) ->
                         %% replaces aux state
-                        {no_reply, MacState, Log};
+                        {no_reply, AuxState, Log};
                     (_RaftState, cast, NewState, _AuxState, Log, _MacState) ->
                         %% replaces aux state
                         {no_reply, NewState, Log}

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -131,7 +131,7 @@ setup_log() ->
     meck:expect(ra_snapshot, accepting, fun(_SS) -> undefined end),
     meck:expect(ra_log, snapshot_state, fun (_) -> snap_state end),
     meck:expect(ra_log, set_snapshot_state, fun (_, Log) -> Log end),
-    meck:expect(ra_log, install_snapshot, fun (_, _, Log) -> Log end),
+    meck:expect(ra_log, install_snapshot, fun (_, _, Log) -> {Log, []} end),
     meck:expect(ra_log, recover_snapshot, fun ra_log_memory:recover_snapshot/1),
     meck:expect(ra_log, snapshot_index_term, fun ra_log_memory: snapshot_index_term/1),
     meck:expect(ra_log, take, fun ra_log_memory:take/3),


### PR DESCRIPTION
This allows processes other than a Ra process to read the Ra log. An
external process will register as an external reader and will be
updated with information about new segments as they are written.