### PR TITLE
Recover wal chunks

### DIFF
--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -268,9 +268,7 @@ recover_wal(Dir, #conf{segment_writer = TblWriter,
     All = [begin
 
                Fd = open_at_first_record(F),
-               ok = recover_wal_chunks(Fd, RecoveryChunkSize, #{
-                        chunk_remainder => <<>>, 
-                        chunk_remainder_len => 0}),
+               ok = recover_wal_chunks(Fd, RecoveryChunkSize, #{}),
                close_existing(Fd),
                recovering_to_closed(F)
            end || F <- WalFiles],
@@ -731,85 +729,72 @@ dump_records(<<_:1/unsigned, 1:1/unsigned, _:22/unsigned,
 dump_records(<<>>, Entries) ->
     Entries.
 
-recover_wal_chunks(Fd, RecoveryChunkSize,
-                     #{chunk_remainder := Remainder,
-                       chunk_remainder_len := RemainderLen} = Cache) ->
-    {Data, DataLen} = read_from_wal_file(Fd, RecoveryChunkSize),
-  
-    %% append this chunk to any remainder of the last chunk
-    {Data0, DataLen0} = case RemainderLen of
-        0 ->
-            {Data, DataLen};
-        _ ->
-            {<<Remainder/bitstring, Data/binary>>, DataLen + RemainderLen}
-    end,
+recover_wal_chunks(Fd, RecoveryChunkSize, Cache) ->
+    Chunk = read_from_wal_file(Fd, RecoveryChunkSize),
+    recover_records(Fd, Chunk, Cache, RecoveryChunkSize).
 
-    case DataLen0 of
-        0 ->
-            ok;
-        _ ->
-            case recover_records(Data0, Cache) of
-                end_of_wal ->
-                    ok;
-                {end_of_chunk, Cache0} ->
-                    Cache1 = Cache0#{
-                        chunk_remainder := <<>>, 
-                        chunk_remainder_len := 0},
-                    recover_wal_chunks(Fd, RecoveryChunkSize, Cache1);
-                {incomplete_record, Chunk, Cache0} ->
-                    Cache1 = Cache0#{
-                        chunk_remainder := Chunk, 
-                        chunk_remainder_len := byte_size(Chunk)},
-                    recover_wal_chunks(Fd, RecoveryChunkSize, Cache1)
-            end
-    end.
-
-recover_records(<<Trunc:1/unsigned, 0:1/unsigned, IdRef:22/unsigned,
+% Reached zeros indicating end of wal file
+recover_records(_, <<_:1/unsigned, 0:1/unsigned, _:22/unsigned, 
+                    IdDataLen:16/unsigned, _:IdDataLen/binary,
+                    _:32/integer, 0:32/unsigned, _/binary>>,
+                  _, _) ->
+    ok;
+% First record or different UID to last record
+recover_records(Fd, <<Trunc:1/unsigned, 0:1/unsigned, IdRef:22/unsigned,
                   IdDataLen:16/unsigned, UId:IdDataLen/binary,
                   Checksum:32/integer,
                   EntryDataLen:32/unsigned,
                   Idx:64/unsigned, Term:64/unsigned,
                   EntryData:EntryDataLen/binary,
                   Rest/binary>>,
-                Cache) ->
-    case EntryDataLen of 
-        0 -> 
-            end_of_wal;
-        _ ->
-            true = validate_and_update(UId, Checksum, Idx, Term, EntryData, Trunc),
-            recover_records(Rest,
-            Cache#{
-                IdRef => {UId, <<1:1/unsigned, IdRef:22/unsigned>>}
-            })
-    end;
+                Cache, RecoveryChunkSize) ->
+    true = validate_and_update(UId, Checksum, Idx, Term, EntryData, Trunc),
+    recover_records(Fd, Rest,
+                    Cache#{
+                        IdRef => {UId, <<1:1/unsigned, IdRef:22/unsigned>>}
+                    }, RecoveryChunkSize);
 
  % TODO: recover writers info, i.e. last index seen
-recover_records(<<Trunc:1/unsigned, 1:1/unsigned, IdRef:22/unsigned,
+% Same UID as last record
+recover_records(Fd, <<Trunc:1/unsigned, 1:1/unsigned, IdRef:22/unsigned,
                   Checksum:32/integer,
                   EntryDataLen:32/unsigned,
                   Idx:64/unsigned, Term:64/unsigned,
                   EntryData:EntryDataLen/binary,
                   Rest/binary>>,
-                Cache) ->
-    case EntryDataLen of 
-        0 -> 
-            end_of_wal;
-        _ ->
-            #{IdRef := {UId, _}} = Cache,
-            true = validate_and_update(UId, Checksum, Idx, Term, EntryData, Trunc),
-            recover_records(Rest, Cache)
+                Cache, RecoveryChunkSize) ->
+    #{IdRef := {UId, _}} = Cache,
+    true = validate_and_update(UId, Checksum, Idx, Term, EntryData, Trunc),
+    recover_records(Fd, Rest, Cache, RecoveryChunkSize);
+% Reached end of chunk, with no remainder, time to read the next chunk
+recover_records(Fd, <<>>, Cache, RecoveryChunkSize) ->
+    Chunk = read_from_wal_file(Fd, RecoveryChunkSize),
+    case Chunk of
+        <<>> -> ok;
+        _ -> recover_records(Fd, Chunk, Cache, RecoveryChunkSize)
     end;
-recover_records(<<>>, Cache) ->
-    {end_of_chunk, Cache};
-recover_records(Chunk, Cache) ->
-    {incomplete_record, Chunk, Cache}.
+% Reached the of chunk, with some remainder, time to read the next chunk
+recover_records(Fd, Chunk, Cache, RecoveryChunkSize) ->
+    NextChunk = read_from_wal_file(Fd, RecoveryChunkSize),
+    
+    case NextChunk of 
+        <<>> ->
+            % we were expecting more to be read and there wasn't meaning
+            % we have a partial record. This should never happen.
+            ?WARN("Partial record lost", []),
+            ok;
+        _ -> 
+            %% append this chunk to the remainder of the last chunk
+            Chunk0 = <<Chunk/binary, NextChunk/binary>>,
+            recover_records(Fd, Chunk0, Cache, RecoveryChunkSize)
+    end.
 
 read_from_wal_file(Fd, Len) ->
     case file:read(Fd, Len) of
         {ok, <<Data/binary>>} ->
-            {Data, byte_size(Data)};
+            Data;
         eof ->
-            {<<>>, 0};
+            <<>>;
         {error, Reason} ->
             exit({could_not_read_wal_chunk, Reason})
     end.

--- a/test/ra_log_wal_SUITE.erl
+++ b/test/ra_log_wal_SUITE.erl
@@ -519,7 +519,7 @@ recover_with_small_chunks(Config) ->
     Conf0 = ?config(wal_conf, Config),
     {UId, _} = WriterId = ?config(writer_id, Config),
     Conf = Conf0#{segment_writer => self(),
-        recovery_chunk_size => 128},
+                  recovery_chunk_size => 128},
     Data = <<42:256/unit:8>>,
     meck:new(ra_log_segment_writer, [passthrough]),
     meck:expect(ra_log_segment_writer, await, fun(_) -> ok end),

--- a/test/ra_log_wal_SUITE.erl
+++ b/test/ra_log_wal_SUITE.erl
@@ -24,6 +24,7 @@ all_tests() ->
      out_of_seq_writes,
      roll_over,
      recover,
+     recover_with_small_chunks,
      recover_empty,
      recover_after_roll_over,
      recover_truncated_write,
@@ -469,6 +470,56 @@ recover(Config) ->
     Conf0 = ?config(wal_conf, Config),
     {UId, _} = WriterId = ?config(writer_id, Config),
     Conf = Conf0#{segment_writer => self()},
+    Data = <<42:256/unit:8>>,
+    meck:new(ra_log_segment_writer, [passthrough]),
+    meck:expect(ra_log_segment_writer, await, fun(_) -> ok end),
+    {ok, _Wal} = ra_log_wal:start_link(Conf, []),
+    [ok = ra_log_wal:write(WriterId, ra_log_wal, Idx, 1, Data)
+     || Idx <- lists:seq(1, 100)],
+    ra_log_wal:force_roll_over(ra_log_wal),
+    [ok = ra_log_wal:write(WriterId, ra_log_wal, Idx, 2, Data)
+     || Idx <- lists:seq(101, 200)],
+    empty_mailbox(),
+    proc_lib:stop(ra_log_wal),
+    {ok, Pid} = ra_log_wal:start_link(Conf, []),
+    % how can we better wait for recovery to finish?
+    timer:sleep(1000),
+
+    % there should be no open mem tables after recovery as we treat any found
+    % wal files as complete
+    [] = ets:lookup(ra_log_open_mem_tables, UId),
+    [ {UId, _, 1, 100, MTid1}, % this is the "old" table
+      % these are the recovered tables
+      {UId, _, 1, 100, MTid2}, {UId, _, 101, 200, MTid4} ] =
+        lists:sort(ets:lookup(ra_log_closed_mem_tables, UId)),
+    100 = ets:info(MTid1, size),
+    100 = ets:info(MTid2, size),
+    100 = ets:info(MTid4, size),
+    % check that both mem_tables notifications are received by the segment writer
+    receive
+        {'$gen_cast', {mem_tables, [{UId, 1, 100, _}], _}} -> ok
+    after 2000 ->
+              throw(new_mem_tables_timeout)
+    end,
+    receive
+        {'$gen_cast', {mem_tables, [{UId, 101, 200, _}], _}} -> ok
+    after 2000 ->
+              throw(new_mem_tables_timeout)
+    end,
+
+    meck:unload(),
+    proc_lib:stop(Pid),
+    ok.
+
+recover_with_small_chunks(Config) ->
+    ok = logger:set_primary_config(level, all),
+    % open wal and write a few entreis
+    % close wal + delete mem_tables
+    % re-open wal and validate mem_tables are re-created
+    Conf0 = ?config(wal_conf, Config),
+    {UId, _} = WriterId = ?config(writer_id, Config),
+    Conf = Conf0#{segment_writer => self(),
+        recovery_chunk_size => 128},
     Data = <<42:256/unit:8>>,
     meck:new(ra_log_segment_writer, [passthrough]),
     meck:expect(ra_log_segment_writer, await, fun(_) -> ok end),


### PR DESCRIPTION
## Proposed Changes

Rather than read each WAL in its entirety, read it in chunks, in order to reduce the memory footprint during recovery.

No breaking changes.
