### PR TITLE
Do not stash membership changes that can't be appended

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -445,7 +445,9 @@ delete_cluster(ServerIds, Timeout) ->
 %% @param ServerId the ra server id of the new server.
 %% @end
 -spec add_member(ra_server_id() | [ra_server_id()], ra_server_id()) ->
-    ra_cmd_ret().
+    ra_cmd_ret() |
+    {error, already_member} |
+    {error, cluster_change_not_permitted}.
 add_member(ServerLoc, ServerId) ->
     add_member(ServerLoc, ServerId, ?DEFAULT_TIMEOUT).
 
@@ -453,7 +455,10 @@ add_member(ServerLoc, ServerId) ->
 %% @see add_member/2
 %% @end
 -spec add_member(ra_server_id() | [ra_server_id()],
-                 ra_server_id(), timeout()) -> ra_cmd_ret().
+                 ra_server_id(), timeout()) ->
+    ra_cmd_ret() |
+    {error, already_member} |
+    {error, cluster_change_not_permitted}.
 add_member(ServerLoc, ServerId, Timeout) ->
     ra_server_proc:command(ServerLoc,
                            {'$ra_join', ServerId, after_log_append},
@@ -475,7 +480,9 @@ add_member(ServerLoc, ServerId, Timeout) ->
 %% @see remove_member/3
 %% @end
 -spec remove_member(ra_server_id() | [ra_server_id()], ra_server_id()) ->
-    ra_cmd_ret().
+    ra_cmd_ret() |
+    {error, not_member} |
+    {error, cluster_change_not_permitted}.
 remove_member(ServerRef, ServerId) ->
     remove_member(ServerRef, ServerId, ?DEFAULT_TIMEOUT).
 
@@ -483,7 +490,10 @@ remove_member(ServerRef, ServerId) ->
 %% @see remove_member/2
 %% @end
 -spec remove_member(ra_server_id() | [ra_server_id()],
-                    ra_server_id(), timeout()) -> ra_cmd_ret().
+                    ra_server_id(), timeout()) ->
+    ra_cmd_ret() |
+    {error, not_member} |
+    {error, cluster_change_not_permitted}.
 remove_member(ServerRef, ServerId, Timeout) ->
     ra_server_proc:command(ServerRef,
                            {'$ra_leave', ServerId, after_log_append},
@@ -595,7 +605,7 @@ leave_and_delete_server(ServerRef, ServerId, Timeout) ->
         {error, _} = Err ->
             Err;
         {ok, _, _} ->
-            ?INFO("Ra node ~w has succesfully left the cluster.", [ServerId]),
+            ?INFO("Ra node ~w has successfully left the cluster.", [ServerId]),
             force_delete_server(ServerId)
     end.
 

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -17,6 +17,8 @@
          %% queries
          members/1,
          members/2,
+         initial_members/1,
+         initial_members/2,
          local_query/2,
          local_query/3,
          leader_query/2,
@@ -856,6 +858,16 @@ members(ServerId) ->
     ra_server_proc:ra_leader_call_ret([ra_server_id()]).
 members(ServerId, Timeout) ->
     ra_server_proc:state_query(ServerId, members, Timeout).
+
+-spec initial_members(ra_server_id()) ->
+    ra_server_proc:ra_leader_call_ret([ra_server_id()]).
+initial_members(ServerId) ->
+    initial_members(ServerId, ?DEFAULT_TIMEOUT).
+
+-spec initial_members(ra_server_id(), timeout()) ->
+    ra_server_proc:ra_leader_call_ret([ra_server_id()] | error).
+initial_members(ServerId, Timeout) ->
+    ra_server_proc:state_query(ServerId, initial_members, Timeout).
 
 %% @doc Transfers leadership from the leader to a follower.
 %% Returns `already_leader' if the transfer targer is already the leader.

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -635,6 +635,8 @@ write_config(Config0, #?MODULE{directory = Dir}) ->
                            list_to_binary(io_lib:format("~p.", [Config]))),
     ok.
 
+read_config(#?MODULE{directory = Dir}) ->
+    read_config(Dir);
 read_config(Dir) ->
     ConfigPath = filename:join(Dir, "config"),
     case filelib:is_file(ConfigPath) of


### PR DESCRIPTION
Raft only supports one cluster change at a time. Previously we'd stash
any changes that came in whilst another was in progress and they would
later be applied after the current one was committed. This could result
in very hard to reason about behavour from the outside which is why this
commit removes it and provides more detailed error messages for the
ra:add_member|remove_member commands.
