### PR TITLE
ra.hrl: Add domain to logged messages

### DIFF
--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -182,7 +182,8 @@
                                                                 ?FUNCTION_NAME,
                                                                 ?FUNCTION_ARITY},
                                                         file => ?FILE,
-                                                        line => ?LINE}),
+                                                        line => ?LINE,
+                                                        domain => [ra]}),
        ok).
 
 -define(DEFAULT_TIMEOUT, 5000).


### PR DESCRIPTION
The domain is `[ra]`. It allows users of Ra to filter log messages emitted by this application.