### PR TITLE
avoid a runtime error when calling ra_system:overview/1 on non started systems

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -711,20 +711,24 @@ overview() ->
 %% @end
 -spec overview(atom()) -> map() | system_not_started.
 overview(System) ->
-
-    #{names := #{segment_writer := SegWriter,
-                 open_mem_tbls := OpenTbls,
-                 closed_mem_tbls := ClosedTbls,
-                 wal := Wal}} = ra_system:fetch(System),
-    #{node => node(),
-      servers => ra_directory:overview(System),
-      %% TODO:filter counter keys by system
-      counters => ra_counters:overview(),
-      wal => #{status => lists:nth(5, element(4, sys:get_status(Wal))),
-               open_mem_tables => ets:info(OpenTbls, size),
-               closed_mem_tables => ets:info(ClosedTbls, size)},
-      segment_writer => ra_log_segment_writer:overview(SegWriter)
-     }.
+    case ra_system:fetch(System) of
+        undefined ->
+            system_not_started;
+        Config ->
+            #{names := #{segment_writer := SegWriter,
+                         open_mem_tbls := OpenTbls,
+                         closed_mem_tbls := ClosedTbls,
+                         wal := Wal}} = Config,
+            #{node => node(),
+              servers => ra_directory:overview(System),
+              %% TODO:filter counter keys by system
+              counters => ra_counters:overview(),
+              wal => #{status => lists:nth(5, element(4, sys:get_status(Wal))),
+                       open_mem_tables => ets:info(OpenTbls, size),
+                       closed_mem_tables => ets:info(ClosedTbls, size)},
+              segment_writer => ra_log_segment_writer:overview(SegWriter)
+             }
+    end.
 
 %% @doc Submits a command to a ra server. Returns after the command has
 %% been applied to the Raft state machine. If the state machine returned a

--- a/test/ra_system_SUITE.erl
+++ b/test/ra_system_SUITE.erl
@@ -31,7 +31,8 @@ all_tests() ->
      start_cluster,
      start_clusters_in_systems,
      restart_system,
-     ra_overview
+     ra_overview,
+     ra_overview_not_started
     ].
 
 groups() ->
@@ -156,6 +157,9 @@ ra_overview(Config) ->
     ?assert(is_map(Overview)),
     ?assert(maps:is_key(servers, Overview)),
     ok.
+
+ra_overview_not_started(_Config) ->
+    ?assertEqual(ra:overview(unstarted_system), system_not_started).
 
 
 %% Utility


### PR DESCRIPTION
## Proposed Changes

Calling ra_system:overview/1 on a non started system causes a runtime error instead of returning `system_not_started` as per the spec.
This simple change should fix that.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories


