### PR TITLE
Don't send snapshots to followers with a lower machine version

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1322,7 +1322,11 @@ overview(#{cfg := #cfg{effective_machine_module = MacMod} = Cfg,
                     cluster, leader_id, voted_for], State),
     O = maps:merge(O0, cfg_to_map(Cfg)),
     LogOverview = ra_log:overview(Log),
-    MacOverview = ra_machine:overview(MacMod, MacState),
+    MacOverview = try ra_machine:overview(MacMod, MacState) of
+                      MO -> MO
+                  catch _:_ = Err ->
+                            {machine_overview_crashed, Err}
+                  end,
     O#{log => LogOverview,
        aux => Aux,
        machine => MacOverview}.

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -40,6 +40,7 @@
          leader_id/1,
          current_term/1,
          machine_version/1,
+         machine/1,
          machine_query/2,
          % TODO: hide behind a handle_leader
          make_rpcs/1,
@@ -1418,6 +1419,10 @@ current_term(State) ->
 -spec machine_version(ra_server_state()) -> non_neg_integer().
 machine_version(#{cfg := #cfg{machine_version = MacVer}}) ->
     MacVer.
+
+-spec machine(ra_server_state()) -> ra_machine:machine().
+machine(#{cfg := #cfg{machine = Machine}}) ->
+    Machine.
 
 -spec machine_query(fun((term()) -> term()), ra_server_state()) ->
     {ra_idxterm(), term()}.

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1499,6 +1499,7 @@ send_snapshots(Me, Id, Term, {_, ToNode} = To, ChunkSize,
 
     case SnapMacVer > TheirMacVer of
         true ->
+            timer:sleep(InstallTimeout),
             ok;
         false ->
             RPC = #install_snapshot_rpc{term = Term,


### PR DESCRIPTION
This is a temporary fix to avoid followers installing snapshots they
cannot yet understand.
