### PR TITLE
fix ra:overview/1 wal status entry

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -714,12 +714,13 @@ overview(System) ->
 
     #{names := #{segment_writer := SegWriter,
                  open_mem_tbls := OpenTbls,
-                 closed_mem_tbls := ClosedTbls}} = ra_system:fetch(System),
+                 closed_mem_tbls := ClosedTbls,
+                 wal := Wal}} = ra_system:fetch(System),
     #{node => node(),
       servers => ra_directory:overview(System),
       %% TODO:filter counter keys by system
       counters => ra_counters:overview(),
-      wal => #{status => lists:nth(5, element(4, sys:get_status(ra_log_wal))),
+      wal => #{status => lists:nth(5, element(4, sys:get_status(Wal))),
                open_mem_tables => ets:info(OpenTbls, size),
                closed_mem_tables => ets:info(ClosedTbls, size)},
       segment_writer => ra_log_segment_writer:overview(SegWriter)

--- a/test/ra_system_SUITE.erl
+++ b/test/ra_system_SUITE.erl
@@ -30,7 +30,8 @@ all_tests() ->
     [
      start_cluster,
      start_clusters_in_systems,
-     restart_system
+     restart_system,
+     ra_overview
     ].
 
 groups() ->
@@ -142,6 +143,18 @@ restart_system(Config) ->
     [ok = start_system_on(Sys, N, DataDir) || N <- Nodes],
     {ok, Started2, []} = ra:start_cluster(Sys, ClusterName, Machine, ServerIds),
     [] = Started2 -- ServerIds,
+    ok.
+
+ra_overview(Config) ->
+    DataDir = ?config(data_dir, Config),
+    SysCfg = #{name => system_name,
+               data_dir => DataDir,
+               names => ra_system:derive_names(system_name)},
+    application:ensure_all_started(ra),
+    ra_system:start(SysCfg),
+    Overview = ra:overview(system_name),
+    ?assert(is_map(Overview)),
+    ?assert(maps:is_key(servers, Overview)),
     ok.
 
 


### PR DESCRIPTION
fix ra:overview/1 to get wal status from the configured name in the
system config, instead of using ra_log_wal, which is only valid for the
default system

## Proposed Changes

Currently `ra:overview/1` gets wal status by calling `sys:get_status(ra_log_wal)`, which is only valid for the default system, and it fails with noproc if the default system is not started.
The proposed fix uses the `names` section from the system info to get the right name, exactly as it is already done for the segment writer, etc.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
