### PR TITLE
Handle pre_vote messages in the await_condition states

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1259,6 +1259,8 @@ handle_receive_snapshot(Msg, State) ->
     {ra_state(), ra_server_state(), effects()}.
 handle_await_condition(#request_vote_rpc{} = Msg, State) ->
     {follower, State, [{next_event, Msg}]};
+handle_await_condition(#pre_vote_rpc{} = PreVote, State) ->
+    process_pre_vote(await_condition, PreVote, State);
 handle_await_condition(election_timeout, State) ->
     call_for_election(pre_vote, State);
 handle_await_condition(await_condition_timeout,
@@ -1922,7 +1924,7 @@ process_pre_vote(FsmState, #pre_vote_rpc{term = Term, candidate_id = Cand,
             case FsmState of
                 follower ->
                     {FsmState, State, [start_election_timeout]};
-                pre_vote ->
+                _ ->
                     {FsmState, State,
                      [{reply, pre_vote_result(Term, Token, false)}]}
             end

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -50,7 +50,8 @@ all_tests() ->
      follower_catchup,
      post_partition_liveness,
      all_metrics_are_integers,
-     transfer_leadership
+     transfer_leadership,
+     transfer_leadership_two_node
     ].
 
 groups() ->
@@ -744,6 +745,22 @@ transfer_leadership(Config) ->
     {ok, _, _} = ra:start_cluster(default, Name, add_machine(), Members),
     % issue a command
     {ok, _, Leader} = ra:process_command({n3, node()}, 5),
+    % transfer leadership
+    [NextInLine | _] = Members -- [Leader],
+    ct:pal("Transferring leadership from ~p to ~p", [Leader, NextInLine]),
+    ok = ra:transfer_leadership(Leader, NextInLine),
+    {ok, _, NewLeader} = ra:process_command(NextInLine, 5),
+    ?assertEqual(NewLeader, NextInLine),
+    ?assertEqual(already_leader, ra:transfer_leadership(NewLeader, NewLeader)),
+    ?assertEqual({error, unknown_member}, ra:transfer_leadership(NewLeader, {unknown, node()})),
+    terminate_cluster(Members).
+
+transfer_leadership_two_node(Config) ->
+    Name = ?config(test_name, Config),
+    Members = [{n1, node()}, {n2, node()}],
+    {ok, _, _} = ra:start_cluster(default, Name, add_machine(), Members),
+    % issue a command
+    {ok, _, Leader} = ra:process_command({n2, node()}, 5),
     % transfer leadership
     [NextInLine | _] = Members -- [Leader],
     ct:pal("Transferring leadership from ~p to ~p", [Leader, NextInLine]),


### PR DESCRIPTION
This allows for better availability if a leader change is needed
whilst any node(s) is in await_condition. An example would be a
leader transfer in a 2 node cluster or when one node is down.

Fixes #251 