### PR TITLE
Fix bugs in log cache truncation

### DIFF
--- a/src/ra_bench.erl
+++ b/src/ra_bench.erl
@@ -107,7 +107,6 @@ run(#{name := Name,
                                    print_counter(counters:get(Counter, 1), Counter)
                            end),
     %% wait for each pid
-    
     Wait = ((Secs * 10000) * 4),
     [begin
          receive

--- a/test/ra_log_props_SUITE.erl
+++ b/test/ra_log_props_SUITE.erl
@@ -25,9 +25,9 @@ all_tests() ->
      write,
      % write_missing_entry,
      % multi_write_missing_entry,
-     write_overwrite_entry
+     write_overwrite_entry,
      % write_index_starts_zero,
-     % append,
+     append
      % append_missing_entry,
      % append_overwrite_entry,
      % append_index_starts_one,


### PR DESCRIPTION
There are cases where the cache was never truncated.

Also make the truncate_cache function a bit simpler and more likely
to eventually catch cases where the cache may be growing.
