### PR TITLE
Revert notify effect processing change

### DIFF
--- a/src/ra_log_reader.erl
+++ b/src/ra_log_reader.erl
@@ -175,7 +175,7 @@ fold(FromIdx, ToIdx, Fun, Acc,
               segment_fold(S, From, To, Fun, Ac)
       end, {State, Acc}, Plan);
 fold(_FromIdx, _ToIdx, _Fun, Acc,
-    #?STATE{} = State) ->
+     #?STATE{} = State) ->
     {State, Acc}.
 
 -spec sparse_read(state(), [ra_index()], [log_entry()]) ->

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -519,7 +519,8 @@ handle_leader({commands, Cmds}, #{cfg := Cfg} =  State00) ->
     {State, _, Effects} = make_pipelined_rpc_effects(Num, State0, Effects0),
 
     {leader, State, Effects};
-handle_leader({ra_log_event, {written, _} = Evt}, State0 = #{log := Log0}) ->
+handle_leader({ra_log_event, {written, _} = Evt},
+              #{log := Log0} = State0) ->
     {Log, Effects0} = ra_log:handle_event(Evt, Log0),
     {State1, Effects1} = evaluate_quorum(State0#{log => Log}, Effects0),
     {State, Effects} = process_pending_consistent_queries(State1, Effects1),
@@ -2145,14 +2146,14 @@ apply_to(ApplyTo, ApplyFun, Notifys0, Effects0,
                     end,
     %% due to machine versioning all entries may not have been applied
     %%
-    FinalEffs = lists:reverse(make_notify_effects(Notifys, Effects)),
+    FinalEffs = make_notify_effects(Notifys, lists:reverse(Effects)),
     {State#{last_applied => AppliedTo,
             log => Log,
             commit_latency => CommitLatency,
             machine_state => MacState}, FinalEffs};
 apply_to(_ApplyTo, _, Notifys, Effects, State)
   when is_list(Effects) ->
-    FinalEffs = lists:reverse(make_notify_effects(Notifys, Effects)),
+    FinalEffs = make_notify_effects(Notifys, lists:reverse(Effects)),
     {State, FinalEffs}.
 
 make_notify_effects(Nots, Prior) when map_size(Nots) > 0 ->

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1520,13 +1520,12 @@ command_notify(_Config) ->
                                 next_index = 5,
                                 last_index = 4,
                                 last_term = 5},
-    %% asserting that the notify effect is positioned _after_ any apply effects
-    %% e.g. {aux, banana}. this ensures that writers aren't notified or reply to
-    %% before the side effects for their command have been executed.
+
     {leader, _State, [_,
+                      {notify, _},
                       {aux,eval},
-                      {aux, banana},
-                      {notify, _}]} =
+                      {aux, banana}
+                     ]} =
         ra_server:handle_leader({N2, AER}, State),
     ok.
 


### PR DESCRIPTION
order done in 773aa85e8ba79c2aed2f4eb766c97ff525d3e2ce

This introduces additional write latency that is dependent on batch size and other effect processing times. Also it doesn't provide strong enough consistency guarantees as it tells you nothing about the effect processing on any nodes but the leader. It is better to assume eventual consistency when it comes to effect processing anyway and design systems accordingly.
