### PR TITLE
Use more efficient iovec

### DIFF
--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -420,9 +420,7 @@ dump_index(File) ->
                                ]),
     {ok, Version, MaxCount} = read_header(Fd),
     IndexSize = MaxCount * index_record_size(Version),
-    {ok, ?HEADER_SIZE} = file:position(Fd, ?HEADER_SIZE),
-    DataOffset = ?HEADER_SIZE + IndexSize,
-    case file:read(Fd, IndexSize) of
+    case file:pread(Fd, ?HEADER_SIZE, IndexSize) of
         {ok, Data} ->
             D = [begin
                      % {ok, _} = file:position(Fd, O),
@@ -435,6 +433,7 @@ dump_index(File) ->
             _ = file:close(Fd),
             % if no entries have been written the file hasn't "stretched"
             % to where the data offset starts.
+            DataOffset = ?HEADER_SIZE + IndexSize,
             {0, DataOffset, undefined, #{}}
     end.
 

--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -166,7 +166,7 @@ process_file(false, Mode, Filename, Fd, Options) ->
                 data_write_offset = ?HEADER_SIZE + IndexSize
                }}.
 
--spec append(state(), ra_index(), ra_term(), binary()) ->
+-spec append(state(), ra_index(), ra_term(), iodata()) ->
     {ok, state()} | {error, full | inet:posix()}.
 append(#state{cfg = #cfg{max_pending = PendingCount},
               pending_count = PendingCount} = State0,
@@ -190,7 +190,7 @@ append(#state{cfg = #cfg{version = Version,
     % check if file is full
     case IndexOffset < DataStart of
         true ->
-            Length = erlang:byte_size(Data),
+            Length = erlang:iolist_size(Data),
             % TODO: check length is less than #FFFFFFFF ??
             Checksum = erlang:crc32(Data),
             OSize = offset_size(Version),

--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -306,7 +306,7 @@ append_to_segment(_, _, StartIdx, EndIdx, Seg, Closed, _State)
     {Seg, Closed};
 append_to_segment(UId, Tid, Idx, EndIdx, Seg0, Closed, State) ->
     [{_, Term, Data0}] = ets:lookup(Tid, Idx),
-    Data = term_to_binary(Data0),
+    Data = term_to_iovec(Data0),
     case ra_log_segment:append(Seg0, Idx, Term, Data) of
         {ok, Seg} ->
             ok = counters:add(State#state.counter, ?C_ENTRIES, 1),

--- a/src/ra_log_snapshot.erl
+++ b/src/ra_log_snapshot.erl
@@ -81,8 +81,7 @@ complete_accept(Chunk, {PartialCrc, Fd}) ->
     complete_accept(Rest, {PartialCrc, Crc, Fd});
 complete_accept(Chunk, {PartialCrc0, Crc, Fd}) ->
     ok = file:write(Fd, Chunk),
-    {ok, 5} = file:position(Fd, 5),
-    ok = file:write(Fd, <<Crc:32/integer>>),
+    ok = file:pwrite(Fd, 5, <<Crc:32/integer>>),
     Crc = erlang:crc32(PartialCrc0, Chunk),
     ok = file:sync(Fd),
     ok = file:close(Fd),
@@ -113,8 +112,7 @@ read_chunk({Crc, ReadState}, Size, Dir) when is_integer(Crc) ->
             Err
     end;
 read_chunk({Pos, Eof, Fd}, Size, _Dir) ->
-    {ok, _} = file:position(Fd, Pos),
-    case file:read(Fd, Size) of
+    case file:pread(Fd, Pos, Size) of
         {ok, Data} ->
             case Pos + Size >= Eof of
                 true ->

--- a/test/ra_log_segment_SUITE.erl
+++ b/test/ra_log_segment_SUITE.erl
@@ -98,7 +98,7 @@ large_segment(Config) ->
     {ok, Seg0} = ra_log_segment:open(Fn),
     Seg = lists:foldl(
       fun (Idx, S0) ->
-              Data = make_data(1100 * 1100),
+              Data = term_to_iovec(crypto:strong_rand_bytes(1100 * 1100)),
               {ok, S} = ra_log_segment:append(S0, Idx, 1, Data),
               S
       end, Seg0, lists:seq(1, 4096)),


### PR DESCRIPTION
Starting rabbitmq-server with 3 schedulers (+S 3) and running perf-test
with
```
-x 1 -y 0 -u qq -qa x-queue-type=quorum -ad false -f persistent -s 200000
```

Flame graphs show that for function `ra_log_segment_writer:append_to_segment`:
* CPU usage drop from 32.7% to 27.1%
* mmap system calls drop from 135,830 (82%) to 110 (0.37%)
* page faults drop from 95,163 (63%) to 293 (1%)

where perf recordings ran for 60 seconds.

CPU before:
![before-cpu](https://user-images.githubusercontent.com/12648310/172363015-4883d907-031a-4bfb-a453-736450f38fde.png)

CPU after:
![after-cpu](https://user-images.githubusercontent.com/12648310/172363039-c55b943a-908a-41ea-85ab-8dcace20da8d.png)

mmap before:
![before-mmap](https://user-images.githubusercontent.com/12648310/172363065-97bac81b-d761-489f-8f4e-3fa7a432471d.png)

mmap after:
![after-mmap](https://user-images.githubusercontent.com/12648310/172363076-dae440c5-7d0b-4cd5-869a-0038643d59f7.png)

page faults before:
![before-page-faults](https://user-images.githubusercontent.com/12648310/172363104-65753408-02ee-4f63-96e3-4be9c66da8b6.png)

page faults after:
![after-page-faults](https://user-images.githubusercontent.com/12648310/172363125-5b581c50-a138-4141-a1a1-89179bdad05b.png)

