### PR TITLE
Oct bug fixes

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -718,6 +718,13 @@ handle_leader({transfer_leadership, Leader},
     ?DEBUG("~s: transfer leadership requested but already leader",
            [LogId]),
     {leader, State, [{reply, already_leader}]};
+handle_leader({transfer_leadership, Member},
+              #{cfg := #cfg{log_id = LogId},
+                cluster := Members} = State)
+  when not is_map_key(Member, Members) ->
+    ?DEBUG("~s: transfer leadership requested but unknown member ~w",
+           [LogId, Member]),
+    {leader, State, [{reply, {error, unknown_member}}]};
 handle_leader({transfer_leadership, ServerId},
               #{cfg := #cfg{log_id = LogId}} = State) ->
     ?DEBUG("~s: transfer leadership to ~w requested",

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -347,6 +347,7 @@ leader(enter, OldState, State0) ->
     {State, Actions} = handle_enter(?FUNCTION_NAME, OldState, State0),
     ok = record_leader_change(id(State0), State0),
     {keep_state, State#state{leader_last_seen = undefined,
+                             delayed_commands = queue:new(),
                              election_timeout_set = false}, Actions};
 leader(EventType, {leader_call, Msg}, State) ->
     %  no need to redirect
@@ -616,7 +617,7 @@ follower(enter, OldState, #state{server_state = ServerState} = State0) ->
                                maybe_set_election_timeout(TimeoutLen, State1,
                                                           Actions0)
                        end,
-    {keep_state, State, Actions};
+    {keep_state, State#state{delayed_commands = queue:new()}, Actions};
 follower({call, From}, {leader_call, Msg}, State) ->
     maybe_redirect(From, Msg, State);
 follower(EventType, {local_call, Msg}, State) ->

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -750,6 +750,7 @@ transfer_leadership(Config) ->
     {ok, _, NewLeader} = ra:process_command(NextInLine, 5),
     ?assertEqual(NewLeader, NextInLine),
     ?assertEqual(already_leader, ra:transfer_leadership(NewLeader, NewLeader)),
+    ?assertEqual({error, unknown_member}, ra:transfer_leadership(NewLeader, {unknown, node()})),
     terminate_cluster(Members).
 
 get_gen_statem_status(Ref) ->


### PR DESCRIPTION
Two bug fixes.

Resets delayed_commands when a leader has to step down to avoid keeping delayed commands around indefinitely and potentially also avoiding any further low priority commands being written if the follower later becomes leader again.

Also avoid entering await_condition state when transfer leadership requests a new leader that isn't a known member.