### PR TITLE
add start_cluster/1

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -33,6 +33,7 @@
          consistent_query/3,
          ping/2,
          % cluster operations
+         start_cluster/1,
          start_cluster/2,
          start_cluster/3,
          start_cluster/4,
@@ -374,6 +375,12 @@ start_cluster(System, ClusterName, Machine, ServerIds, Timeout)
 %% If a cluster could not be formed any servers that did manage to start are
 %% forcefully deleted.
 %% @end
+-spec start_cluster([ra_server:ra_server_config()]) ->
+    {ok, [ra_server_id()], [ra_server_id()]} |
+    {error, cluster_not_formed}.
+start_cluster(ServerConfigs)
+  start_cluster(default, ServerConfigs).
+
 -spec start_cluster(atom(), [ra_server:ra_server_config()]) ->
     {ok, [ra_server_id()], [ra_server_id()]} |
     {error, cluster_not_formed}.


### PR DESCRIPTION
## Proposed Changes

trying to upgrade ra library from previous outdated version where System wasn't part of ra library.
adding start_cluster/1 which defers to start_cluster/2 with `default` will help upgrade


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

