### PR TITLE
Add a Bazel build

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -4,6 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         otp:
         - "23.2"
@@ -38,6 +39,7 @@ jobs:
   build-bazel:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         otp:
         - "23.2"
@@ -63,3 +65,9 @@ jobs:
     - name: TEST
       run: |
         bazelisk test //...
+    - name: CAPTURE TEST LOGS ON FAILURE
+      uses: actions/upload-artifact@v2-preview
+      if: failure()
+      with:
+        name: bazel-testlogs-${{matrix.otp}}
+        path: bazel-testlogs/*

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -35,3 +35,31 @@ jobs:
       with:
         name: ct-logs-${{matrix.otp}}
         path: logs/*
+  build-bazel:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        otp:
+        - "23.2"
+        - "24.0"
+    steps:
+    - name: CHECKOUT
+      uses: actions/checkout@v2
+    - name: CONFIGURE ERLANG
+      uses: gleam-lang/setup-erlang@v1.1.2
+      with:
+        otp-version: ${{ matrix.otp }}
+    - name: CONFIGURE BAZEL
+      run: |
+        ERLANG_HOME="$(dirname $(dirname $(which erl)))"
+        cat << EOF >> .bazelrc
+          build --@bazel-erlang//:erlang_version=${{ matrix.erlang_version }}
+          build --@bazel-erlang//:erlang_home=${ERLANG_HOME}
+
+          build --incompatible_strict_action_env
+
+          build --test_strategy=exclusive
+        EOF
+    - name: TEST
+      run: |
+        bazelisk test //...

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -65,9 +65,13 @@ jobs:
     - name: TEST
       run: |
         bazelisk test //...
+    - name: RESOVLE TEST LOGS PATH
+      run: |
+        echo "::set-output name=LOGS_PATH::$(readlink -f bazel-testlogs)"
+      id: resolve-test-logs-path
     - name: CAPTURE TEST LOGS ON FAILURE
       uses: actions/upload-artifact@v2-preview
       if: failure()
       with:
         name: bazel-testlogs-${{matrix.otp}}
-        path: bazel-testlogs/*
+        path: ${{ steps.resolve-test-logs-path.outputs.LOGS_PATH }}/*

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ config
 *.segment
 
 doc/*
+
+/.bazelrc
+/bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,68 @@
+load(
+    "@bazel-erlang//:bazel_erlang_lib.bzl",
+    "erlang_lib",
+    "test_erlang_lib",
+)
+load("@bazel-erlang//:xref.bzl", "xref")
+load("@bazel-erlang//:dialyze.bzl", "DEFAULT_PLT_APPS", "dialyze", "plt")
+load(":ra.bzl", "ra_suites")
+
+NAME = "ra"
+
+EXTRA_APPS = [
+    "sasl",
+    "crypto",
+]
+
+FIRST_SRCS = [
+    "src/ra_machine.erl",
+    "src/ra_snapshot.erl",
+]
+
+DEPS = [
+    "@gen_batch_server//:bazel_erlang_lib",
+]
+
+RUNTIME_DEPS = [
+    "@aten//:bazel_erlang_lib",
+]
+
+erlang_lib(
+    app_name = NAME,
+    extra_apps = EXTRA_APPS,
+    first_srcs = FIRST_SRCS,
+    runtime_deps = RUNTIME_DEPS,
+    deps = DEPS,
+)
+
+test_erlang_lib(
+    app_name = NAME,
+    extra_apps = EXTRA_APPS,
+    first_srcs = FIRST_SRCS,
+    runtime_deps = RUNTIME_DEPS,
+    deps = DEPS,
+)
+
+xref()
+
+plt(
+    name = "base_plt",
+    apps = DEFAULT_PLT_APPS + EXTRA_APPS + [
+        "eunit",
+        "syntax_tools",
+        "erts",
+        "kernel",
+        "stdlib",
+        "common_test",
+        "inets",
+        "mnesia",
+        "ssh",
+        "ssl",
+    ],
+)
+
+dialyze(
+    plt = ":base_plt",
+)
+
+ra_suites()

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,5 @@ RABBITMQ_UPSTREAM_FETCH_URL ?= https://github.com/rabbitmq/aten.git
 
 show-upstream-git-fetch-url:
 	@echo $(RABBITMQ_UPSTREAM_FETCH_URL)
+
+include mk/bazel.mk

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,54 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel-erlang",
+    strip_prefix = "bazel-erlang-master",
+    urls = ["https://github.com/rabbitmq/bazel-erlang/archive/master.zip"],
+)
+
+load("@bazel-erlang//:bazel_erlang.bzl", "bazel_erlang_deps")
+
+bazel_erlang_deps()
+
+load("@bazel-erlang//:github.bzl", "github_bazel_erlang_lib")
+load("@bazel-erlang//:hex_pm.bzl", "hex_pm_bazel_erlang_lib")
+
+hex_pm_bazel_erlang_lib(
+    name = "aten",
+    sha256 = "30721679da07ccb55bb0f407cb0e40c7dc6d1e258f3ebfb789c55982878e4427",
+    version = "0.5.6",
+)
+
+hex_pm_bazel_erlang_lib(
+    name = "gen_batch_server",
+    sha256 = "ff6b0ed0f7be945f38b94ddd4784d128f35ff029c34dad6ca0c6cb17ab7bc9c4",
+    version = "0.8.4",
+)
+
+http_archive(
+    name = "inet_tcp_proxy",
+    build_file_content = """load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlang_lib")
+erlang_lib(
+    app_name = "inet_tcp_proxy_dist",
+    app_version = "0.1.0",
+    app_description = "Erlang distribution proxy to simulate network failures",
+    app_module = "inet_tcp_proxy_dist_app",
+)
+""",
+    strip_prefix = "inet_tcp_proxy-master",
+    urls = ["https://github.com/rabbitmq/inet_tcp_proxy/archive/master.zip"],
+)
+
+github_bazel_erlang_lib(
+    name = "meck",
+    org = "eproxus",
+)
+
+github_bazel_erlang_lib(
+    name = "proper",
+    first_srcs = [
+        "src/vararg.erl",
+        "src/proper_target.erl",
+    ],
+    org = "manopapad",
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -2,8 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel-erlang",
-    strip_prefix = "bazel-erlang-master",
-    urls = ["https://github.com/rabbitmq/bazel-erlang/archive/master.zip"],
+    sha256 = "098975fca1be2cd68d24bb8eefaf16e113f9ccb777bb4345f04cc7590d5c9cb7",
+    strip_prefix = "bazel-erlang-1.0.0",
+    urls = ["https://github.com/rabbitmq/bazel-erlang/archive/refs/tags/1.0.0.zip"],
 )
 
 load("@bazel-erlang//:bazel_erlang.bzl", "bazel_erlang_deps")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel-erlang",
-    sha256 = "098975fca1be2cd68d24bb8eefaf16e113f9ccb777bb4345f04cc7590d5c9cb7",
-    strip_prefix = "bazel-erlang-1.0.0",
-    urls = ["https://github.com/rabbitmq/bazel-erlang/archive/refs/tags/1.0.0.zip"],
+    sha256 = "422a9222522216f59a01703a13f578c601d6bddf5617bee8da3c43e3b299fc4e",
+    strip_prefix = "bazel-erlang-1.1.0",
+    urls = ["https://github.com/rabbitmq/bazel-erlang/archive/refs/tags/1.1.0.zip"],
 )
 
 load("@bazel-erlang//:bazel_erlang.bzl", "bazel_erlang_deps")

--- a/mk/bazel.mk
+++ b/mk/bazel.mk
@@ -1,0 +1,12 @@
+define BAZELRC
+build --@bazel-erlang//:erlang_home=$(shell dirname $$(dirname $$(which erl)))
+build --@bazel-erlang//:erlang_version=$(shell erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell)
+
+build --incompatible_strict_action_env
+
+build --test_strategy=exclusive
+endef
+
+export BAZELRC
+.bazelrc:
+	echo "$$BAZELRC" > $@

--- a/ra.bzl
+++ b/ra.bzl
@@ -1,0 +1,47 @@
+load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlc")
+load("@bazel-erlang//:ct.bzl", "ct_suite")
+
+TEST_ERLC_OPTS = [
+    "-DTEST",
+    "+debug_info",
+    "+nowarn_export_all",
+]
+
+def ra_suites():
+    suites = native.glob(["test/*_SUITE.erl"])
+    helpers = native.glob(["test/*.erl"], exclude = suites)
+
+    hdrs = [
+        "src/ra.hrl",
+        "src/ra_server.hrl",
+    ]
+
+    erlc(
+        name = "test_helpers",
+        srcs = helpers,
+        hdrs = hdrs,
+        deps = [
+            ":test_bazel_erlang_lib",
+        ],
+        testonly = True,
+    )
+
+    for file in suites:
+        name = file.replace("test/", "").replace(".erl", "")
+        ct_suite(
+            erlc_opts = TEST_ERLC_OPTS,
+            name = name,
+            runtime_deps = [
+                "@gen_batch_server//:bazel_erlang_lib",
+                "@aten//:bazel_erlang_lib",
+                "@inet_tcp_proxy//:bazel_erlang_lib",
+                "@meck//:bazel_erlang_lib",
+            ],
+            deps = [
+                "@proper//:bazel_erlang_lib",
+            ],
+            additional_hdrs = hdrs,
+            additional_beam = [
+                ":test_helpers",
+            ],
+        )

--- a/test/erlang_node_helpers.erl
+++ b/test/erlang_node_helpers.erl
@@ -27,7 +27,7 @@ start_erlang_node(Node, Config) ->
                                              [{return, list}]),
                         "-pa \"" ++ DistModPath ++ "\" -proto_dist " ++ DistArg
                 end,
-    ct_slave:start(Node, [{erl_flags, StartArgs}]),
+    {ok, _} = ct_slave:start(Node, [{erl_flags, StartArgs}]),
     wait_for_distribution(Node, 50),
     add_lib_dir(Node),
     Node.


### PR DESCRIPTION
Add a parallel Bazel build to the existing gnu make build. This will allow other erlang projects using [bazel-erlang](https://github.com/rabbitmq/bazel-erlang) (i.e. rabbitmq-server) to consume ra directly.


## Proposed Changes

Add a parallel Bazel build to the existing gnu make build. This will allow other erlang projects using bazel-erlang (i.e. rabbitmq-server) to consume ra directly.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

To bootstrap the bazel build:

Install [bazelisk](https://github.com/bazelbuild/bazelisk)

Create a .bazelrc with:

```
make .bazelrc
```

and then

`bazelisk test //... --test_strategy=exclusive`

