### PR TITLE
ra: Fix force_delete_server/1 spec

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -155,9 +155,9 @@ stop_server(ServerId) ->
 %% @doc Deletes a ra server
 %% The server is forcefully deleted.
 %% @param ServerId the ra_server_id() of the server
-%% @returns `{ok | error, nodedown}'
+%% @returns `ok | {error, nodedown} | {badrpc, Reason}'
 %% @end
--spec force_delete_server(ServerId :: ra_server_id()) -> ok | {error, term()}.
+-spec force_delete_server(ServerId :: ra_server_id()) -> ok | {error, term()} | {badrpc, term()}.
 force_delete_server(ServerId) ->
     ra_server_sup_sup:delete_server(ServerId).
 


### PR DESCRIPTION
It can return `{badrpc, Reason}` from the underlying `rpc:call/4`.

Found by Dialyzer in rabbitmq-server.