### PR TITLE
Use term_to_iovec instead of term_to_binary in WAL

### DIFF
--- a/test/ra_log_wal_SUITE.erl
+++ b/test/ra_log_wal_SUITE.erl
@@ -176,7 +176,7 @@ write_many(Config) ->
                                                         Batch, Data, Config),
                    io_lib:format("Scenario ~s took ~bms using ~b "
                                  "reductions for ~b writes @ ~b bytes, "
-                                 "batch size ~b",
+                                 "batch size ~b~n",
                                  [Name, Time, Reductions, Num, Data, Batch])
                end || {Name, Num, Check, Batch, Data} <- Tests],
     ct:pal("~s", [Results]),


### PR DESCRIPTION
This should result in fewer allocations inside the WAL as
less binary data will typically be copied when serialising each entry term.

Include two perf page-fault captures: 

`main` branch:
![out_mem_main](https://user-images.githubusercontent.com/1180564/168815163-06181f50-3766-418f-b882-98b28cdfcfc5.svg)
this PR:
![out_mem_pr](https://user-images.githubusercontent.com/1180564/168815174-013e86a6-de31-44ef-bb62-8bdc6edf87e0.svg)

