### PR TITLE
clarifying spec fixes for queries

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -768,7 +768,7 @@ pipeline_command(ServerId, Command) ->
 %% @end
 -spec local_query(ServerId :: ra_server_id(),
                   QueryFun :: query_fun()) ->
-    ra_server_proc:ra_leader_call_ret({ra_idxterm(), term()}).
+    ra_server_proc:ra_leader_call_ret({ra_idxterm(), Reply :: term()}).
 local_query(ServerId, QueryFun) ->
     local_query(ServerId, QueryFun, ?DEFAULT_TIMEOUT).
 
@@ -781,8 +781,8 @@ local_query(ServerId, QueryFun) ->
 -spec local_query(ServerId :: ra_server_id(),
                   QueryFun :: query_fun(),
                   Timeout :: timeout()) ->
-    ra_server_proc:ra_leader_call_ret({ra_idxterm(), term()}) |
-    {ok, {ra_idxterm(), term()}, not_known}.
+    ra_server_proc:ra_leader_call_ret({ra_idxterm(), Reply :: term()}) |
+    {ok, {ra_idxterm(), Reply :: term()}, not_known}.
 local_query(ServerId, QueryFun, Timeout) ->
     ra_server_proc:query(ServerId, QueryFun, local, Timeout).
 
@@ -798,8 +798,8 @@ local_query(ServerId, QueryFun, Timeout) ->
 %% @end
 -spec leader_query(ServerId :: ra_server_id() | [ra_server_id()],
                    QueryFun :: query_fun()) ->
-    ra_server_proc:ra_leader_call_ret(term()) |
-    {ok, {ra_idxterm(), term()}, not_known}.
+    ra_server_proc:ra_leader_call_ret({ra_idxterm(), Reply :: term()}) |
+    {ok, {ra_idxterm(), Reply :: term()}, not_known}.
 leader_query(ServerId, QueryFun) ->
     leader_query(ServerId, QueryFun, ?DEFAULT_TIMEOUT).
 
@@ -812,8 +812,8 @@ leader_query(ServerId, QueryFun) ->
 -spec leader_query(ServerId :: ra_server_id() | [ra_server_id()],
                    QueryFun :: query_fun(),
                    Timeout :: timeout()) ->
-    ra_server_proc:ra_leader_call_ret(term()) |
-    {ok, {ra_idxterm(), term()}, not_known}.
+    ra_server_proc:ra_leader_call_ret({ra_idxterm(), Reply :: term()}) |
+    {ok, {ra_idxterm(), Reply :: term()}, not_known}.
 leader_query(ServerId, QueryFun, Timeout) ->
     ra_server_proc:query(ServerId, QueryFun, leader, Timeout).
 
@@ -828,7 +828,7 @@ leader_query(ServerId, QueryFun, Timeout) ->
 %% @end
 -spec consistent_query(ServerId :: ra_server_id() | [ra_server_id()],
                        QueryFun :: query_fun()) ->
-    ra_server_proc:ra_leader_call_ret(term()).
+    ra_server_proc:ra_leader_call_ret({ra_idxterm(), Reply :: term()}).
 consistent_query(ServerId, QueryFun) ->
     consistent_query(ServerId, QueryFun, ?DEFAULT_TIMEOUT).
 
@@ -841,7 +841,7 @@ consistent_query(ServerId, QueryFun) ->
 -spec consistent_query(ServerId :: ra_server_id() | [ra_server_id()],
                        QueryFun :: query_fun(),
                        Timeout :: timeout()) ->
-    ra_server_proc:ra_leader_call_ret(term()).
+    ra_server_proc:ra_leader_call_ret({ra_idxterm(), Reply :: term()}).
 consistent_query(ServerId, QueryFun, Timeout) ->
     ra_server_proc:query(ServerId, QueryFun, consistent, Timeout).
 

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -828,7 +828,7 @@ leader_query(ServerId, QueryFun, Timeout) ->
 %% @end
 -spec consistent_query(ServerId :: ra_server_id() | [ra_server_id()],
                        QueryFun :: query_fun()) ->
-    ra_server_proc:ra_leader_call_ret({ra_idxterm(), Reply :: term()}).
+    ra_server_proc:ra_leader_call_ret(Reply :: term()).
 consistent_query(ServerId, QueryFun) ->
     consistent_query(ServerId, QueryFun, ?DEFAULT_TIMEOUT).
 
@@ -841,7 +841,7 @@ consistent_query(ServerId, QueryFun) ->
 -spec consistent_query(ServerId :: ra_server_id() | [ra_server_id()],
                        QueryFun :: query_fun(),
                        Timeout :: timeout()) ->
-    ra_server_proc:ra_leader_call_ret({ra_idxterm(), Reply :: term()}).
+    ra_server_proc:ra_leader_call_ret(Reply :: term()).
 consistent_query(ServerId, QueryFun, Timeout) ->
     ra_server_proc:query(ServerId, QueryFun, consistent, Timeout).
 

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -160,8 +160,8 @@ cast_command(ServerId, Priority, Cmd) ->
 
 -spec query(server_loc(), query_fun(),
             local | consistent | leader, timeout()) ->
-    ra_server_proc:ra_leader_call_ret(term())
-    | {ok, Reply :: term(), not_known}.
+    ra_server_proc:ra_leader_call_ret({ra_idxterm(), Reply :: term()})
+    | {ok, {ra_idxterm(), Reply :: term()}, not_known}.
 query(ServerLoc, QueryFun, local, Timeout) ->
     statem_call(ServerLoc, {local_query, QueryFun}, Timeout);
 query(ServerLoc, QueryFun, leader, Timeout) ->

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -161,6 +161,7 @@ cast_command(ServerId, Priority, Cmd) ->
 -spec query(server_loc(), query_fun(),
             local | consistent | leader, timeout()) ->
     ra_server_proc:ra_leader_call_ret({ra_idxterm(), Reply :: term()})
+    | ra_server_proc:ra_leader_call_ret(Reply :: term())
     | {ok, {ra_idxterm(), Reply :: term()}, not_known}.
 query(ServerLoc, QueryFun, local, Timeout) ->
     statem_call(ServerLoc, {local_query, QueryFun}, Timeout);


### PR DESCRIPTION
## Proposed Changes

More spec fixes.  Previoulsy, most of the query functions were speced like:

                ra_server_proc:ra_leader_call_ret(term()) |
                {ok, {ra_idxterm(), term()}, not_known}

This is type-correct, but a bit confusing.  The term() in the first row is really {ra_idxterm(), Reply}.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x ] I have read the `CONTRIBUTING.md` document
- [x ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

