### PR TITLE
Delete ra_metrics entries

### DIFF
--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -831,7 +831,7 @@ handle_event(_EventType, EventContent, StateName, State) ->
 
 terminate(Reason, StateName,
           #state{conf = #conf{name = Key, cluster_name = ClusterName},
-                 server_state = ServerState} = State) ->
+                 server_state = ServerState = #{cfg := #cfg{metrics_key = MetricsKey}}} = State) ->
     ?INFO("~s: terminating with ~w in state ~w~n",
           [log_id(State), Reason, StateName]),
     UId = uid(State),
@@ -863,11 +863,7 @@ terminate(Reason, StateName,
 
         _ -> ok
     end,
-    case ServerState of
-      #{cfg := #cfg{metrics_key = MetricsKey}} ->
-        ets:delete(ra_metrics, MetricsKey);
-      _ -> ok
-    end,
+    _ = ets:delete(ra_metrics, MetricsKey),
     _ = ets:delete(ra_state, Key),
     ok = ra_counters:delete({Key, self()}),
     ok.

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -13,6 +13,7 @@
 
 
 -include("ra.hrl").
+-include("ra_server.hrl").
 
 %% State functions
 -export([
@@ -862,7 +863,11 @@ terminate(Reason, StateName,
 
         _ -> ok
     end,
-    _ = ets:delete(ra_metrics, Key),
+    case ServerState of
+      #{cfg := #cfg{metrics_key = MetricsKey}} ->
+        ets:delete(ra_metrics, MetricsKey);
+      _ -> ok
+    end,
     _ = ets:delete(ra_state, Key),
     ok = ra_counters:delete({Key, self()}),
     ok.


### PR DESCRIPTION
Before this commit, entries didn't get deleted from `ra_metrics` table since we used the wrong key.
## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Further Comments

Before this PR, in RabbitMQ, although a quorum queue (here `q8`) was deleted, Prometheus still reported metrics for the deleted queue:
```
rabbitmq_raft_term_total{vhost="/",queue="q8"} 4
rabbitmq_raft_log_snapshot_index{vhost="/",queue="q8"} 0
rabbitmq_raft_log_last_applied_index{vhost="/",queue="q8"} 5
rabbitmq_raft_log_commit_index{vhost="/",queue="q8"} 5
rabbitmq_raft_log_last_written_index{vhost="/",queue="q8"} 5
rabbitmq_raft_entry_commit_latency_seconds{vhost="/",queue="q8"} 0.0
```
After this PR, these metrics are not reported anymore for deleted quorum queues.