### PR TITLE
Clear leader ID after receiving a DOWN event in `ra_server_proc`

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -38,6 +38,7 @@
          log_id/1,
          system_config/1,
          leader_id/1,
+         clear_leader_id/1,
          current_term/1,
          machine_version/1,
          machine/1,
@@ -1435,6 +1436,10 @@ system_config(#{cfg := #cfg{system_config = SC}}) -> SC.
 -spec leader_id(ra_server_state()) -> maybe(ra_server_id()).
 leader_id(State) ->
     maps:get(leader_id, State, undefined).
+
+-spec clear_leader_id(ra_server_state()) -> ra_server_state().
+clear_leader_id(State) ->
+    State#{leader_id => undefined}.
 
 -spec current_term(ra_server_state()) -> maybe(ra_term()).
 current_term(State) ->

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -626,8 +626,8 @@ send_command_to_follower_during_election() ->
     [{timetrap, {seconds, 20}}].
 
 send_command_to_follower_during_election(Config) ->
-    %ok = logger:set_primary_config(level, debug),
-    %ok = logger:update_handler_config(default, #{filter_default => log}),
+    ok = logger:set_primary_config(level, debug),
+    ok = logger:update_handler_config(default, #{filter_default => log}),
 
     Name = ?config(test_name, Config),
     Members = [{n1, node()}, {n2, node()}, {n3, node()}],

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -639,6 +639,10 @@ send_command_to_follower_during_election(Config) ->
     [Follower, _] = Followers,
 
     % shut down the leader
+    % first we ensure that the follower we will use later at least has
+    % learnt about the first leader
+    ra:members(Follower),
+
     gen_statem:stop(Leader, normal, 2000),
     % issue command to confirm a new leader is elected
     NewLeader = wait_for_leader(Leader, Follower, 5, 5000),

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -47,6 +47,8 @@ all_tests() ->
      start_and_join_then_leave_and_terminate,
      leader_steps_down_after_replicating_new_cluster,
      stop_leader_and_wait_for_elections,
+     {testcase, send_command_to_follower_during_election,
+      [{repeat_until_fail, 50}]},
      follower_catchup,
      post_partition_liveness,
      all_metrics_are_integers,
@@ -619,6 +621,53 @@ stop_leader_and_wait_for_elections(Config) ->
     {ok, _, NewLeader} = ra:process_command(Serv, 5),
     true = (NewLeader =/= Leader),
     terminate_cluster(Rem).
+
+send_command_to_follower_during_election() ->
+    [{timetrap, {seconds, 20}}].
+
+send_command_to_follower_during_election(Config) ->
+    %ok = logger:set_primary_config(level, debug),
+    %ok = logger:update_handler_config(default, #{filter_default => log}),
+
+    Name = ?config(test_name, Config),
+    Members = [{n1, node()}, {n2, node()}, {n3, node()}],
+    {ok, _, _} = ra:start_cluster(default, Name, add_machine(), Members),
+    % issue one command to query leader
+    {ok, _, Leader} = ra:process_command({n3, node()}, 5),
+    Followers = Members -- [Leader],
+    ct:pal("Leader = ~p~nFollowers = ~p", [Leader, Followers]),
+    [Follower, _] = Followers,
+
+    % shut down the leader
+    gen_statem:stop(Leader, normal, 2000),
+    % issue command to confirm a new leader is elected
+    NewLeader = wait_for_leader(Leader, Follower, 5, 5000),
+    ?assertNotEqual(Leader, NewLeader),
+    terminate_cluster(Followers).
+
+wait_for_leader(OldLeader, Follower, Command, Timeout) ->
+    case ra:process_command(Follower, Command, Timeout) of
+        {ok, _, NewLeader} ->
+            NewLeader;
+        {timeout, Follower} ->
+            wait_for_leader(OldLeader, Follower, Command, Timeout);
+        {timeout, OldLeader} ->
+            ct:pal(
+              "ERROR: Follower ~0p redirected command to exited "
+              "leader on ~0p",
+              [Follower, OldLeader]),
+            exit({bad_redirect_from_follower_to_exited_leader,
+                  #{follower => Follower,
+                    exited_leader => OldLeader}});
+        {error, noproc} ->
+            ct:pal(
+              "ERROR: Follower ~0p (probably) redirected command "
+              "to exited leader on ~0p",
+              [Follower, OldLeader]),
+            exit({bad_redirect_from_follower_to_exited_leader,
+                  #{follower => Follower,
+                    exited_leader => OldLeader}})
+    end.
 
 queue_example(Config) ->
     Self = self(),


### PR DESCRIPTION
If the DOWN reason is something else than `noconnection`, we know that the leader process is really gone. We want to clear the leader ID we know at this point, while a new election is running.

This is to make sure that `follower_leader_change()` won't create a useless monitor and more importantly, it won't redirect pending commands to that old leader. This would cause the commands callers to get a `noproc' error or a timeout.

Without this fix, I observe the following sequence of events in a 3-node Ra cluster:
1. The leader is stopped.
2. Followers receive a `DOWN` event with the `shutdown` reason.
3. They clear the monitor reference and set an election timer.
4. If a follower receives messages before it switches to the `pre_vote` state, it will call `follower_leader_change()` for each of them.
5. In `follower_leader_change()`, `NewLeader` is still the `OldLeader` because it was never cleared and the election is still in progress. However, the monitor reference is cleared already. Therefore the last clause in `follower_leader_change()` is executed.
6. A new monitor is created for an exited process; this monitor emits a new `DOWN` event right away with the `noproc` reason.
7. Pending commands are redirected to the `NewLeader` which is `OldLeader`.
8. The redirect either returns `{error, noproc}` if the process was not restarted or `{timeout, OldLeader}` if the process is being restarted but before the election is finished.

The redirect is therefore bogus in this case. I would expect the command to either be processed after the election is successful, or time out at the follower (not after a redirect to the wrong process).