### PR TITLE
Optional WAL entry limit

### DIFF
--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -78,7 +78,7 @@
               filename :: maybe(file:filename()),
               writer_name_cache = {0, #{}} :: writer_name_cache(),
               max_size :: non_neg_integer(),
-              count = 0 :: non_neg_integer()
+              entry_count = 0 :: non_neg_integer()
               }).
 
 -record(state, {conf = #conf{},
@@ -334,7 +334,7 @@ serialize_header(UId, Trunc, {Next, Cache} = WriterCache) ->
 write_data({UId, _} = Id, Idx, Term, Data0, Trunc,
            #state{conf = #conf{compute_checksums = ComputeChecksum},
                   wal = #wal{writer_name_cache = Cache0,
-                             count = Count} = Wal} = State00) ->
+                             entry_count = Count} = Wal} = State00) ->
     EntryData = to_binary(Data0),
     EntryDataLen = byte_size(EntryData),
     {HeaderData, HeaderLen, Cache} = serialize_header(UId, Trunc, Cache0),
@@ -352,7 +352,7 @@ write_data({UId, _} = Id, Idx, Term, Data0, Trunc,
             write_data(Id, Idx, Term, Data0, Trunc, State);
         false ->
             State0 = State00#state{wal = Wal#wal{writer_name_cache = Cache,
-                                                 count = Count + 1}},
+                                                 entry_count = Count + 1}},
             Entry = [<<Idx:64/unsigned,
                        Term:64/unsigned>>,
                      EntryData],
@@ -829,7 +829,7 @@ to_binary(Term) ->
 should_roll_wal(DataSize, #state{conf = #conf{max_entries = MaxEntries},
                                  file_size = FileSize,
                                  wal = #wal{max_size = MaxWalSize,
-                                            count = Count}}) ->
+                                            entry_count = Count}}) ->
     TooManyEntries = case MaxEntries of
                          undefined -> false;
                          _ ->

--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -678,7 +678,6 @@ complete_batch(#state{batch = #batch{waiting = Waiting,
                          Pid ! {ra_log_event, {written, {From, To, Term}}},
                          ok
                  end, Waiting),
-    % erlang:send_after(Cfg#confgtimeout, rollover, 
     State.
 
 wal2list(File) ->

--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -67,6 +67,7 @@
                segment_writer = ra_log_segment_writer :: atom(),
                compute_checksums = false :: boolean(),
                max_size_bytes :: non_neg_integer(),
+               max_entries :: undefined | non_neg_integer(),
                recovery_chunk_size = ?WAL_RECOVERY_CHUNK_SIZE :: non_neg_integer(),
                write_strategy = default :: wal_write_strategy(),
                sync_method = datasync :: sync | datasync,
@@ -76,7 +77,8 @@
 -record(wal, {fd :: maybe(file:io_device()),
               filename :: maybe(file:filename()),
               writer_name_cache = {0, #{}} :: writer_name_cache(),
-              max_size :: non_neg_integer()
+              max_size :: non_neg_integer(),
+              count = 0 :: non_neg_integer()
               }).
 
 -record(state, {conf = #conf{},
@@ -101,6 +103,7 @@
 -type state() :: #state{}.
 -type wal_conf() :: #{dir => file:filename_all(),
                       max_size_bytes => non_neg_integer(),
+                      max_entries => non_neg_integer(),
                       segment_writer => atom() | pid(),
                       compute_checksums => boolean(),
                       write_strategy => wal_write_strategy(),
@@ -188,6 +191,7 @@ start_link(Config, Options0) when is_list(Options0) ->
 -spec init(wal_conf()) -> {ok, state()}.
 init(#{dir := Dir} = Conf0) ->
     #{max_size_bytes := MaxWalSize,
+      max_entries := MaxEntries,
       recovery_chunk_size := RecoveryChunkSize,
       segment_writer := SegWriter,
       compute_checksums := ComputeChecksums,
@@ -209,6 +213,7 @@ init(#{dir := Dir} = Conf0) ->
                  segment_writer = SegWriter,
                  compute_checksums = ComputeChecksums,
                  max_size_bytes = max(?WAL_MIN_SIZE, MaxWalSize),
+                 max_entries = MaxEntries,
                  recovery_chunk_size = RecoveryChunkSize,
                  write_strategy = WriteStrategy,
                  sync_method = SyncMethod,
@@ -328,9 +333,8 @@ serialize_header(UId, Trunc, {Next, Cache} = WriterCache) ->
 
 write_data({UId, _} = Id, Idx, Term, Data0, Trunc,
            #state{conf = #conf{compute_checksums = ComputeChecksum},
-                  file_size = FileSize,
-                  wal = #wal{max_size = MaxWalSize,
-                             writer_name_cache = Cache0} = Wal} = State00) ->
+                  wal = #wal{writer_name_cache = Cache0,
+                             count = Count} = Wal} = State00) ->
     EntryData = to_binary(Data0),
     EntryDataLen = byte_size(EntryData),
     {HeaderData, HeaderLen, Cache} = serialize_header(UId, Trunc, Cache0),
@@ -339,7 +343,7 @@ write_data({UId, _} = Id, Idx, Term, Data0, Trunc,
     DataSize = HeaderLen + 24 + EntryDataLen,
     % if the next write is going to exceed the configured max wal size
     % we roll over to a new wal.
-    case FileSize + DataSize > MaxWalSize of
+    case should_roll_wal(DataSize, State00) of
         true ->
             State = roll_over(State00),
             % TODO: there is some redundant computation performed by
@@ -347,7 +351,8 @@ write_data({UId, _} = Id, Idx, Term, Data0, Trunc,
             % when a wal file fills up
             write_data(Id, Idx, Term, Data0, Trunc, State);
         false ->
-            State0 = State00#state{wal = Wal#wal{writer_name_cache = Cache}},
+            State0 = State00#state{wal = Wal#wal{writer_name_cache = Cache,
+                                                 count = Count + 1}},
             Entry = [<<Idx:64/unsigned,
                        Term:64/unsigned>>,
                      EntryData],
@@ -361,6 +366,7 @@ write_data({UId, _} = Id, Idx, Term, Data0, Trunc,
             append_data(State0, Id, Idx, Term, Data0,
                         DataSize, Record, Trunc)
     end.
+
 
 handle_msg({append, {UId, Pid} = Id, Idx, Term, Entry},
            #state{writers = Writers} = State0) ->
@@ -672,6 +678,7 @@ complete_batch(#state{batch = #batch{waiting = Waiting,
                          Pid ! {ra_log_event, {written, {From, To, Term}}},
                          ok
                  end, Waiting),
+    % erlang:send_after(Cfg#confgtimeout, rollover, 
     State.
 
 wal2list(File) ->
@@ -811,6 +818,7 @@ validate_checksum(Checksum, Idx, Term, Data) ->
 merge_conf_defaults(Conf) ->
     maps:merge(#{segment_writer => ra_log_segment_writer,
                  max_size_bytes => ?WAL_DEFAULT_MAX_SIZE_BYTES,
+                 max_entries => undefined,
                  recovery_chunk_size => ?WAL_RECOVERY_CHUNK_SIZE,
                  compute_checksums => true,
                  write_strategy => default,
@@ -818,3 +826,14 @@ merge_conf_defaults(Conf) ->
 
 to_binary(Term) ->
     term_to_binary(Term).
+
+should_roll_wal(DataSize, #state{conf = #conf{max_entries = MaxEntries},
+                                 file_size = FileSize,
+                                 wal = #wal{max_size = MaxWalSize,
+                                            count = Count}}) ->
+    TooManyEntries = case MaxEntries of
+                         undefined -> false;
+                         _ ->
+                             Count + 1 > MaxEntries
+                     end,
+    FileSize + DataSize > MaxWalSize orelse TooManyEntries.

--- a/test/ra_log_wal_SUITE.erl
+++ b/test/ra_log_wal_SUITE.erl
@@ -31,6 +31,7 @@ all_tests() ->
      truncate_write,
      out_of_seq_writes,
      roll_over,
+     roll_over_entry_limit,
      recover,
      recover_overwrite_in_same_batch,
      recover_with_small_chunks,
@@ -415,6 +416,47 @@ roll_over(Config) ->
     meck:unload(),
     proc_lib:stop(Pid),
     ok.
+
+roll_over_entry_limit(Config) ->
+    Conf = ?config(wal_conf, Config),
+    {UId, _} = WriterId = ?config(writer_id, Config),
+    NumWrites = 1001,
+    meck:new(ra_log_segment_writer, [passthrough]),
+    meck:expect(ra_log_segment_writer, await,
+                fun(_) -> ok end),
+    % configure max_wal_entries
+    {ok, Pid} = ra_log_wal:start_link(Conf#{max_entries => 1000,
+                                            segment_writer => self()}, []),
+    % write enough entries to trigger roll over
+    Data = crypto:strong_rand_bytes(1024),
+    [begin
+         ok = ra_log_wal:write(WriterId, ra_log_wal, Idx, 1, Data)
+     end || Idx <- lists:seq(1, NumWrites)],
+    % wait for writes
+    receive {ra_log_event, {written, {_, NumWrites, 1}}} -> ok
+    after 5000 -> throw(written_timeout)
+    end,
+
+    % validate we receive the new mem tables notifications as if we were
+    % the writer process
+    receive
+        {'$gen_cast', {mem_tables, [{UId, _Fst, _Lst, Tid}], _}} ->
+            [{UId, _, _, CurrentTid}] = ets:lookup(ra_log_open_mem_tables, UId),
+            % the current tid is not the same as the rolled over one
+            ?assert(Tid =/= CurrentTid),
+            % ensure closed mem tables contain the previous mem_table
+            [{UId, _, _, _, Tid}] = ets:lookup(ra_log_closed_mem_tables, UId)
+    after 2000 ->
+              throw(new_mem_tables_timeout)
+    end,
+
+    % TODO: validate we can read first and last written
+    ?assert(undefined =/= mem_tbl_read(UId, 1)),
+    ?assert(undefined =/= mem_tbl_read(UId, 5)),
+    meck:unload(),
+    proc_lib:stop(Pid),
+    ok.
+
 
 recover_truncated_write(Config) ->
     % open wal and write a few entreis


### PR DESCRIPTION
Optionally allows the configuration that limits the number of entries
per wal file. This is useful to limit the memory used by keeping the
tail in ETS when the wal max size is fairly large and
ra servers are writing very small entries.

Also adds a configuration option for enabling WAL hibernation
