### PR TITLE
Fix bug when a log read is partially covered by the cache

### DIFF
--- a/test/ra_log_SUITE.erl
+++ b/test/ra_log_SUITE.erl
@@ -25,6 +25,7 @@ all_tests() ->
      write_then_overwrite,
      append_integrity_error,
      take,
+     take_cache,
      last
     ].
 
@@ -228,6 +229,15 @@ take(Config) ->
     {[], 0, _} = ra_log:take(5, 0, Log5),
     ok.
 
+take_cache(Config) ->
+    Log0 = ?config(ra_log, Config),
+    Term = 1,
+    Idx = ra_log:next_index(Log0),
+    Log1 = ra_log:append_sync({Idx, Term, <<"one">>}, Log0),
+    Idx2 = Idx +1,
+    Log = ra_log:append({Idx2, Term, <<"two">>}, Log1),
+    {[?IDX(Idx), ?IDX(Idx2)], 2, _Log2} = ra_log:take(1, 2, Log),
+    ok.
 
 last(Config) ->
     Log0 = ?config(ra_log, Config),


### PR DESCRIPTION
A refactor must have accedentally missed to include any entries read
from the cache in the read result. This would have resulted in leader
creating gaps in the log replication messages causing followers to have
to ask the leader to back up. Everything still works it just does a bit
of unnecessary work.

## Proposed Changes

Please describe the big picture of your changes here to communicate to the
RabbitMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

A pull request that doesn't explain **why** the change was made has a much
lower chance of being accepted.

If English isn't your first language, don't worry about it and try to
communicate the problem you are trying to solve to the best of your abilities.
As long as we can understand the intent, it's all good.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
