### PR TITLE
fix bad match when a node in follower state terminates

### DIFF
--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -687,7 +687,7 @@ follower(info, {node_event, Node, down}, State0) ->
             {State, Actions} = maybe_set_election_timeout(long, State0, []),
             {keep_state, State, Actions};
         _ ->
-            {keep_state, State0}
+            {keep_state, State0, []}
     end;
 follower(info, {node_event, Node, up}, State) ->
     case leader_id(State) of
@@ -698,7 +698,7 @@ follower(info, {node_event, Node, up}, State) ->
              State#state{election_timeout_set = false},
              [{state_timeout, infinity, election_timeout}]};
         _ ->
-            {keep_state, State}
+            {keep_state, State, []}
     end;
 follower(info, {Status, Node, InfoList}, State0)
   when Status =:= nodedown orelse Status =:= nodeup ->


### PR DESCRIPTION

## Proposed Changes

This follows up the discussion in #282, and modifies the `ra_server_proc:follower` function to always return a 3-element tuple, as suggested in the issue. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

