### PR TITLE
Avoid writing config on server init if it has not changed

### DIFF
--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -642,7 +642,7 @@ overview(#?MODULE{last_index = LastIndex,
 write_config(Config0, #?MODULE{cfg = #cfg{directory = Dir}}) ->
     ConfigPath = filename:join(Dir, "config"),
     % clean config of potentially unserialisable data
-    Config = maps:without([parent, counter], Config0),
+    Config = maps:without([parent, counter, has_changed], Config0),
     ok = ra_lib:write_file(ConfigPath,
                            list_to_binary(io_lib:format("~p.", [Config]))),
     ok.

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -255,7 +255,14 @@ init(#{id := Id,
                                     %% use sequential access pattern during
                                     %% recovery
                                     initial_access_pattern => sequential}),
-    ok = ra_log:write_config(Config, Log0),
+    %% only write config if it is different from what is already on disk
+    case Config of
+        #{has_changed := false} ->
+            ok;
+        _ ->
+            ok = ra_log:write_config(Config, Log0)
+    end,
+
     MetaName = meta_name(SystemConfig),
     CurrentTerm = ra_log_meta:fetch(MetaName, UId, current_term, 0),
     LastApplied = ra_log_meta:fetch(MetaName, UId, last_applied, 0),


### PR DESCRIPTION
Optimisation to avoid disk use and (hopefully) improve recovery times
when 1000s of ra servers need to recovered.
