### PR TITLE
Fix docs for `ra:start_cluster/1`

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -361,8 +361,18 @@ start_cluster(System, ClusterName, Machine, ServerIds, Timeout)
                end || Id <- ServerIds],
     start_cluster(System, Configs, Timeout).
 
+%% @doc Same as `start_cluster/2' but uses the default Ra system.
+%% @param ServerConfigs a list of initial server configurations
+%% DEPRECATED: use start_cluster/2
+%% @end
+-spec start_cluster([ra_server:ra_server_config()]) ->
+    {ok, [ra_server_id()], [ra_server_id()]} |
+    {error, cluster_not_formed}.
+start_cluster(ServerConfigs) ->
+  start_cluster(default, ServerConfigs).
+
 %% @doc Starts a new distributed ra cluster.
-%%
+%% @param System the system name
 %% @param ServerConfigs a list of initial server configurations
 %% @returns
 %% `{ok, Started, NotStarted}'  if a cluster could be successfully
@@ -375,12 +385,6 @@ start_cluster(System, ClusterName, Machine, ServerIds, Timeout)
 %% If a cluster could not be formed any servers that did manage to start are
 %% forcefully deleted.
 %% @end
--spec start_cluster([ra_server:ra_server_config()]) ->
-    {ok, [ra_server_id()], [ra_server_id()]} |
-    {error, cluster_not_formed}.
-start_cluster(ServerConfigs)
-  start_cluster(default, ServerConfigs).
-
 -spec start_cluster(atom(), [ra_server:ra_server_config()]) ->
     {ok, [ra_server_id()], [ra_server_id()]} |
     {error, cluster_not_formed}.
@@ -388,7 +392,8 @@ start_cluster(System, ServerConfigs)
   when is_atom(System) ->
     start_cluster(System, ServerConfigs, ?START_TIMEOUT).
 
-%% @doc Same as `start_cluster/1' but accepts a custom timeout.
+%% @doc Same as `start_cluster/2' but accepts a custom timeout.
+%% @param System the system name
 %% @param ServerConfigs a list of initial server configurations
 %% @param Timeout the timeout to use
 %% @end


### PR DESCRIPTION
## Proposed Changes

A follow-up to #296. The `start_cluster/2` docs have been restored and fixed to add the missing `SystemId` parameter. `start_cluster/1` docs mark the function as deprecated to prefer `start_cluster/2` which is in-line with how `start_server/1`/`restart_server/1`/`stop_server/1` treat the default system.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
