### PR TITLE
Add two less safe wal write strategies.

### DIFF
--- a/src/ra_file_handle.erl
+++ b/src/ra_file_handle.erl
@@ -14,7 +14,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
--export([open/2, close/1, sync/1, datasync/1, write/2, read/2, position/2]).
+-export([open/2, close/1, sync/1, datasync/1, none/1, write/2, read/2, position/2]).
 -export([pwrite/2, pwrite/3, pread/2, pread/3]).
 
 -define(SERVER, ?MODULE).
@@ -37,6 +37,10 @@ sync(Fd) ->
 
 datasync(Fd) ->
     update(io_sync, fun() -> file:datasync(Fd) end).
+
+%% called when wal does not sync at all
+none(_Fd) ->
+    ok.
 
 write(Fd, Bytes) ->
     update(io_write, iolist_size(Bytes), fun() -> file:write(Fd, Bytes) end).

--- a/src/ra_system.erl
+++ b/src/ra_system.erl
@@ -33,8 +33,8 @@
                     wal_compute_checksums => boolean(),
                     wal_max_batch_size => non_neg_integer(),
                     wal_max_entries => non_neg_integer(),
-                    wal_write_strategy => default | o_sync,
-                    wal_sync_method => datasync | sync,
+                    wal_write_strategy => default | o_sync | sync_after_notify,
+                    wal_sync_method => datasync | sync | none,
                     wal_hibernate_after => non_neg_integer(),
                     snapshot_chunk_size => non_neg_integer(),
                     receive_snapshot_timeout => non_neg_integer()

--- a/test/ra_log_wal_SUITE.erl
+++ b/test/ra_log_wal_SUITE.erl
@@ -16,7 +16,9 @@ all() ->
     [
      {group, default},
      {group, fsync},
-     {group, o_sync}
+     {group, o_sync},
+     {group, sync_after_notify},
+     {group, no_sync}
     ].
 
 
@@ -47,7 +49,9 @@ groups() ->
      {default, [], all_tests()},
      %% uses fsync instead of the default fdatasync
      {fsync, [], all_tests()},
-     {o_sync, [], all_tests()}
+     {o_sync, [], all_tests()},
+     {sync_after_notify, [], all_tests()},
+     {no_sync, [], all_tests()}
     ].
 
 -define(SYS, default).
@@ -68,9 +72,9 @@ init_per_group(Group, Config) ->
         case Group of
             fsync ->
                 {sync, default};
-            o_sync ->
-                {datasync, Group};
-            default ->
+            no_sync ->
+                {none, default};
+            _ ->
                 {datasync, Group}
         end,
     [{write_strategy, WriteStrat},


### PR DESCRIPTION
1. sync_after_notify: this write strategy will send confirmation notifications
back to writing processes after writing but  _before_ initiating the fsync operation.

This should improve latency for Ra machines that do not need high throughput but also provide a reasonable
chance of data reaching disk even during failures.

2. Sync Method: none: This sync method implements a noop for the
sync operation effectively disabling fsync apart from when closing the
file. Only to be used when the disk used provide additional guarantees. E.g.
when the disk has batteries and can ensure data is synced in case of a power
outage.
