### PR TITLE
Set off_heap for ra_servers

### DIFF
--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -264,6 +264,7 @@ multi_statem_call([ServerId | ServerIds], Msg, Errs, Timeout) ->
 
 init(Config0 = #{id := Id, cluster_name := ClusterName}) ->
     process_flag(trap_exit, true),
+    process_flag(message_queue_data, off_heap),
     Key = ra_lib:ra_server_id_to_local_name(Id),
     Config = #{counter := Counter,
                system_config := SysConf} = maps:merge(config_defaults(Key),


### PR DESCRIPTION
Ra tends to implement centralised utilities such as data stores and thus
will benefit from setting the off_heap message_queue_data strategy.

This will avoid messages being scanned by the Gc before they have been "received"
as well as enables further fan-in scalability.
