### PR TITLE
ServerIds only have the form {Name, Node}

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -438,7 +438,7 @@ start_cluster(System, [#{cluster_name := ClusterName} | _] = ServerConfigs,
 -spec start_server(atom(), ra_cluster_name(), ra_server_id(),
                    ra_server:machine_conf(), [ra_server_id()]) ->
     ok | {error, term()}.
-start_server(System, ClusterName, ServerId, Machine, ServerIds)
+start_server(System, ClusterName, {_, _} = ServerId, Machine, ServerIds)
   when is_atom(System) ->
     UId = new_uid(ra_lib:to_binary(ClusterName)),
     Conf = #{cluster_name => ClusterName,

--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -37,7 +37,7 @@
 %%
 %% Ra servers need to be registered stable names (names that are reachable
 %% after node restart). Pids are not stable in this sense.
--type ra_server_id() :: atom() | {Name :: atom(), Node :: node()}.
+-type ra_server_id() :: {Name :: atom(), Node :: node()}.
 
 -type ra_peer_status() :: normal | {sending_snapshot, pid()} | suspended.
 

--- a/src/ra_directory.erl
+++ b/src/ra_directory.erl
@@ -161,7 +161,9 @@ uid_of(#{directory_rev := Tbl}, ServerName) when is_atom(ServerName) ->
         [] -> undefined;
         [{_, UId}] ->
             UId
-    end.
+    end;
+uid_of(SystemOrNames, {ServerName, _}) when is_atom(ServerName) ->
+    uid_of(SystemOrNames, ServerName).
 
 overview(System) when is_atom(System) ->
     #{directory := Tbl,

--- a/test/ra_dbg_SUITE.erl
+++ b/test/ra_dbg_SUITE.erl
@@ -75,22 +75,22 @@ filter_entry_duplicate(_Config) ->
 
 execute_state_machine() ->
   %% creating a new WAL file with ra_fifo
-  Nodes = [{ra_dbg, node()}],
+  [Srv] = Nodes = [{ra_dbg, node()}],
   ClusterId = ra_dbg,
   Config = #{name => ClusterId},
   Machine = {module, ra_fifo, Config},
   ra:start(),
   {ok, _, _} = ra:start_cluster(default, ClusterId, Machine, Nodes),
 
-  {ok, _, _} = ra:process_command(ra_dbg, {enqueue, self(), 1, <<"1">>}),
-  {ok, _, _} = ra:process_command(ra_dbg, {enqueue, self(), 2, <<"2">>}),
-  {ok, _, _} = ra:process_command(ra_dbg, {enqueue, self(), 3, <<"3">>}),
+  {ok, _, _} = ra:process_command(Srv, {enqueue, self(), 1, <<"1">>}),
+  {ok, _, _} = ra:process_command(Srv, {enqueue, self(), 2, <<"2">>}),
+  {ok, _, _} = ra:process_command(Srv, {enqueue, self(), 3, <<"3">>}),
 
   ConsumerId = {<<"ctag1">>, self()},
-  {ok, {dequeue, {MsgId, _}}, _} = ra:process_command(ra_dbg, {checkout, {dequeue, unsettled}, ConsumerId}),
+  {ok, {dequeue, {MsgId, _}}, _} = ra:process_command(Srv, {checkout, {dequeue, unsettled}, ConsumerId}),
 
-  {ok, _, _} = ra:process_command(ra_dbg, {settle, [MsgId], ConsumerId}),
-  {ok, FinalState, _} = ra:consistent_query(ra_dbg, fun(State) -> State end),
+  {ok, _, _} = ra:process_command(Srv, {settle, [MsgId], ConsumerId}),
+  {ok, FinalState, _} = ra:consistent_query(Srv, fun(State) -> State end),
   {Config, FinalState}.
 
 wal_file() ->

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -81,6 +81,10 @@ init_per_testcase(TestCase, Config) ->
 end_per_testcase(_, _Config) ->
     ok.
 
+-define(N1, {n1, node()}).
+-define(N2, {n2, node()}).
+-define(N3, {n3, node()}).
+
 handle_overwrite(Config) ->
     UId = ?config(uid, Config),
     Log0 = ra_log_init(#{uid => UId}),
@@ -610,7 +614,7 @@ snapshot_installation(Config) ->
                  end,
 
     %% create snapshot chunk
-    Meta = meta(15, 2, [n1]),
+    Meta = meta(15, 2, [?N1]),
     Chunk = create_snapshot_chunk(Config, Meta),
 
     SnapState0 = ra_log:snapshot_state(Log2),
@@ -654,7 +658,7 @@ append_after_snapshot_installation(Config) ->
                                      {9, 2} == ra_log:last_written(L)
                              end),
     %% do snapshot
-    Meta = meta(15, 2, [n1]),
+    Meta = meta(15, 2, [?N1]),
     Chunk = create_snapshot_chunk(Config, Meta),
     SnapState0 = ra_log:snapshot_state(Log1),
     {ok, SnapState1} = ra_snapshot:begin_accept(Meta, SnapState0),
@@ -686,7 +690,7 @@ written_event_after_snapshot_installation(Config) ->
     Log1 = write_n(1, 10, 2, Log0),
     SnapIdx = 10,
     %% do snapshot in
-    Meta = meta(SnapIdx, 2, [n1]),
+    Meta = meta(SnapIdx, 2, [?N1]),
     Chunk = create_snapshot_chunk(Config, Meta),
     SnapState0 = ra_log:snapshot_state(Log1),
     {ok, SnapState1} = ra_snapshot:begin_accept(Meta, SnapState0),
@@ -728,8 +732,8 @@ update_release_cursor(Config) ->
     % assert there are two segments at this point
     [_, _] = find_segments(Config),
     % update release cursor to the last entry of the first segment
-    {Log2, _} = ra_log:update_release_cursor(127, #{n1 => new_peer(),
-                                                    n2 => new_peer()},
+    {Log2, _} = ra_log:update_release_cursor(127, #{?N1 => new_peer(),
+                                                    ?N2 => new_peer()},
                                              1, initial_state, Log1),
 
     Log3 = assert_log_events(Log2,
@@ -746,8 +750,8 @@ update_release_cursor(Config) ->
                  end, 10, 100),
     Log3b = validate_read(128, 150, 2, Log3),
     % update the release cursor all the way
-    {Log4, _} = ra_log:update_release_cursor(149, #{n1 => new_peer(),
-                                                    n2 => new_peer()},
+    {Log4, _} = ra_log:update_release_cursor(149, #{?N1 => new_peer(),
+                                                    ?N2 => new_peer()},
                                              1, initial_state, Log3b),
     Log5 = assert_log_events(Log4,
                              fun (L) ->
@@ -789,8 +793,8 @@ update_release_cursor_with_machine_version(Config) ->
     [_, _] = find_segments(Config),
     % update release cursor to the last entry of the first segment
     MacVer = 2,
-    {Log2, _} = ra_log:update_release_cursor(127, #{n1 => new_peer(),
-                                                    n2 => new_peer()},
+    {Log2, _} = ra_log:update_release_cursor(127, #{?N1 => new_peer(),
+                                                    ?N2 => new_peer()},
                                              MacVer,
                                              initial_state, Log1),
     Log = assert_log_events(Log2,
@@ -841,8 +845,8 @@ missed_closed_tables_are_deleted_at_next_opportunity(Config) ->
     Log5 = validate_read(1, 155, 2, Log4),
 
     % then update the release cursor
-    {Log6, _} = ra_log:update_release_cursor(154, #{n1 => new_peer(),
-                                                    n2 => new_peer()},
+    {Log6, _} = ra_log:update_release_cursor(154, #{?N1 => new_peer(),
+                                                    ?N2 => new_peer()},
                                              1, initial_state, Log5),
     _Log = deliver_all_log_events(Log6, 500),
 


### PR DESCRIPTION
This simplifies some of the internals and settles on a single
representation of a server id.
