### PR TITLE
Use our fork of BCR and the latest rules_erlang

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 build --experimental_enable_bzlmod
+build --registry=https://raw.githubusercontent.com/rabbitmq/bazel-central-registry/dev/
 
 build --incompatible_strict_action_env
 build --local_test_jobs=1

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_erlang//:erlang_app.bzl", "erlang_app", "test_erlang_app")
-load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:xref2.bzl", "xref")
 load("@rules_erlang//:dialyze.bzl", "DEFAULT_PLT_APPS", "dialyze", "plt")
 load(":ra.bzl", "ra_suites")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,17 +1,11 @@
 module(
     name = "ra",
-    version = "2.0.12",
+    version = "2.3.0",
 )
 
 bazel_dep(
     name = "rules_erlang",
-    version = "3.1.0",
-)
-
-archive_override(
-    module_name = "rules_erlang",
-    urls = ["https://github.com/rabbitmq/rules_erlang/archive/refs/tags/3.1.0.zip"],
-    strip_prefix = "rules_erlang-3.1.0",
+    version = "3.2.0",
 )
 
 erlang_package = use_extension(

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -42,7 +42,7 @@ git_repository(
 git_repository(
     name = "rules_erlang",
     remote = "https://github.com/rabbitmq/rules_erlang.git",
-    tag = "3.1.0",
+    tag = "3.2.0",
 )
 
 load(


### PR DESCRIPTION
## Proposed Changes

Version 3.2.0 of rules_erlang has been blocked in the BCR (bazel-central-registry) CI due to toolchain resolution bugs that don't affect our use of it. Version 3.2.0 is available in our fork of the registry, so we can use that instead.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [x] CI

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
