### PR TITLE
Fix integer overflow bug in segment index

### DIFF
--- a/test/ra_machine_version_SUITE.erl
+++ b/test/ra_machine_version_SUITE.erl
@@ -119,7 +119,7 @@ server_with_higher_version_needs_quorum_to_be_elected(Config) ->
     ra:stop_server(Leader2),
     ra:restart_server(Leader2),
     %% this last leader must now be a version 2 not 1
-    {ok, _, Leader3} = ra:members(Leader2),
+    {ok, _, Leader3} = ra:members(Leader2, 60000),
 
     ?assertNotEqual(LastFollower, Leader3),
     ok.


### PR DESCRIPTION
The file offset was for some inexplicable reason recorded as a 32 bit
integer effectively limiting max file size to ~4GB. With large Ra
commands and large segment max entries configured it is fairly easy to
go beyond this causing data in the segment to be overwritten.

This change stores the offset in 64 bit but remains backwards compatible
by incrementing the segment file version and handling this in the code.
