### PR TITLE
Install higher versioned snapshot

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1158,13 +1158,18 @@ handle_follower(#install_snapshot_rpc{term = Term,
 %% need to check if it's the first or last rpc
 %% TODO: must abort pending if for some reason we need to do so
 handle_follower(#install_snapshot_rpc{term = Term,
-                                      meta = #{index := SnapIdx} = Meta,
+                                      meta = #{index := SnapIdx,
+                                               machine_version := SnapMacVer} = Meta,
                                       leader_id = LeaderId,
                                       chunk_state = {1, _ChunkFlag}} = Rpc,
-                #{cfg := #cfg{log_id = LogId}, log := Log0,
+                #{cfg := #cfg{log_id = LogId,
+                              machine_version = MacVer}, log := Log0,
                   last_applied := LastApplied,
                   current_term := CurTerm} = State0)
-  when Term >= CurTerm andalso SnapIdx > LastApplied ->
+  when Term >= CurTerm andalso
+       SnapIdx > LastApplied andalso
+       %% only install snapshot if the machine version is understood
+       MacVer >= SnapMacVer ->
     %% only begin snapshot procedure if Idx is higher than the last_applied
     %% index.
     ?DEBUG("~s: begin_accept snapshot at index ~b in term ~b",
@@ -1197,32 +1202,51 @@ handle_follower(Msg, State) ->
     {follower, State, []}.
 
 handle_receive_snapshot(#install_snapshot_rpc{term = Term,
-                                              meta = #{index := LastIndex,
-                                                       term := LastTerm},
+                                              meta = #{index := SnapIndex,
+                                                       machine_version := SnapMacVer,
+                                                       term := SnapTerm},
                                               chunk_state = {Num, ChunkFlag},
                                               data = Data},
-                        #{cfg := #cfg{id = Id, log_id = LogId},
+                        #{cfg := #cfg{id = Id,
+                                      log_id = LogId,
+                                      effective_machine_version = CurEffMacVer,
+                                      machine_versions = MachineVersions,
+                                      machine = Machine} = Cfg0,
                           log := Log0,
                           current_term := CurTerm} = State0)
   when Term >= CurTerm ->
     ?DEBUG("~s: receiving snapshot chunk: ~b / ~w, index ~b, term ~b",
-           [LogId, Num, ChunkFlag, LastIndex, LastTerm]),
+           [LogId, Num, ChunkFlag, SnapIndex, SnapTerm]),
     SnapState0 = ra_log:snapshot_state(Log0),
     {ok, SnapState} = ra_snapshot:accept_chunk(Data, Num, ChunkFlag,
                                                SnapState0),
     Reply = #install_snapshot_result{term = CurTerm,
-                                     last_term = LastTerm,
-                                     last_index = LastIndex},
+                                     last_term = SnapTerm,
+                                     last_index = SnapIndex},
     case ChunkFlag of
         last ->
             %% this is the last chunk so we can "install" it
-            {Log, Effs} = ra_log:install_snapshot({LastIndex, LastTerm},
+            {Log, Effs} = ra_log:install_snapshot({SnapIndex, SnapTerm},
                                                   SnapState, Log0),
+            %% if the machine version of the snapshot is higher
+            %% we also need to update the current effective machine configuration
+            Cfg = case SnapMacVer > CurEffMacVer of
+                      true ->
+                          EffMacMod = ra_machine:which_module(Machine, SnapMacVer),
+                          Cfg0#cfg{effective_machine_version = SnapMacVer,
+                                   machine_versions = [{SnapIndex, SnapMacVer}
+                                                       | MachineVersions],
+                                   effective_machine_module = EffMacMod};
+                      false ->
+                          Cfg0
+                  end,
+
             {#{cluster := ClusterIds}, MacState} = ra_log:recover_snapshot(Log),
-            State = State0#{log => Log,
+            State = State0#{cfg => Cfg,
+                            log => Log,
                             current_term => Term,
-                            commit_index => LastIndex,
-                            last_applied => LastIndex,
+                            commit_index => SnapIndex,
+                            last_applied => SnapIndex,
                             cluster => make_cluster(Id, ClusterIds),
                             machine_state => MacState},
             %% it was the last snapshot chunk so we can revert back to

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1775,9 +1775,13 @@ handle_down(leader, machine, Pid, Info, State)
     handle_leader({command, {'$usr', #{ts => erlang:system_time(millisecond)},
                             {down, Pid, Info}, noreply}},
                   State);
-handle_down(leader, snapshot_sender, Pid, Info,
+handle_down(RaftState, snapshot_sender, Pid, Info,
             #{cfg := #cfg{log_id = LogId}} = State)
-  when is_pid(Pid) ->
+  when (RaftState == leader orelse
+        RaftState == await_condition)
+       andalso is_pid(Pid)  ->
+    %% if a rebalance is being done we also need to handle snapshot_sender
+    %% downs here
     ?DEBUG_IF(Info /= normal,
               "~s: Snapshot sender process ~w exited with ~W",
               [LogId, Pid, Info, 10]),

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -40,6 +40,7 @@
          leader_id/1,
          current_term/1,
          machine_version/1,
+         machine/1,
          machine_query/2,
          % TODO: hide behind a handle_leader
          make_rpcs/1,
@@ -1418,6 +1419,10 @@ current_term(State) ->
 -spec machine_version(ra_server_state()) -> non_neg_integer().
 machine_version(#{cfg := #cfg{machine_version = MacVer}}) ->
     MacVer.
+
+-spec machine(ra_server_state()) -> ra_machine:machine().
+machine(#{cfg := #cfg{machine = Machine}}) ->
+    Machine.
 
 -spec machine_query(fun((term()) -> term()), ra_server_state()) ->
     {ra_idxterm(), term()}.

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -447,7 +447,7 @@ leader(_, tick_timeout, State0) ->
     ServerState = State1#state.server_state,
     Effects = ra_server:tick(ServerState),
     {State2, Actions} = ?HANDLE_EFFECTS(RpcEffs ++ Effects ++ [{aux, tick}],
-                                       cast, State1),
+                                        cast, State1),
     %% try sending any pending applied notifications again
     State = send_applied_notifications(State2, #{}),
     {keep_state, handle_tick_metrics(State),

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -47,6 +47,7 @@ all() ->
      leader_appends_cluster_change_then_steps_before_applying_it,
      leader_receives_install_snapshot_rpc,
      follower_installs_snapshot,
+     follower_ignores_installs_snapshot_with_higher_machine_version,
      follower_receives_stale_snapshot,
      receive_snapshot_timeout,
      snapshotted_follower_received_append_entries,
@@ -1210,33 +1211,47 @@ follower_machine_version(_Config) ->
     ok.
 
 follower_install_snapshot_machine_version(_Config) ->
+    %% follower receives a snapshot with a higher machine version that it's current
+    %% effective machine version, in this case the follower will never receive
+    %% the noop command for the machine version bump and thus it needs to be
+    %% updated here
+    MacMod1 = follower_install_snapshot_machine_version_1,
     MacVer = 1,
-    %
-    State00 = base_state(3, ?FUNCTION_NAME),
+    mock_machine(MacMod1),
+
+    #{cfg := Cfg} = State000 = base_state(3, ?FUNCTION_NAME),
+    %% patch up machine version so that the follower "understands" machine version 1
+    State00 = State000#{cfg => Cfg#cfg{machine_version = 1}},
+    meck:expect(?FUNCTION_NAME, which_module,
+                fun (0) ->
+                        ?FUNCTION_NAME;
+                    (1) ->
+                        MacMod1
+                end),
     %% follower with lower machine version is advised of higher machine version
     %% by install snapshot rpc
     SnapMeta = #{index => 4,
                  term => 5,
                  cluster => [?N1, ?N2, ?N3],
                  machine_version => MacVer},
-    SnapData = [<<"hi4_v2">>],
+    SnapData = <<"hi4_v2">>,
 
     ISR = #install_snapshot_rpc{term = 5, leader_id = ?N1,
                                 meta = SnapMeta,
                                 chunk_state = {1, last},
                                 data = SnapData},
-    {receive_snapshot, #{cfg := #cfg{machine_version = 0,
-                                     effective_machine_version = 0},
+    {receive_snapshot, #{cfg := #cfg{effective_machine_version = 0},
                          last_applied := 3,
                          commit_index := _} = State0,
      _Effects0} = ra_server:handle_follower(ISR, State00),
 
     meck:expect(ra_log, recover_snapshot, fun (_) -> {SnapMeta, SnapData} end),
-    {follower, #{cfg := #cfg{machine_version = 0,
+    {follower, #{cfg := #cfg{machine_version = _,%% this gets populated on init only
                              machine_versions = [{4, 1}, {0,0}],
+                             effective_machine_module = MacMod1,
                              effective_machine_version = 1},
-                 last_applied := 3,
-                 machine_state := <<"hi3">>, %% old machine state
+                 last_applied := 4,
+                 machine_state := SnapData, %% old machine state
                  commit_index := 4},
      _} = ra_server:handle_receive_snapshot(ISR, State0),
     ok.
@@ -1642,6 +1657,27 @@ follower_installs_snapshot(_Config) ->
                  leader_id := N1},
      [{reply, #install_snapshot_result{}}]} =
         ra_server:handle_receive_snapshot(ISRpc, FState1),
+
+    ok.
+
+follower_ignores_installs_snapshot_with_higher_machine_version(_Config) ->
+    %% currently followers cannot correctly handle snapshots with a higher
+    %% machine version so have to ignore them
+    N1 = ?N1, N2 = ?N2, N3 = ?N3,
+    #{N3 := {_, FState = #{cluster := Config}, _}}
+    = init_servers([N1, N2, N3], {module, ra_queue, #{}}),
+    LastTerm = 1, % snapshot term
+    Term = 2, % leader term
+    Idx = 3,
+    ISRpc = #install_snapshot_rpc{term = Term, leader_id = N1,
+                                  meta = #{index => Idx,
+                                           term => LastTerm,
+                                           cluster => maps:keys(Config),
+                                           machine_version => 1},
+                                  chunk_state = {1, last},
+                                  data = []},
+    {follower, FState, _} =
+        ra_server:handle_follower(ISRpc, FState),
 
     ok.
 


### PR DESCRIPTION
Fixes around snapshot installations in combination with machine versions.

Firstly leaders will try to avoid sending snapshots to followers that do not yet have the code for the newer machine versions.

Also we better handle snapshots installs with a higher machine versions.