### PR TITLE
Allow the binary serialization function to be configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PROJECT = ra
 ESCRIPT_NAME = ra_fifo_cli
 ESCRIPT_EMU_ARGS = -noinput -setcookie ra_fifo_cli
 
-dep_gen_batch_server = hex 0.8.2
+dep_gen_batch_server = hex 0.8.3
 dep_aten = hex 0.5.3
 DEPS = aten gen_batch_server
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,15 @@ in a separate repository.
         </td>
         <td>Positive integer</td>
     </tr>
+    <tr>
+        <td>to_iodata_mfa</td>
+        <td>
+            Allows the function used for binary serialisation in the WAL and
+            segment writer to be configured. Needs to return an iodata in the
+            erlang binary format. Default: erlang:term_to_binary/2
+        </td>
+        <td>{Module, Function, AdditionalArgsList}</td>
+    </tr>
 </table>
 
 ## Logging

--- a/src/ra_env.erl
+++ b/src/ra_env.erl
@@ -4,7 +4,8 @@
          data_dir/0,
          server_data_dir/1,
          wal_data_dir/0,
-         configure_logger/1
+         configure_logger/1,
+         to_iodata_mfa/0
          ]).
 
 -export_type([
@@ -37,3 +38,11 @@ wal_data_dir() ->
 %% use this when interacting with Ra from a node without Ra running on it
 configure_logger(Module) ->
     persistent_term:put('$ra_logger', Module).
+
+to_iodata_mfa() ->
+    case application:get_env(ra, to_iodata_mfa) of
+        {ok, MFA} ->
+            MFA;
+        undefined ->
+            {erlang, term_to_binary, []}
+    end.

--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -133,7 +133,7 @@ process_file(false, Mode, Filename, Fd, Options) ->
                 data_write_offset = ?HEADER_SIZE + IndexSize
                }}.
 
--spec append(state(), ra_index(), ra_term(), binary()) ->
+-spec append(state(), ra_index(), ra_term(), iodata()) ->
     {ok, state()} | {error, full | inet:posix()}.
 append(#state{cfg = #cfg{max_pending = PendingCount},
               pending_count = PendingCount} = State0,
@@ -157,7 +157,7 @@ append(#state{cfg = #cfg{version = Version,
     % check if file is full
     case IndexOffset < DataStart of
         true ->
-            Length = erlang:byte_size(Data),
+            Length = iolist_size(Data),
             % TODO: check length is less than #FFFFFFFF ??
             Checksum = erlang:crc32(Data),
             OSize = offset_size(Version),

--- a/test/ra_log_segment_writer_SUITE.erl
+++ b/test/ra_log_segment_writer_SUITE.erl
@@ -32,14 +32,20 @@ all_tests() ->
 
 groups() ->
     [
-     {tests, [], all_tests()}
+     {tests, [], all_tests()},
+     {iovec, [], all_tests()}
     ].
 
+init_per_group(iovec, Config) ->
+    application:load(ra),
+    application:set_env(ra, to_iodata_mfa, {erlang, term_to_iovec, []}),
+    ra_env:configure_logger(logger),
+    Config;
 init_per_group(tests, Config) ->
     ra_env:configure_logger(logger),
     Config.
 
-end_per_group(tests, Config) ->
+end_per_group(_, Config) ->
     Config.
 
 init_per_testcase(TestCase, Config) ->

--- a/test/ra_log_wal_SUITE.erl
+++ b/test/ra_log_wal_SUITE.erl
@@ -37,6 +37,7 @@ all_tests() ->
 groups() ->
     [
      {default, [], all_tests()},
+     {iovec, [], all_tests()},
      %% uses fsync instead of the default fdatasync
      {fsync, [], all_tests()},
      {o_sync, [], all_tests()}
@@ -57,6 +58,9 @@ init_per_group(Group, Config) ->
                 {sync, default};
             o_sync ->
                 {datasync, Group};
+            iovec ->
+                ok = application:set_env(ra, to_iodata_mfa, {erlang, term_to_iovec, []}),
+                {datasync, default};
             default ->
                 {datasync, Group}
         end,


### PR DESCRIPTION
Primarily this will allow the use of term_to_iovec instead of
term_to_binary.
