### PR TITLE
ra_machine: "Deduplicate" the `send_msg_opt()` type spec

### DIFF
--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -104,7 +104,7 @@
 %% These commands may be passed to the {@link apply/2} function in reaction
 %% to monitor effects
 
--type send_msg_opt() :: [ra_event | cast | local] | ra_event | cast | local.
+-type send_msg_opt() :: ra_event | cast | local.
 %% ra_event: the message will be wrapped up and sent as a ra event
 %% e.g: `{ra_event, ra_server_id(), Msg}'
 %%


### PR DESCRIPTION
It doesn't need to include the list of options as it is already handled by the `send_msg_opts()` type (note the plural).

Before this change, it means options could be nested indefinitely which I'm not sure we want to accept.