### PR TITLE
ra v1.1.5 - aten -> 0.5.4, gen_batch_server -> 0.8.4 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ PROJECT = ra
 ESCRIPT_NAME = ra_fifo_cli
 ESCRIPT_EMU_ARGS = -noinput -setcookie ra_fifo_cli
 
-dep_gen_batch_server = hex 0.8.3
-dep_aten = hex 0.5.3
+dep_gen_batch_server = hex 0.8.4
+dep_aten = hex 0.5.4
 DEPS = aten gen_batch_server
 
 TEST_DEPS = proper meck eunit_formatters looking_glass inet_tcp_proxy

--- a/src/ra.app.src
+++ b/src/ra.app.src
@@ -1,6 +1,6 @@
 {application,ra,
              [{description,"Raft library"},
-              {vsn,"1.1.4"},
+              {vsn,"1.1.5"},
               {licenses,["Apache","MPL"]},
               {links,[{"github","https://github.com/rabbitmq/ra"}]},
               {modules,[ra,ra_app,ra_directory,ra_env,ra_file_handle,ra_flru,


### PR DESCRIPTION
[sigh] turns out I missed bumping the deps in both places. This gets the `Makefile` hex deps.