### PR TITLE
Sparse read

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -22,7 +22,7 @@ hex_pm_erlang_app(
 
 hex_pm_erlang_app(
     name = "gen_batch_server",
-    sha256 = "ff6b0ed0f7be945f38b94ddd4784d128f35ff029c34dad6ca0c6cb17ab7bc9c4",
+    sha256 = "94a49a528486298b009d2a1b452132c0a0d68b3e89d17d3764cb1ec879b7557a",
     version = "0.8.7",
 )
 

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -17,6 +17,7 @@
          append_sync/2,
          write_sync/2,
          take/3,
+         sparse_read/2,
          last_index_term/1,
          set_last_index/2,
          handle_event/2,
@@ -307,6 +308,48 @@ take(Start, Num, #?MODULE{cfg = Cfg,
     end;
 take(_, _, State) ->
     {[], 0, State}.
+
+
+%% read a list of indexes,
+%% will be returned in ascending order
+-spec sparse_read([ra_index()], state()) ->
+    {[log_entry()], state()}.
+sparse_read(Indexes0, #?MODULE{cfg = Cfg,
+                               reader = Reader0,
+                               cache = Cache} = State) ->
+    ok = incr_counter(Cfg, ?C_RA_LOG_READ_OPS, 1),
+    %% indexes need to be sorted high -> low but will be returned
+    %% low -> high
+    Sort = ra_lib:lists_detect_sort(Indexes0),
+    Indexes1 = case Sort of
+                   unsorted ->
+                       lists:sort(fun erlang:'>'/2, Indexes0);
+                   ascending ->
+                       lists:reverse(Indexes0);
+                   _ ->
+                       % descending or undefined
+                       Indexes0
+               end,
+    {Entries0, CacheNumRead, Indexes} = cache_read_sparse(Indexes1, Cache, []),
+    ok = incr_counter(Cfg, ?C_RA_LOG_READ_CACHE, CacheNumRead),
+    {Entries1, Reader} = ra_log_reader:sparse_read(Reader0, Indexes, Entries0),
+    Entries = case Sort of
+                  descending ->
+                      lists:reverse(Entries1);
+                  unsorted ->
+                      %% need to return entries in the order of the original
+                      %% Indexes0 list
+                      Lookup = lists:foldl(
+                                 fun ({I, _, _} = E, Acc) ->
+                                         maps:put(I, E, Acc)
+                                 end, #{}, Entries1),
+                      maps_with_values(Indexes0, Lookup);
+                  _ ->
+                      %% nothing to do for ascending or undefined
+                      Entries1
+              end,
+
+    {Entries, State#?MODULE{reader = Reader}}.
 
 -spec last_index_term(state()) -> ra_idxterm().
 last_index_term(#?MODULE{last_index = LastIdx, last_term = LastTerm}) ->
@@ -844,6 +887,19 @@ cache_take0(Next, Last, Cache, Acc) ->
             Acc
     end.
 
+cache_read_sparse(Indexes, Cache, Acc) ->
+    cache_read_sparse(Indexes, Cache, 0, Acc).
+
+cache_read_sparse([], _Cache, Num, Acc) ->
+    {Acc, Num, []}; %% no reminder
+cache_read_sparse([Next | Rem] = Indexes, Cache, Num, Acc) ->
+    case Cache of
+        #{Next := Entry} ->
+            cache_read_sparse(Rem, Cache, Num + 1, [Entry | Acc]);
+        _ ->
+            {Acc, Num, Indexes}
+    end.
+
 maybe_append_first_entry(State0 = #?MODULE{last_index = -1}) ->
     State = append({0, 0, undefined}, State0),
     receive
@@ -993,6 +1049,18 @@ incr_counter(#cfg{counter = undefined}, _Ix, _N) ->
 server_data_dir(Dir, UId) ->
     Me = ra_lib:to_list(UId),
     filename:join(Dir, Me).
+
+maps_with_values(Keys, Map) ->
+    lists:foldr(
+      fun (K, Acc) ->
+              case Map of
+                  #{K := Value} ->
+                      [Value | Acc];
+                  _ ->
+                      Acc
+              end
+      end, [], Keys).
+
 %%%% TESTS
 
 -ifdef(TEST).

--- a/src/ra_log_reader.erl
+++ b/src/ra_log_reader.erl
@@ -171,7 +171,7 @@ sparse_read(#?STATE{cfg = #cfg{} = Cfg} = State, Indexes0, Entries0) ->
             {Entries1, State};
         {Entries1, OpenC, Rem1} ->
             ok = incr_counter(Cfg, ?C_RA_LOG_READ_OPEN_MEM_TBL, OpenC),
-            case catch closed_mem_tbl_sparse_read(Cfg, Rem1, Entries1) of
+            case closed_mem_tbl_sparse_read(Cfg, Rem1, Entries1) of
                 {Entries2, ClosedC, []} ->
                     ok = incr_counter(Cfg, ?C_RA_LOG_READ_CLOSED_MEM_TBL, ClosedC),
                     {Entries2, State};
@@ -180,10 +180,6 @@ sparse_read(#?STATE{cfg = #cfg{} = Cfg} = State, Indexes0, Entries0) ->
                     {Open, _, SegC, Entries} = (catch segment_sparse_read(State, Rem2, Entries2)),
                     ok = incr_counter(Cfg, ?C_RA_LOG_READ_SEGMENT, SegC),
                     {Entries, State#?MODULE{open_segments = Open}}
-                % {ets_miss, _Index} ->
-                %     %% this would happend if a mem table was deleted after
-                %     %% an external reader had read the range
-                %     sparse_read(N-1, From, To, Entries0, State)
             end
     end.
 

--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -21,7 +21,6 @@
          max_count/1,
          filename/1,
          segref/1,
-         advise/1,
          is_same_as/2]).
 
 -export([dump/1,
@@ -374,10 +373,6 @@ segref(#state{range = undefined}) ->
 segref(#state{range = {Start, End},
               cfg = #cfg{filename = Fn}}) ->
     {Start, End, ra_lib:to_string(filename:basename(Fn))}.
-
-advise(#state{cfg = #cfg{fd = Fd, mode = read}}) ->
-    file:advise(Fd, 0, 0, will_need).
-
 
 -spec is_same_as(state(), file:filename_all()) -> boolean().
 is_same_as(#state{cfg = #cfg{filename = Fn0}}, Fn) ->

--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -133,6 +133,7 @@
     {demonitor, node, node()} |
     {timer, term(), non_neg_integer() | infinity} |
     {log, [ra_index()], fun(([user_command()]) -> effects())} |
+    {log, [ra_index()], fun(([user_command()]) -> effects()), {local, node()}} |
     {release_cursor, ra_index(), state()} |
     {aux, term()} |
     garbage_collection.

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -301,6 +301,7 @@ pipeline_command(Config) ->
     receive
         {ra_event, _, {applied, [{Correlation, 14}]}} -> ok
     after 2000 ->
+              flush(),
               exit(consensus_timeout)
     end,
     terminate_cluster(Cluster).

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -46,6 +46,7 @@ all_tests() ->
      missed_closed_tables_are_deleted_at_next_opportunity,
      transient_writer_is_handled,
      read_opt,
+     sparse_read,
      written_event_after_snapshot,
      updated_segment_can_be_read,
      open_segments_limit,
@@ -285,6 +286,57 @@ read_opt(Config) ->
     ct:pal("read all took ~wms Reduction ~w", [Time3 / 1000, Reds3]),
     ok.
 
+sparse_read(Config) ->
+    Num = 4096 * 2,
+    Div = 2,
+    Log0 = write_and_roll(1, Num div Div, 1, ra_log_init(Config), 50),
+    Log1 = wait_for_segments(Log0, 5000),
+    Log2 = write_no_roll(Num div Div, Num, 1, Log1, 50),
+    %% read small batch of the latest entries
+    {_, _, Log3} = ra_log:take(Num - 5, 5, Log2),
+    ct:pal("log overview ~p", [ra_log:overview(Log3)]),
+    %% warm up run
+    {_, _, Log4} = ra_log:take(1, Num, Log3),
+    ra_log:close(Log4),
+    NumDiv2 = Num div 2,
+    %% create a list of indexes with some consecutive and some gaps
+    Indexes = lists:usort(lists:seq(1, Num, 2) ++ lists:seq(1, Num, 5)),
+    LogTake = ra_log_init(Config),
+    {TimeTake, {_, _, LogTake1}} =
+        timer:tc(fun () ->
+                         _ = erlang:statistics(exact_reductions),
+                         ra_log:take(1, NumDiv2, LogTake)
+                 end),
+    {_, Reds} = erlang:statistics(exact_reductions),
+    ra_log:close(LogTake1),
+    ct:pal("read ~b Indexes with take/3 took ~wms Reduction ~w",
+           [NumDiv2, TimeTake / 1000, Reds]),
+
+    LogSparse = ra_log_init(Config),
+    {TimeSparse, {SparseEntries, _}} =
+        timer:tc(fun () ->
+                         _ = erlang:statistics(exact_reductions),
+                         ra_log:sparse_read(Indexes, LogSparse)
+                 end),
+    {_, Reds2} = erlang:statistics(exact_reductions),
+    ReadIndexes = [I || {I, _, _} <- SparseEntries],
+    ?assertEqual(Indexes, ReadIndexes),
+    ct:pal("read ~b indexes with sparse_read/2 took ~wms Reduction ~w",
+           [length(SparseEntries), TimeSparse / 1000, Reds2]),
+
+    LogO = ra_log_init(Config),
+    {[{1, _, _},
+      {2, _, _},
+      {3, _, _}], LogO1} = ra_log:sparse_read([1,2,3], LogO),
+
+    {[{6, _, _},
+      {5, _, _},
+      {3, _, _}], LogO2} = ra_log:sparse_read([6,5,3], LogO1),
+
+    {[{1000, _, _},
+      {5, _, _},
+      {99, _, _}], _LogO3} = ra_log:sparse_read([1000,5,99], LogO2),
+    ok.
 
 written_event_after_snapshot(Config) ->
     Log0 = ra_log_init(Config, #{snapshot_interval => 1}),
@@ -993,6 +1045,10 @@ write_and_roll(From, To, Term, Log0, Timeout) ->
     ok = ra_log_wal:force_roll_over(ra_log_wal),
     deliver_all_log_events(Log1, Timeout).
 
+write_no_roll(From, To, Term, Log0, Timeout) ->
+    Log1 = write_n(From, To, Term, Log0),
+    deliver_all_log_events(Log1, Timeout).
+
 write_and_roll_no_deliver(From, To, Term, Log0) ->
     Log1 = write_n(From, To, Term, Log0),
     ok = ra_log_wal:force_roll_over(ra_log_wal),
@@ -1017,7 +1073,17 @@ deliver_all_log_events(Log0, Timeout) ->
     receive
         {ra_log_event, Evt} ->
             ct:pal("log evt: ~p", [Evt]),
-            {Log, Effs} = ra_log:handle_event(Evt, Log0),
+            {Log1, Effs} = ra_log:handle_event(Evt, Log0),
+            Log = lists:foldl(
+                    fun({send_msg, P, E}, Acc) ->
+                            P ! E,
+                            Acc;
+                       ({next_event, {ra_log_event, E}}, Acc0) ->
+                            {Acc, _} = ra_log:handle_event(E, Acc0),
+                            Acc;
+                       (_, Acc) ->
+                            Acc
+                    end, Log1, Effs),
             [P ! E || {send_msg, P, E, _} <- Effs],
             % ct:pal("log evt effs: ~p", [Effs]),
             deliver_all_log_events(Log, Timeout)


### PR DESCRIPTION
This implements a more efficient way of reading a list of non consecutive indexes from the Ra log using a new `ra_log:sparse_read` function. This can be used by RabbitMQ quorum queues to read messages due to be delivered to consumers in a faster manner.

There is also an optimisation where it will automatically read ahead if some of the indexes in the requested list form a consecutive run (as is likely to happen for RabbitMQ quorum queues also).