### PR TITLE
Ensure WAL header is always written

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Indicate whether the wal should compute and validate checksums. Default: true
 
     The default. Uses the fdatasync system call after each batch. This avoids flushing
     file meta-data after each write batch and thus may be slightly faster than
-    `sync` on some system. NB: not all systems support fdatasync. Please consult system
+    `sync` on some system. When datasync is configured the wal will try to
+    pre allocate the entire WAL file.
+    NB: not all systems support fdatasync. Please consult system
     documentation and configure it to use sync instead if it is not supported.
 
     - `sync`:
@@ -134,12 +136,6 @@ Indicate whether the wal should compute and validate checksums. Default: true
 
 Controls the internal max batch size that the WAL will accept. Higher numbers may
 result in higher memory use. Default: 32768.
-
-* `wal_pre_allocate`:
-
-Boolean. When enabled each new WAL file will be extended to it's maximum size on creation. 
-Only likely to be useful if `wal_sync_method` is set to `datasync`. Default: false.
-
 
 * `logger_module`:
 

--- a/docs/ra.html
+++ b/docs/ra.html
@@ -23,8 +23,7 @@
     {segment_max_entries, non_neg_integer()} |
     {wal_max_size_bytes, non_neg_integer()} |
     {wal_compute_checksums, boolean()} |
-    {wal_write_strategy, default | o_sync} |
-    {wal_pre_allocate, boolean()}</pre></p>
+    {wal_write_strategy, default | o_sync}</pre></p>
 
 
 <h3 class="typedecl"><a name="type-index">index()</a></h3>
@@ -96,6 +95,8 @@ an optional process-scoped term as correlation identifier.</td></tr>
 <tr><td valign="top"><a href="#consistent_query-3">consistent_query/3</a></td><td>Same as <code>consistent_query/2</code> but accepts a custom timeout.</td></tr>
 <tr><td valign="top"><a href="#members-1">members/1</a></td><td>Returns a list of cluster members.</td></tr>
 <tr><td valign="top"><a href="#members-2">members/2</a></td><td>Returns a list of cluster members.</td></tr>
+<tr><td valign="top"><a href="#initial_members-1">initial_members/1</a></td><td></td></tr>
+<tr><td valign="top"><a href="#initial_members-2">initial_members/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#transfer_leadership-2">transfer_leadership/2</a></td><td>Transfers leadership from the leader to a follower.</td></tr>
 <tr><td valign="top"><a href="#aux_command-2">aux_command/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#cast_aux_command-2">cast_aux_command/2</a></td><td></td></tr>
@@ -350,7 +351,9 @@ an optional process-scoped term as correlation identifier.</td></tr>
 <div class="spec">
 <p><pre>add_member(ServerLoc :: <a href="#type-ra_server_id">ra_server_id()</a> | [<a href="#type-ra_server_id">ra_server_id()</a>],
            ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>) -&gt;
-              <a href="#type-ra_cmd_ret">ra_cmd_ret()</a></pre></p>
+              <a href="#type-ra_cmd_ret">ra_cmd_ret()</a> |
+              {error, already_member} |
+              {error, cluster_change_not_permitted}</pre></p>
 <p><tt>ServerLoc</tt>: the ra server or servers to try to send the command to<br>
 <tt>ServerId</tt>: the ra server id of the new server.<br>
 </p>
@@ -369,7 +372,9 @@ an optional process-scoped term as correlation identifier.</td></tr>
 <p><pre>add_member(ServerLoc :: <a href="#type-ra_server_id">ra_server_id()</a> | [<a href="#type-ra_server_id">ra_server_id()</a>],
            ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>,
            Timeout :: timeout()) -&gt;
-              <a href="#type-ra_cmd_ret">ra_cmd_ret()</a></pre></p>
+              <a href="#type-ra_cmd_ret">ra_cmd_ret()</a> |
+              {error, already_member} |
+              {error, cluster_change_not_permitted}</pre></p>
 </div><p>Same as <code>add_member/2</code> but also accepts a timeout.</p>
 <p><b>See also:</b> <a href="#add_member-2">add_member/2</a>.</p>
 
@@ -377,7 +382,9 @@ an optional process-scoped term as correlation identifier.</td></tr>
 <div class="spec">
 <p><pre>remove_member(ServerRef :: <a href="#type-ra_server_id">ra_server_id()</a> | [<a href="#type-ra_server_id">ra_server_id()</a>],
               ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>) -&gt;
-                 <a href="#type-ra_cmd_ret">ra_cmd_ret()</a></pre></p>
+                 <a href="#type-ra_cmd_ret">ra_cmd_ret()</a> |
+                 {error, not_member} |
+                 {error, cluster_change_not_permitted}</pre></p>
 <p><tt>ServerRef</tt>: the ra server to send the command to<br>
 <tt>ServerId</tt>: the ra server id of the server to remove<br>
 </p>
@@ -395,7 +402,9 @@ command to the log.</p>
 <p><pre>remove_member(ServerRef :: <a href="#type-ra_server_id">ra_server_id()</a> | [<a href="#type-ra_server_id">ra_server_id()</a>],
               ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>,
               Timeout :: timeout()) -&gt;
-                 <a href="#type-ra_cmd_ret">ra_cmd_ret()</a></pre></p>
+                 <a href="#type-ra_cmd_ret">ra_cmd_ret()</a> |
+                 {error, not_member} |
+                 {error, cluster_change_not_permitted}</pre></p>
 </div><p>Same as <code>remove_member/2</code> but also accepts a timeout.</p>
 <p><b>See also:</b> <a href="#remove_member-2">remove_member/2</a>.</p>
 
@@ -729,6 +738,19 @@ success or otherwise.</p>
 <tt>Timeout</tt>: the timeout to use<br>
 </p>
 </div><p>Returns a list of cluster members</p>
+
+<h3 class="function"><a name="initial_members-1">initial_members/1</a></h3>
+<div class="spec">
+<p><pre>initial_members(ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>) -&gt;
+                   <a href="ra_server_proc.html#type-ra_leader_call_ret">ra_server_proc:ra_leader_call_ret</a>([<a href="#type-ra_server_id">ra_server_id()</a>])</pre></p>
+</div>
+
+<h3 class="function"><a name="initial_members-2">initial_members/2</a></h3>
+<div class="spec">
+<p><pre>initial_members(ServerId :: <a href="#type-ra_server_id">ra_server_id()</a>, Timeout :: timeout()) -&gt;
+                   <a href="ra_server_proc.html#type-ra_leader_call_ret">ra_server_proc:ra_leader_call_ret</a>([<a href="#type-ra_server_id">ra_server_id()</a>] |
+                                                     error)</pre></p>
+</div>
 
 <h3 class="function"><a name="transfer_leadership-2">transfer_leadership/2</a></h3>
 <div class="spec">

--- a/docs/ra_env.html
+++ b/docs/ra_env.html
@@ -18,7 +18,6 @@
 <tr><td valign="top"><a href="#server_data_dir-1">server_data_dir/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#wal_data_dir-0">wal_data_dir/0</a></td><td></td></tr>
 <tr><td valign="top"><a href="#configure_logger-1">configure_logger/1</a></td><td></td></tr>
-<tr><td valign="top"><a href="#wal_pre_allocate-0">wal_pre_allocate/0</a></td><td></td></tr>
 </table>
 
 <h2><a name="functions">Function Details</a></h2>
@@ -41,11 +40,6 @@
 <h3 class="function"><a name="configure_logger-1">configure_logger/1</a></h3>
 <div class="spec">
 <p><tt>configure_logger(Module) -&gt; any()</tt></p>
-</div>
-
-<h3 class="function"><a name="wal_pre_allocate-0">wal_pre_allocate/0</a></h3>
-<div class="spec">
-<p><tt>wal_pre_allocate() -&gt; any()</tt></p>
 </div>
 <hr>
 

--- a/docs/ra_server.html
+++ b/docs/ra_server.html
@@ -150,7 +150,6 @@
       cluster := <a href="#type-ra_cluster">ra_cluster()</a>,
       cluster_change_permitted := boolean(),
       cluster_index_term := <a href="#type-ra_idxterm">ra_idxterm()</a>,
-      pending_cluster_changes := [term()],
       previous_cluster =&gt; {<a href="#type-ra_index">ra_index()</a>, <a href="#type-ra_term">ra_term()</a>, <a href="#type-ra_cluster">ra_cluster()</a>},
       current_term := <a href="#type-ra_term">ra_term()</a>,
       log := term(),

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -74,8 +74,7 @@
     {segment_max_entries, non_neg_integer()} |
     {wal_max_size_bytes, non_neg_integer()} |
     {wal_compute_checksums, boolean()} |
-    {wal_write_strategy, default | o_sync} |
-    {wal_pre_allocate, boolean()}.
+    {wal_write_strategy, default | o_sync}.
 
 -type query_fun() :: fun((term()) -> term()) |
                      {M :: module(), F :: atom(), A :: list()}.

--- a/src/ra_env.erl
+++ b/src/ra_env.erl
@@ -4,8 +4,7 @@
          data_dir/0,
          server_data_dir/1,
          wal_data_dir/0,
-         configure_logger/1,
-         wal_pre_allocate/0
+         configure_logger/1
          ]).
 
 -export_type([
@@ -38,9 +37,3 @@ wal_data_dir() ->
 %% use this when interacting with Ra from a node without Ra running on it
 configure_logger(Module) ->
     persistent_term:put('$ra_logger', Module).
-
-wal_pre_allocate() ->
-    case application:get_env(ra, wal_pre_allocate) of
-        {ok, true} -> true;
-        _ -> false
-    end.

--- a/test/coordination_SUITE.erl
+++ b/test/coordination_SUITE.erl
@@ -333,6 +333,7 @@ leaderboard(Config) ->
     %% synchronously get leader
     {ok, _, Leader} = ra:members(hd(Started)),
 
+    timer:sleep(500),
     %% assert leaderboard has correct leader on all nodes
     [begin
          L = rpc:call(N, ra_leaderboard, lookup_leader, [ClusterName]),

--- a/test/ra_dbg_SUITE.erl
+++ b/test/ra_dbg_SUITE.erl
@@ -7,14 +7,12 @@
 
 all() ->
   [
-    {group, no_wal_preallocate},
-    {group, wal_pre_allocate}
+    {group, tests}
   ].
 
 groups() ->
   [
-    {no_wal_preallocate, [], all_tests()},
-    {wal_pre_allocate, [], all_tests()}
+    {tests, [], all_tests()}
   ].
 
 all_tests() ->
@@ -30,16 +28,11 @@ end_per_suite(_Config) ->
   ok.
 
 init_per_testcase(TestCase, Config) ->
-  application:load(ra),
-  Group = proplists:get_value(name, proplists:get_value(tc_group_properties, Config)),
-  WorkDirectory = proplists:get_value(priv_dir, Config),
-  ok = application:set_env(ra, data_dir, filename:join(WorkDirectory, atom_to_list(Group) ++ "-" ++ atom_to_list(TestCase))),
-  case Group of
-      wal_pre_allocate ->
-        ok = application:set_env(ra, wal_pre_allocate, true);
-      _ -> ok
-  end,
-  Config.
+    application:load(ra),
+    Group = proplists:get_value(name, proplists:get_value(tc_group_properties, Config)),
+    WorkDirectory = proplists:get_value(priv_dir, Config),
+    ok = application:set_env(ra, data_dir, filename:join(WorkDirectory, atom_to_list(Group) ++ "-" ++ atom_to_list(TestCase))),
+    Config.
 
 end_per_testcase(_TestCase, _Config) ->
   application:stop(ra),

--- a/test/ra_log_wal_SUITE.erl
+++ b/test/ra_log_wal_SUITE.erl
@@ -47,7 +47,6 @@ init_per_group(Group, Config) ->
     ra_directory:init(?config(priv_dir, Config)),
     ra_counters:init(),
     % application:ensure_all_started(lg),
-    ok = application:set_env(ra, wal_pre_allocate, false),
     {SyncMethod, WriteStrat} =
         case Group of
             fsync ->
@@ -55,7 +54,6 @@ init_per_group(Group, Config) ->
             o_sync ->
                 {datasync, Group};
             default ->
-                ok = application:set_env(ra, wal_pre_allocate, true),
                 {datasync, Group}
         end,
     [{write_strategy, WriteStrat},


### PR DESCRIPTION
By first writing the header to a temporary file then renaming to the
.wal extension.
