### PR TITLE
Retry send in separate process after nosuspend

### DIFF
--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -39,7 +39,7 @@
 %% after node restart). Pids are not stable in this sense.
 -type ra_server_id() :: atom() | {Name :: atom(), Node :: node()}.
 
--type ra_peer_status() :: normal | {sending_snapshot, pid()}.
+-type ra_peer_status() :: normal | {sending_snapshot, pid()} | suspended.
 
 -type ra_peer_state() :: #{next_index := non_neg_integer(),
                            match_index := non_neg_integer(),

--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -49,7 +49,7 @@
                            commit_index_sent := non_neg_integer(),
                            %% indicates that a snapshot is being sent
                            %% to the peer
-                           status => ra_peer_status()}.
+                           status := ra_peer_status()}.
 
 -type ra_cluster() :: #{ra_server_id() => ra_peer_state()}.
 

--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -197,6 +197,7 @@
          read_open_mem_tbl,
          read_closed_mem_tbl,
          read_segment,
+         fetch_term,
          snapshots_written,
          snapshot_installed,
          reserved_1
@@ -208,9 +209,10 @@
 -define(C_RA_LOG_READ_OPEN_MEM_TBL, 5).
 -define(C_RA_LOG_READ_CLOSED_MEM_TBL, 6).
 -define(C_RA_LOG_READ_SEGMENT, 7).
--define(C_RA_LOG_SNAPSHOTS_WRITTEN, 8).
--define(C_RA_LOG_SNAPSHOTS_INSTALLED, 9).
--define(C_RA_LOG_RESERVED, 10).
+-define(C_RA_LOG_FETCH_TERM, 8).
+-define(C_RA_LOG_SNAPSHOTS_WRITTEN, 9).
+-define(C_RA_LOG_SNAPSHOTS_INSTALLED, 10).
+-define(C_RA_LOG_RESERVED, 11).
 
 -define(C_RA_SRV_AER_RECEIVED_FOLLOWER, ?C_RA_LOG_RESERVED + 1).
 -define(C_RA_SRV_AER_REPLIES_SUCCESS, ?C_RA_LOG_RESERVED + 2).

--- a/src/ra_bench.erl
+++ b/src/ra_bench.erl
@@ -47,26 +47,28 @@ apply(#{index := I}, {noop, _}, State) ->
 run() ->
     run(#{name => noop,
           seconds => 10,
-          target => 50000,
+          target => 500,
           degree => 5,
           nodes => [node() | nodes()]}).
 
+-define(DATA_SIZE, 256).
 
 run(#{name := Name,
       seconds := Secs,
       target := Target,
       nodes := Nodes,
-      degree := Degree}) ->
+      degree := Degree} = Conf) ->
 
-    io:format("starting nodes ~w~n", [Nodes]),
+    io:format("starting servers on ~w~n", [Nodes]),
     {ok, ServerIds, []} = start(Name, Nodes),
     {ok,_, Leader} = ra:members(hd(ServerIds)),
     TotalOps = Secs * Target,
     Each = TotalOps div Degree,
     Start = os:system_time(millisecond),
-    Pids =  [spawn_client(self(), Leader, Each) || _ <- lists:seq(1, Degree)],
+    DataSize = maps:get(data_size, Conf, ?DATA_SIZE),
+    Pids =  [spawn_client(self(), Leader, Each, DataSize) || _ <- lists:seq(1, Degree)],
     %% wait for each pid
-    Wait = ((Secs * 1000) * 4),
+    Wait = ((Secs * 10000) * 4),
     [begin
          receive
              {done, P} ->
@@ -82,9 +84,8 @@ run(#{name := Name,
               [TotalOps, Taken, TotalOps div (Taken div 1000)]),
 
     BName = atom_to_binary(Name, utf8),
-    print_metrics(BName),
     [rpc:call(N, ?MODULE, print_metrics, [BName])
-     || N <- nodes()],
+     || N <- Nodes],
     _ = ra:delete_cluster(ServerIds),
     %% 
     ok.
@@ -110,38 +111,39 @@ prepare() ->
     % error_logger:logfile(filename:join(ra_env:data_dir(), "log.log")),
     ok.
 
-send_n(_, 0) -> ok;
-send_n(Leader, N) ->
-    ra:pipeline_command(Leader, {noop, <<>>}, make_ref(), low),
-    send_n(Leader, N-1).
+send_n(_, _Data, 0) -> ok;
+send_n(Leader, Data, N) ->
+    ra:pipeline_command(Leader, {noop, Data}, make_ref(), low),
+    send_n(Leader, Data, N-1).
 
--define(PIPE_SIZE, 4000).
+-define(PIPE_SIZE, 200).
 
-client_loop(0, 0, _Leader) ->
+client_loop(0, 0, _Leader, _Data) ->
     ok;
-client_loop(Num, Sent, _Leader) ->
+client_loop(Num, Sent, _Leader, Data) ->
     receive
         {ra_event, Leader, {applied, Applied}} ->
             N = length(Applied),
             ToSend = min(Sent, N),
-            send_n(Leader, ToSend),
-            client_loop(Num - N, Sent - ToSend, Leader);
+            send_n(Leader, Data, ToSend),
+            client_loop(Num - N, Sent - ToSend, Leader, Data);
         {ra_event, _, {rejected, {not_leader, NewLeader, _}}} ->
             io:format("new leader ~w~n", [NewLeader]),
-            send_n(NewLeader, 1),
-            client_loop(Num, Sent, NewLeader);
+            send_n(NewLeader, Data, 1),
+            client_loop(Num, Sent, NewLeader, Data);
         {ra_event, Leader, Evt} ->
             io:format("unexpected ra_event ~w~n", [Evt]),
-            client_loop(Num, Sent,Leader)
+            client_loop(Num, Sent, Leader, Data)
     end.
 
-spawn_client(Parent, Leader, Num) when Num >= ?PIPE_SIZE ->
+spawn_client(Parent, Leader, Num, DataSize) when Num >= ?PIPE_SIZE ->
+    Data = crypto:strong_rand_bytes(DataSize),
     spawn_link(
       fun () ->
               %% first send one 1000 noop commands
               %% then top up as they are applied
-              send_n(Leader, ?PIPE_SIZE),
-              ok = client_loop(Num, Num - ?PIPE_SIZE, Leader),
+              send_n(Leader, Data, ?PIPE_SIZE),
+              ok = client_loop(Num, Num - ?PIPE_SIZE, Leader, Data),
               Parent ! {done, self()}
       end).
 

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -306,7 +306,6 @@ take(Start, Num, #?MODULE{cfg = Cfg,
             {Entries, C0, State};
         {Entries0, C0, {S, F}} ->
             {Entries, C1, Reader} = ra_log_reader:read(S, F, Reader0, Entries0),
-            %% TODO: avoid concat
             {Entries, C0 + C1, State#?MODULE{reader = Reader}}
     end;
 take(_, _, State) ->
@@ -430,9 +429,9 @@ handle_event({segments, Tid, NewSegs},
             %% delay deletion until all readers confirmed they have received
             %% the update
             Pid = spawn(fun () ->
-                          ok = log_update_wait_n(length(Readers)),
-                          DeleteFun()
-                  end),
+                                ok = log_update_wait_n(length(Readers)),
+                                DeleteFun()
+                        end),
             {State, log_update_effects(Readers, Pid, State)}
     end;
 handle_event({snapshot_written, {Idx, _} = Snap},
@@ -634,7 +633,6 @@ overview(#?MODULE{last_index = LastIndex,
       first_index => FirstIndex,
       last_written_index_term => LWIT,
       num_segments => length(ra_log_reader:segment_refs(Reader)),
-      %%TODO: re-introduce open segment count
       open_segments => ra_log_reader:num_open_segments(Reader),
       snapshot_index => case ra_snapshot:current(SnapshotState) of
                             undefined -> undefined;
@@ -872,7 +870,6 @@ resend_from0(Idx, #?MODULE{cfg = Cfg,
                         wal_write(Acc, maps:get(I, Cache))
                 end,
                 State#?MODULE{last_resend_time = erlang:system_time(seconds)},
-                % TODO: replace with recursive function
                 lists:seq(Idx, LastIdx));
 resend_from0(Idx, #?MODULE{last_resend_time = LastResend,
                            cfg = #cfg{resend_window_seconds = ResendWindow}} = State) ->

--- a/src/ra_log_reader.erl
+++ b/src/ra_log_reader.erl
@@ -174,7 +174,8 @@ retry_read(N, From, To, #?STATE{cfg = #cfg{uid = UId} = Cfg} = State) ->
 
 
 -spec fetch_term(ra_index(), state()) -> {ra_index(), state()}.
-fetch_term(Idx, #?STATE{cfg = #cfg{uid = UId}} = State0) ->
+fetch_term(Idx, #?STATE{cfg = #cfg{uid = UId} = Cfg} = State0) ->
+    incr_counter(Cfg, {?C_RA_LOG_FETCH_TERM, 1}),
     case ets:lookup(ra_log_open_mem_tables, UId) of
         [{_, From, To, Tid}] when Idx >= From andalso Idx =< To ->
             Term = ets:lookup_element(Tid, Idx, 2),

--- a/src/ra_log_reader.erl
+++ b/src/ra_log_reader.erl
@@ -26,7 +26,6 @@
 
 -define(STATE, ?MODULE).
 
-%% TODO: these could be captured in a record
 -define(METRICS_OPEN_MEM_TBL_POS, 3).
 -define(METRICS_CLOSED_MEM_TBL_POS, 4).
 -define(METRICS_SEGMENT_POS, 5).

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1322,7 +1322,8 @@ is_fully_replicated(#{commit_index := CI} = State) ->
         [] -> true; % there is only one server
         Peers ->
             MinMI = lists:min([M || #{match_index := M} <- Peers]),
-            MinMI >= CI
+            MinCI = lists:min([M || #{commit_index_sent := M} <- Peers]),
+            MinMI >= CI andalso MinCI >= CI
     end.
 
 handle_aux(RaftState, Type, Cmd, #{cfg := #cfg{effective_machine_module = MacMod},
@@ -1909,7 +1910,8 @@ new_peer() ->
     #{next_index => 1,
       match_index => 0,
       commit_index_sent => 0,
-      query_index => 0}.
+      query_index => 0,
+      status => normal}.
 
 new_peer_with(Map) ->
     maps:merge(new_peer(), Map).

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -2199,7 +2199,7 @@ apply_with({Idx, _, {'$ra_cluster', CmdMeta, delete, ReplyType}},
     State = State0#{last_applied => Idx, machine_state => MacSt},
     throw({delete_and_terminate, State, EOLEffects ++ NotEffs ++ Effects1});
 apply_with({Idx, _, _} = Cmd, Acc) ->
-    % TODO: remove to make more strics, ideally we should not need a catch all
+    % TODO: remove to make more strict, ideally we should not need a catch all
     ?WARN("~s: apply_with: unhandled command: ~W~n",
           [log_id(element(2, Acc)), Cmd, 10]),
     setelement(2, Acc, Idx).

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1198,7 +1198,6 @@ handle_effect(_, {record_leader_msg, _LeaderId}, _, State0, Actions) ->
 send_rpcs(State0) ->
     {State, Rpcs} = make_rpcs(State0),
     % module call so that we can mock
-    % TODO: review
     % We can ignore send failures here as they have not incremented
     % the peer's next index
     [_ = ?MODULE:send_rpc(To, Rpc, State) || {send_rpc, To, Rpc} <- Rpcs],

--- a/test/coordination_SUITE.erl
+++ b/test/coordination_SUITE.erl
@@ -449,6 +449,8 @@ start_follower(N, PrivDir) ->
     ct:pal("starting secondary node with ~s on host ~s for node ~s~n", [Pa, Host, node()]),
     {ok, S} = slave:start_link(Host, N, Pa),
     _ = rpc:call(S, ra, start, []),
+    ok = ct_rpc:call(S, logger, set_primary_config,
+                     [level, all]),
     S.
 
 flush() ->

--- a/test/coordination_SUITE.erl
+++ b/test/coordination_SUITE.erl
@@ -39,7 +39,8 @@ all_tests() ->
      start_cluster_minority,
      send_local_msg,
      local_log_effect,
-     leaderboard
+     leaderboard,
+     bench
     ].
 
 groups() ->
@@ -190,7 +191,7 @@ delete_two_server_cluster(Config) ->
     Machine = {module, ?MODULE, #{}},
     {ok, _, []} = ra:start_cluster(ClusterName, Machine, NodeIds),
     {ok, _} = ra:delete_cluster(NodeIds),
-    timer:sleep(250),
+    timer:sleep(1000),
     {error, _} = ra_server_proc:ping(hd(tl(NodeIds)), 50),
     {error, _} = ra_server_proc:ping(hd(NodeIds), 50),
     % assert all nodes are actually started
@@ -358,6 +359,19 @@ leaderboard(Config) ->
      end || {_, N} <- NodeIds],
 
     [ok = slave:stop(S) || {_, S} <- NodeIds],
+    ok.
+
+bench(Config) ->
+    %% exercies the large message handling code
+    PrivDir = ?config(data_dir, Config),
+    Nodes = [start_follower(N, PrivDir) || N <- [s1,s2,s3]],
+    ok = ra_bench:run(#{name => ?FUNCTION_NAME,
+                        seconds => 10,
+                        target => 500,
+                        degree => 3,
+                        data_size => 256 * 1000,
+                        nodes => Nodes}),
+    [ok = slave:stop(N) || N <- Nodes],
     ok.
 
 test_local_msg(Leader, ReceiverNode, ExpectedSenderNode, CmdTag, Opts0) ->

--- a/test/ra_2_SUITE.erl
+++ b/test/ra_2_SUITE.erl
@@ -529,7 +529,7 @@ external_reader(Config) ->
     receive
         {ra_event, _, {machine, {ra_log_update, _, _, _} = E}} ->
             R1 = ra_log_reader:handle_log_update(E, R0),
-            {Entries, _R2} = ra_log_reader:read(0, 1026, R1),
+            {Entries, _, _R2} = ra_log_reader:read(0, 1026, R1),
             ct:pal("read ~w ~w", [length(Entries), lists:last(Entries)]),
             %% read all entries
             ok

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -128,7 +128,8 @@ receive_segment(Config) ->
     [] = ets:tab2list(ra_log_open_mem_tables),
     [] = ets:tab2list(ra_log_closed_mem_tables),
     % validate reads
-    {Entries, FinalLog} = ra_log:take(1, 3, Log3),
+    {Entries, C, FinalLog} = ra_log:take(1, 3, Log3),
+    ?assertEqual(length(Entries), C),
     ra_log:close(FinalLog),
     ok.
 
@@ -140,9 +141,9 @@ read_one(Config) ->
     Log1 = append_n(1, 2, 1, Log0),
     % ensure the written event is delivered
     Log2 = deliver_all_log_events(Log1, 200),
-    {[_], Log} = ra_log:take(1, 5, Log2),
+    {[_], 1, Log} = ra_log:take(1, 5, Log2),
     % read out of range
-    {[], Log} = ra_log:take(5, 5, Log2),
+    {[], 0, Log} = ra_log:take(5, 5, Log2),
     #{?FUNCTION_NAME := #{read_cache := M1,
                           read_open_mem_tbl := M2,
                           read_closed_mem_tbl := M3,
@@ -157,15 +158,15 @@ take_after_overwrite_and_init(Config) ->
     Log0 = ra_log:init(#{uid => UId}),
     Log1 = write_and_roll_no_deliver(1, 5, 1, Log0),
     Log2 = deliver_written_log_events(Log1, 200),
-    {[_, _, _, _], Log3} = ra_log:take(1, 5, Log2),
+    {[_, _, _, _], 4, Log3} = ra_log:take(1, 5, Log2),
     Log4 = write_and_roll_no_deliver(1, 2, 2, Log3),
     % fake lost segments event
     Log5 = deliver_written_log_events(Log4, 200),
     % ensure we cannot take stale entries
-    {[{1, 2, _}], Log6} = ra_log:take(1, 5, Log5),
+    {[{1, 2, _}], 1, Log6} = ra_log:take(1, 5, Log5),
     _ = ra_log:close(Log6),
     Log = ra_log:init(#{uid => UId}),
-    {[{1, 2, _}], _} = ra_log:take(1, 5, Log),
+    {[{1, 2, _}], 1, _} = ra_log:take(1, 5, Log),
     ok.
 
 
@@ -257,7 +258,7 @@ read_opt(Config) ->
     Log1 = write_and_roll(1, Num, 1, Log0, 50),
     Log2 = wait_for_segments(Log1, 5000),
     %% read small batch of the latest entries
-    {_, Log} = ra_log:take(Num - 5, 5, Log2),
+    {_, _, Log} = ra_log:take(Num - 5, 5, Log2),
     %% measure the time it takes to read the first index
     {Time, _} = timer:tc(fun () ->
                                  _ = erlang:statistics(exact_reductions),
@@ -313,11 +314,13 @@ updated_segment_can_be_read(Config) ->
     % Log2 = deliver_all_log_events(Log1, 200),
     %% read some, this will open the segment with the an index of entries
     %% 1 - 4
-    {Entries, Log3} = ra_log:take(1, 25, Log2),
+    {Entries, C0, Log3} = ra_log:take(1, 25, Log2),
+    ?assertEqual(length(Entries), C0),
     %% append a few more itmes and process the segments
     Log4 = append_and_roll(5, 16, 1, Log3),
     % this should return all entries
-    {Entries1, _} = ra_log:take(1, 15, Log4),
+    {Entries1, C1, _} = ra_log:take(1, 15, Log4),
+    ?assertEqual(length(Entries1), C1),
     ct:pal("Entries: ~p~n", [Entries]),
     ct:pal("Entries1: ~p~n", [Entries1]),
     ct:pal("Counters ~p", [ra_counters:overview(?FUNCTION_NAME)]),
@@ -332,7 +335,7 @@ cache_overwrite_then_take(Config) ->
     Log1 = write_n(1, 5, 1, Log0),
     Log2 = write_n(3, 4, 2, Log1),
     % validate only 3 entries can be read even if requested range is greater
-    {[_, _, _], _} = ra_log:take(1, 5, Log2),
+    {[_, _, _], 3, _} = ra_log:take(1, 5, Log2),
     ok.
 
 last_written_overwrite(Config) ->
@@ -474,7 +477,7 @@ resend_write(Config) ->
     Log6 = assert_log_events(Log5, fun (L) ->
                                            {13, 2} == ra_log:last_written(L)
                                    end),
-    {[_, _, _, _, _], _} = ra_log:take(9, 5, Log6),
+    {[_, _, _, _, _], 5, _} = ra_log:take(9, 5, Log6),
     ra_log:close(Log6),
 
     ok.
@@ -512,7 +515,8 @@ wal_down_read_availability(Config) ->
                                            {9, 2} == ra_log:last_written(L)
                                    end),
     ok = supervisor:terminate_child(ra_log_wal_sup, ra_log_wal),
-    {Entries, _} = ra_log:take(0, 10, Log2),
+    {Entries, C0, _} = ra_log:take(0, 10, Log2),
+    ?assertEqual(length(Entries), C0),
     ?assert(length(Entries) =:= 10),
     ok.
 
@@ -564,11 +568,13 @@ detect_lost_written_range(Config) ->
                                            {19, 2} == ra_log:last_written(L)
                                    end),
     % validate no writes were lost and can be recovered
-    {Entries, _} = ra_log:take(0, 20, Log5),
+    {Entries, C0, _} = ra_log:take(0, 20, Log5),
+    ?assertEqual(length(Entries), C0),
     ra_log:close(Log5),
     Log = ra_log:init(#{uid => UId}),
     {19, 2} = ra_log:last_written(Log5),
-    {RecoveredEntries, _} = ra_log:take(0, 20, Log),
+    {RecoveredEntries, C1, _} = ra_log:take(0, 20, Log),
+    ?assertEqual(length(RecoveredEntries), C1),
     ?assert(length(Entries) =:= 20),
     ?assert(length(RecoveredEntries) =:= 20),
     Entries = RecoveredEntries,
@@ -622,8 +628,8 @@ snapshot_installation(Config) ->
     Log = assert_log_events(Log5, fun (L) ->
                                           {19, 2} == ra_log:last_written(L)
                                   end),
-    {[], _} = ra_log:take(1, 9, Log),
-    {[_, _], _} = ra_log:take(16, 2, Log),
+    {[], 0, _} = ra_log:take(1, 9, Log),
+    {[_, _], 2, _} = ra_log:take(16, 2, Log),
     ok.
 
 append_after_snapshot_installation(Config) ->
@@ -657,8 +663,8 @@ append_after_snapshot_installation(Config) ->
     Log = assert_log_events(Log3, fun (L) ->
                                           {19, 2} == ra_log:last_written(L)
                                   end),
-    {[], _} = ra_log:take(1, 9, Log),
-    {[_, _], _} = ra_log:take(16, 2, Log),
+    {[], 0, _} = ra_log:take(1, 9, Log),
+    {[_, _], 2, _} = ra_log:take(16, 2, Log),
     ok.
 
 written_event_after_snapshot_installation(Config) ->
@@ -892,7 +898,7 @@ external_reader(Config) ->
             fun () ->
                     receive
                         {ra_log_reader_state, R1} = Evt ->
-                            {Es, R2} = ra_log_reader:read(0, 220, R1),
+                            {Es, _, R2} = ra_log_reader:read(0, 220, R1),
                             Len1 = length(Es),
                             ct:pal("Es ~w", [Len1]),
                             Self ! {got, Evt, Es},
@@ -900,10 +906,10 @@ external_reader(Config) ->
                                 {ra_log_update, _, F, _} = Evt2 ->
                                     %% reader before update has been processed
                                     %% should work
-                                    {Stale, _} = ra_log_reader:read(F, 220, R2),
+                                    {Stale, _, _} = ra_log_reader:read(F, 220, R2),
                                     ?assertEqual(Len1, length(Stale)),
                                     R3 = ra_log_reader:handle_log_update(Evt2, R2),
-                                    {Es2, _R4} = ra_log_reader:read(F, 220, R3),
+                                    {Es2, _, _R4} = ra_log_reader:read(F, 220, R3),
                                     ct:pal("Es2 ~w", [length(Es2)]),
                                     ?assertEqual(Len1, length(Es2)),
                                     Self ! {got, Evt2, Es2}
@@ -943,7 +949,8 @@ validate_read(To, To, _Term, Log0) ->
     Log0;
 validate_read(From, To, Term, Log0) ->
     End = min(From + 25, To),
-    {Entries, Log} = ra_log:take(From, End - From, Log0),
+    {Entries, C0, Log} = ra_log:take(From, End - From, Log0),
+    ?assertEqual(length(Entries), C0),
     % validate entries are correctly read
     Expected = [ {I, Term, <<I:64/integer>>} ||
                  I <- lists:seq(From, End - 1) ],

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -1110,7 +1110,8 @@ new_peer() ->
     #{next_index => 1,
       match_index => 0,
       commit_index_sent => 0,
-      query_index => 0}.
+      query_index => 0,
+      status => normal}.
 
 flush() ->
     receive

--- a/test/ra_log_SUITE.erl
+++ b/test/ra_log_SUITE.erl
@@ -214,17 +214,18 @@ take(Config) ->
                                ra_log:append_sync(Entry, L0)
                        end, Log0, lists:seq(Idx, LastIdx)),
     % wont work for memory
-    {[?IDX(1)], Log2} = ra_log:take(1, 1, Log1),
-    {[?IDX(1), ?IDX(2)], Log3} = ra_log:take(1, 2, Log2),
+    {[?IDX(1)], 1, Log2} = ra_log:take(1, 1, Log1),
+    {[?IDX(1), ?IDX(2)], 2, Log3} = ra_log:take(1, 2, Log2),
     % partly out of range
-    {[?IDX(9), ?IDX(10)], Log4} = ra_log:take(9, 3, Log3),
+    {[?IDX(9), ?IDX(10)], 2, Log4} = ra_log:take(9, 3, Log3),
     % completely out of range
-    {[], Log5} = ra_log:take(11, 3, Log4),
+    {[], 0, Log5} = ra_log:take(11, 3, Log4),
     % take all
-    {Taken, _} = ra_log:take(1, 10, Log5),
-    %% take 0
-    {[], _} = ra_log:take(5, 0, Log5),
+    {Taken, C0, _} = ra_log:take(1, 10, Log5),
+    ?assertEqual(length(Taken), C0),
     ?assertEqual(10, length(Taken)),
+    %% take 0
+    {[], 0, _} = ra_log:take(5, 0, Log5),
     ok.
 
 

--- a/test/ra_log_memory.erl
+++ b/test/ra_log_memory.erl
@@ -102,10 +102,9 @@ write(_Entries, _State) ->
     {error, {integrity_error, undefined}}.
 
 
--spec take(ra_index(), non_neg_integer(), ra_log_memory_state()) ->
-    {[log_entry()], ra_log_memory_state()}.
 take(Start, Num, #state{last_index = LastIdx, entries = Log} = State) ->
-    {sparse_take(Start, Log, Num, LastIdx, []), State}.
+    Entries = sparse_take(Start, Log, Num, LastIdx, []),
+    {Entries, length(Entries), State}.
 
 % this allows for missing entries in the log
 sparse_take(Idx, _Log, Num, Max, Res)

--- a/test/ra_log_props_SUITE.erl
+++ b/test/ra_log_props_SUITE.erl
@@ -163,7 +163,7 @@ write_prop(TestCase) ->
            {ok, Log0} = ra_log:write(
                           Entries,
                           ra_log:init(#{uid => TestCase})),
-           {LogEntries, Log} = ra_log:take(1, length(Entries), Log0),
+           {LogEntries, _, Log} = ra_log:take(1, length(Entries), Log0),
            reset(Log),
            ?WHENFAIL(io:format("Entries taken from the log: ~p~nRa log state: ~p~n",
                                [LogEntries, Log]),
@@ -211,7 +211,7 @@ write_overwrite_entry_prop(TestCase) ->
                                 ra_log:init(#{uid => TestCase})),
               NewEntry = [{Idx, Term, <<"overwrite">>}],
               {ok, Log} = ra_log:write(NewEntry, Log0),
-              {LogEntries, Log1} = ra_log:take(1, length(Entries), Log),
+              {LogEntries, _, Log1} = ra_log:take(1, length(Entries), Log),
               reset(Log1),
               ?WHENFAIL(io:format("Head: ~p~n New entry: ~p~n"
                                   "Entries taken from the log: ~p~n"
@@ -261,7 +261,7 @@ append_missing_entry_prop(TestCase) ->
                            exit:{integrity_error, _} ->
                                true
                        end,
-              {LogEntries, Log} = ra_log:take(1, length(Head), Log0),
+              {LogEntries, _, Log} = ra_log:take(1, length(Head), Log0),
               reset(Log),
               ?WHENFAIL(io:format("Failed: ~p~nHead: ~p~n Tail: ~p~n"
                                   "Entries taken from the log: ~p~n"
@@ -303,7 +303,7 @@ append_prop(TestCase) ->
            Log0 = append_all(
                    Entries,
                    ra_log:init(#{uid => TestCase})),
-           {LogEntries, Log} = ra_log:take(1, length(Entries), Log0),
+           {LogEntries, _, Log} = ra_log:take(1, length(Entries), Log0),
            reset(Log),
            ?WHENFAIL(io:format("Entries taken from the log: ~p~nRa log state: ~p~n",
                                [LogEntries, Log]),
@@ -368,7 +368,7 @@ take_prop(TestCase) ->
               {ok, Log0} = ra_log:write(
                                  Entries,
                                  ra_log:init(#{uid => TestCase})),
-              {Selected, Log} = ra_log:take(Start, Num, Log0),
+              {Selected, _, Log} = ra_log:take(Start, Num, Log0),
               Expected = lists:sublist(Entries, Start, Num),
               reset(Log),
               ?WHENFAIL(io:format("Selected: ~p~nExpected: ~p~n",
@@ -389,7 +389,7 @@ take_out_of_range_prop(TestCase) ->
               {ok, Log0} = ra_log:write(
                                 Entries,
                                 ra_log:init(#{uid => TestCase})),
-              {Reply, Log} = ra_log:take(Start, Num, Log0),
+              {Reply, _, Log} = ra_log:take(Start, Num, Log0),
               reset(Log),
               ?WHENFAIL(io:format("Start: ~p Num: ~p~nReply: ~p~n", [Start, Num, Reply]),
                         Reply == [])
@@ -579,7 +579,7 @@ last_written_with_wal_prop(TestCase) ->
                                       {Acc, Last0, Idx, St}
                               end, {Log0, {0, 0}, 0, wal_up}, All),
               Got = ra_log:last_written(Log),
-              {Written, Log1} = ra_log:take(1, LastIdx, Log),
+              {Written, _, Log1} = ra_log:take(1, LastIdx, Log),
               reset(Log1),
               ?WHENFAIL(io:format("Got: ~p, Expected: ~p Written: ~p~n Actions: ~p~n",
                                   [Got, Last, Written, All]),
@@ -628,7 +628,7 @@ last_written_with_segment_writer_prop(TestCase) ->
                                       {Acc, Last0, Idx, St}
                               end, {Log0, {0, 0}, 0, sw_up}, All),
               Got = ra_log:last_written(Log),
-              {Written, Log1} = ra_log:take(1, LastIdx, Log),
+              {Written, _, Log1} = ra_log:take(1, LastIdx, Log),
               reset(Log1),
               ?WHENFAIL(ct:pal("Got: ~p, Expected: ~p Written: ~p~n Actions: ~p~n",
                                   [Got, Last, Written, All]),
@@ -703,7 +703,7 @@ last_written_with_crashing_segment_writer_prop(TestCase) ->
                                                       ets:tab2list(ra_log_open_mem_tables),
                                                       ets:tab2list(ra_log_closed_mem_tables)
                                                      ]),
-              {Written, Log2} = ra_log:take(1, EIdx, Log1),
+              {Written, _, Log2} = ra_log:take(1, EIdx, Log1),
               %% We got all the data, can reset now
               basic_reset(Log2),
               ?WHENFAIL(ct:pal("Last written entry: ~p; actually last idx term: ~p;"

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -2361,7 +2361,8 @@ new_peer() ->
     #{next_index => 1,
       match_index => 0,
       query_index => 0,
-      commit_index_sent => 0}.
+      commit_index_sent => 0,
+      status => normal}.
 
 new_peer_with(Map) ->
     maps:merge(new_peer(), Map).


### PR DESCRIPTION
Instead of dropping all rpcs and relying on the retry protocol we start
a separate process to retry the rpc send allowing it to block until the
send has completed after which it updates the peer's status so it can
start pipelining again.