### PR TITLE
Pre allocate wal file

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -71,7 +71,8 @@
     {segment_max_entries, non_neg_integer()} |
     {wal_max_size_bytes, non_neg_integer()} |
     {wal_compute_checksums, boolean()} |
-    {wal_write_strategy, default | o_sync}.
+    {wal_write_strategy, default | o_sync} |
+    {wal_pre_allocate, boolean()}.
 
 -type query_fun() :: fun((term()) -> term()) |
                      {M :: module(), F :: atom(), A :: list()}.

--- a/src/ra_env.erl
+++ b/src/ra_env.erl
@@ -4,7 +4,8 @@
          data_dir/0,
          server_data_dir/1,
          wal_data_dir/0,
-         configure_logger/1
+         configure_logger/1,
+         wal_pre_allocate/0
          ]).
 
 -export_type([
@@ -37,3 +38,9 @@ wal_data_dir() ->
 %% use this when interacting with Ra from a node without Ra running on it
 configure_logger(Module) ->
     persistent_term:put('$ra_logger', Module).
+
+wal_pre_allocate() ->
+    case application:get_env(ra, wal_pre_allocate) of
+        {ok, true} -> true;
+        _ -> false
+    end.

--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -44,7 +44,6 @@
 
 -record(batch, {writes = 0 :: non_neg_integer(),
                 waiting = #{} :: #{pid() => #batch_writer{}},
-                start_time :: maybe(integer()),
                 pending = [] :: iolist()
                }).
 


### PR DESCRIPTION
This should benefit use of fdatasync and direct io scenarios as
fdatasync may well be upgraded to full fsync when the file size is
extended (as it is for every write).

Referece: #153