### PR TITLE
Refactor reading from log to reduce peak memory use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ dep_aten = hex 0.5.8
 dep_seshat = hex 0.3.2
 DEPS = aten gen_batch_server seshat
 
-TEST_DEPS = proper meck eunit_formatters looking_glass inet_tcp_proxy
+TEST_DEPS = proper meck eunit_formatters inet_tcp_proxy
 
 BUILD_DEPS = elvis_mk
 
@@ -24,7 +24,7 @@ dep_inet_tcp_proxy = git https://github.com/rabbitmq/inet_tcp_proxy.git
 
 DEP_PLUGINS = elvis_mk
 
-PLT_APPS += eunit proper syntax_tools erts kernel stdlib common_test inets aten mnesia ssh ssl meck looking_glass gen_batch_server inet_tcp_proxy
+PLT_APPS += eunit proper syntax_tools erts kernel stdlib common_test inets aten mnesia ssh ssl meck gen_batch_server inet_tcp_proxy
 
 EDOC_OUTPUT = docs
 EDOC_OPTS = {pretty_printer, erl_pp}, {sort_functions, false}

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1494,15 +1494,11 @@ send(To, Msg, Conf) ->
             Res
     end.
 
-
 fold_log(From, Fun, Term, State) ->
     case ra_server:log_fold(State#state.server_state, Fun, Term) of
         {ok, Result, ServerState} ->
             {keep_state, State#state{server_state = ServerState},
-             [{reply, From, {ok, Result}}]};
-        {error, Reason, ServerState} ->
-            {keep_state, State#state{server_state = ServerState},
-             [{reply, From, {error, Reason}}]}
+             [{reply, From, {ok, Result}}]}
     end.
 
 send_snapshots(Me, Id, Term, {_, ToNode} = To, ChunkSize,

--- a/test/erlang_node_helpers.erl
+++ b/test/erlang_node_helpers.erl
@@ -25,9 +25,10 @@ start_erlang_node(Node, Config) ->
                                           code:where_is_file(DistModS ++ ".beam"))),
                         DistArg = re:replace(DistModS, "_dist$", "",
                                              [{return, list}]),
-                        "-pa \"" ++ DistModPath ++ "\" -proto_dist " ++ DistArg
+                        "-pa \"" ++ DistModPath ++ "\" -proto_dist " ++ DistArg ++
+                        " -kernel prevent_overlapping_partitions false"
                 end,
-    {ok, _} = ct_slave:start(Node, [{erl_flags, StartArgs}]),
+    _ = ct_slave:start(Node, [{erl_flags, StartArgs}]),
     wait_for_distribution(Node, 50),
     add_lib_dir(Node),
     Node.

--- a/test/partitions_SUITE.erl
+++ b/test/partitions_SUITE.erl
@@ -25,7 +25,15 @@ groups() ->
             ],
     [{tests, [], Tests}].
 
-init_per_group(_, Config) -> Config.
+init_per_suite(Config) ->
+    application:set_env(kernel, prevent_overlapping_partitions, false),
+    Config.
+
+end_per_suite(Config) ->
+    Config.
+
+init_per_group(_, Config) ->
+    Config.
 
 end_per_group(_, _Config) -> ok.
 

--- a/test/ra_2_SUITE.erl
+++ b/test/ra_2_SUITE.erl
@@ -570,7 +570,7 @@ external_reader(Config) ->
     receive
         {ra_event, _, {machine, {ra_log_update, _, _, _} = E}} ->
             R1 = ra_log_reader:handle_log_update(E, R0),
-            {Entries, _, _R2} = ra_log_reader:read(0, 1026, R1),
+            {Entries, _R2} = ra_log_reader:sparse_read(R1, lists:seq(0, 1026), []),
             ct:pal("read ~w ~w", [length(Entries), lists:last(Entries)]),
             %% read all entries
             ok

--- a/test/ra_log_SUITE.erl
+++ b/test/ra_log_SUITE.erl
@@ -215,18 +215,17 @@ take(Config) ->
                                ra_log:append_sync(Entry, L0)
                        end, Log0, lists:seq(Idx, LastIdx)),
     % won't work for memory
-    {[?IDX(1)], 1, Log2} = ra_log:take(1, 1, Log1),
-    {[?IDX(1), ?IDX(2)], 2, Log3} = ra_log:take(1, 2, Log2),
+    {[?IDX(1)], Log2} = ra_log_take(1, 1, Log1),
+    {[?IDX(1), ?IDX(2)], Log3} = ra_log_take(1, 2, Log2),
     % partly out of range
-    {[?IDX(9), ?IDX(10)], 2, Log4} = ra_log:take(9, 3, Log3),
+    {[?IDX(9), ?IDX(10)], Log4} = ra_log_take(9, 11, Log3),
     % completely out of range
-    {[], 0, Log5} = ra_log:take(11, 3, Log4),
+    {[], Log5} = ra_log_take(11, 14, Log4),
     % take all
-    {Taken, C0, _} = ra_log:take(1, 10, Log5),
-    ?assertEqual(length(Taken), C0),
+    {Taken, _} = ra_log_take(1, 10, Log5),
     ?assertEqual(10, length(Taken)),
     %% take 0
-    {[], 0, _} = ra_log:take(5, 0, Log5),
+    {[], _} = ra_log_take(5, 4, Log5),
     ok.
 
 take_cache(Config) ->
@@ -236,7 +235,7 @@ take_cache(Config) ->
     Log1 = ra_log:append_sync({Idx, Term, <<"one">>}, Log0),
     Idx2 = Idx +1,
     Log = ra_log:append({Idx2, Term, <<"two">>}, Log1),
-    {[?IDX(Idx), ?IDX(Idx2)], 2, _Log2} = ra_log:take(1, 2, Log),
+    {[?IDX(Idx), ?IDX(Idx2)], _Log2} = ra_log_take(1, 2, Log),
     ok.
 
 last(Config) ->
@@ -272,3 +271,7 @@ append_in(Term, Data, Log0) ->
     Idx = ra_log:next_index(Log0),
     Entry = {Idx, Term, Data},
     ra_log:append_sync(Entry, Log0).
+
+ra_log_take(From, To, Log0) ->
+    {Acc, Log} = ra_log:fold(From, To, fun (E, Acc) -> [E | Acc] end, [], Log0),
+    {lists:reverse(Acc), Log}.

--- a/test/ra_log_memory.erl
+++ b/test/ra_log_memory.erl
@@ -11,6 +11,7 @@
          append/2,
          write/2,
          take/3,
+         fold/5,
          last_index_term/1,
          set_last_index/2,
          handle_event/2,
@@ -105,6 +106,12 @@ write(_Entries, _State) ->
 take(Start, Num, #state{last_index = LastIdx, entries = Log} = State) ->
     Entries = sparse_take(Start, Log, Num, LastIdx, []),
     {Entries, length(Entries), State}.
+
+fold(From, To, Fun, Acc0, #state{last_index = LastIdx,
+                                 entries = Log} = State) ->
+    Entries = sparse_take(From, Log, To - From + 1, LastIdx, []),
+    Acc = lists:foldl(Fun, Acc0, Entries),
+    {Acc, State}.
 
 % this allows for missing entries in the log
 sparse_take(Idx, _Log, Num, Max, Res)

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -149,7 +149,7 @@ setup_log() ->
     meck:expect(ra_log, install_snapshot, fun (_, _, Log) -> {Log, []} end),
     meck:expect(ra_log, recover_snapshot, fun ra_log_memory:recover_snapshot/1),
     meck:expect(ra_log, snapshot_index_term, fun ra_log_memory:snapshot_index_term/1),
-    meck:expect(ra_log, take, fun ra_log_memory:take/3),
+    meck:expect(ra_log, fold, fun ra_log_memory:fold/5),
     meck:expect(ra_log, release_resources, fun ra_log_memory:release_resources/3),
     meck:expect(ra_log, append_sync,
                 fun({Idx, Term, _} = E, L) ->


### PR DESCRIPTION
Instead of reading batches into memory then processing we now
process each entry as it is read from the log by introducing a new
ra_log:fold/5 function. This function replaces all prior uses of
ra_log:take which has been removed.


This substantially reduces peak memory use during recovery when, e.g. a quorum queue has a long backlog of largish messages. As a consequence of this recovery takes less time and thus has a positive availability property.

I tested this with a few clustered workloads and could not detect any noticeable performance regressions elsewhere.