### PR TITLE
Recovery mode in a new force_restart_server call/3

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -194,9 +194,15 @@ restart_server(System, ServerId, AddConfig)
         {'EXIT', Err} -> {error, Err}
     end.
 
-%% @doc Restarts a previously successfully started ra server with inclusion filter apllied to the members list.
-%% This method is designed mostly for a data recovery purposes and when applied to the minority group
-%%
+%% @doc Restarts a previously successfully started ra server in a new cluster configuration
+%% through inclusion filter of nodes.
+%% This function call is designed mostly for a data recovery purposes.
+%% Allows to forcely restart a server in a new restricted membership configuration.
+%% @param System the system identifier
+%% @param ServerId the ra_server_id() of the server
+%% @param FilterNodes to test against membership configuration
+%% @returns the same ra:restart_server/2
+%% @end
 
 -spec force_restart_server(atom(), ra_server_id(), [node()]) ->
           ok | {error, term()}.
@@ -204,8 +210,15 @@ force_restart_server(System, ServerId, FilterNodes)
   when is_list(FilterNodes) ->
     force_restart_server(System, ServerId, FilterNodes, #{}).
 
-%% @doc
-%%
+%% @doc Same as `force_restart_server/3' but accepts additional config parameters
+%% @see ra:restart_server/3.
+%% @param System the system identifier
+%% @param ServerId the ra_server_id() of the server
+%% @param FilterNodes to test against membership configuration
+%% @param AddConfig additional config parameters to be merged into the
+%% original config.
+%% @returns the same ra:restart_server/2
+%% @end
 
 -spec force_restart_server(atom(), ra_server_id(), [node()], ra_server:mutable_config()) ->
     ok | {error, term()}.

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -50,6 +50,8 @@
          restart_server/1,
          restart_server/2,
          restart_server/3,
+         force_restart_server/3,
+         force_restart_server/4,
          % deprecated
          stop_server/1,
          stop_server/2,
@@ -191,6 +193,24 @@ restart_server(System, ServerId, AddConfig)
         {error, _} = Err -> Err;
         {'EXIT', Err} -> {error, Err}
     end.
+
+%% @doc
+%%
+
+-spec force_restart_server(atom(), ra_server_id(), [node()]) ->
+          ok | {error, term()}.
+force_restart_server(System, ServerId, FilterNodes)
+  when is_list(FilterNodes) ->
+    force_restart_server(System, ServerId, FilterNodes, #{}).
+
+%% @doc
+%%
+
+-spec force_restart_server(atom(), ra_server_id(), [node()], ra_server:mutable_config()) ->
+    ok | {error, term()}.
+force_restart_server(System, ServerId, FilterNodes, AddConfig)
+  when is_list(FilterNodes) ->
+    restart_server(System, ServerId, AddConfig#{filter_nodes => FilterNodes}).
 
 %% @doc Stops a ra server in the default system
 %% @param ServerId the ra_server_id() of the server

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -168,13 +168,7 @@ restart_server(ServerId) ->
     ok | {error, term()}.
 restart_server(System, ServerId)
   when is_atom(System) ->
-    % don't match on return value in case it is already running
-    case catch ra_server_sup_sup:restart_server(System, ServerId, #{}) of
-        {ok, _} -> ok;
-        {ok, _, _} -> ok;
-        {error, _} = Err -> Err;
-        {'EXIT', Err} -> {error, Err}
-    end.
+    restart_server(System, ServerId, #{}).
 
 %% @doc Restarts a previously successfully started ra server
 %% @param System the system identifier

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -446,7 +446,7 @@ start_cluster(System, [#{cluster_name := ClusterName} | _] = ServerConfigs,
             end
     end.
 
-%% @doc Starts a new distributed ra cluster.
+%% @doc Starts server in a new distributed ra cluster.
 %% @param ClusterName the name of the cluster.
 %% @param ServerId the ra_server_id() of the server
 %% @param Machine The {@link ra_machine:machine/0} configuration.

--- a/src/ra.erl
+++ b/src/ra.erl
@@ -194,7 +194,8 @@ restart_server(System, ServerId, AddConfig)
         {'EXIT', Err} -> {error, Err}
     end.
 
-%% @doc
+%% @doc Restarts a previously successfully started ra server with inclusion filter apllied to the members list.
+%% This method is designed mostly for a data recovery purposes and when applied to the minority group
 %%
 
 -spec force_restart_server(atom(), ra_server_id(), [node()]) ->

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -363,10 +363,8 @@ recover(#{cfg := #cfg{log_id = LogId,
            [LogId,  EffMacVer, MacVer, LastApplied, CommitIndex, After - Before]),
     %% disable segment read cache by setting random access pattern
     Log = ra_log:release_resources(1, random, Log0),
-
     FilterNodes = maps:get(filter_nodes, State0),
     Cluster0 = maps:get(cluster, State0),
-
     Cluster1 = case FilterNodes of undefined ->
                        Cluster0;
                    _ ->
@@ -376,7 +374,6 @@ recover(#{cfg := #cfg{log_id = LogId,
                                            Res
                                    end, Cluster0)
               end,
-
     State#{cluster => Cluster1,
            log => Log,
            %% reset commit latency as recovery may calculate a very old value

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -2233,7 +2233,8 @@ apply_with({Idx, Term, {'$ra_cluster_change', CmdMeta, NewCluster, ReplyType}},
                     State1 = State0#{cluster => NewCluster,
                                      cluster_change_permitted => true,
                                      cluster_index_term => {Idx, Term}},
-                    State2 = State1#{ cluster => validate_cluster(State1) };
+                    State2 = State1#{cluster => validate_cluster(State1)},
+                    State2;
                 _  ->
                     ?DEBUG("~s: committing ra cluster change to ~w",
                            [log_id(State0), maps:keys(NewCluster)]),

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -85,7 +85,7 @@
       queries_waiting_heartbeats := queue:queue({non_neg_integer(), consistent_query_ref()}),
       pending_consistent_queries := [consistent_query_ref()],
       commit_latency => 'maybe'(non_neg_integer()),
-      nodes => 'maybe'([node()])
+      filter_nodes => 'maybe'([node()])
      }.
 
 -type ra_state() :: leader | follower | candidate
@@ -204,7 +204,7 @@
                             max_pipeline_count => non_neg_integer(),
                             ra_event_formatter => {module(), atom(), [term()]},
                             %% distribution setup
-                            nodes := 'maybe'([node()])}.
+                            filter_nodes => 'maybe'([node()])}.
 
 -type config() :: ra_server_config().
 
@@ -239,7 +239,6 @@ init(#{id := Id,
        machine := MachineConf} = Config) ->
     SystemConfig = maps:get(system_config, Config,
                             ra_system:default_config()),
-    Nodes = maps:get(nodes, Config, undefined),
     LogId = maps:get(friendly_name, Config,
                      lists:flatten(io_lib:format("~w", [Id]))),
     MaxPipelineCount = maps:get(max_pipeline_count, Config,
@@ -338,7 +337,7 @@ init(#{id := Id,
       query_index => 0,
       queries_waiting_heartbeats => queue:new(),
       pending_consistent_queries => [],
-      nodes => Nodes}.
+      filter_nodes => maps:get(filter_nodes, Config, undefined)}.
 
 recover(#{cfg := #cfg{log_id = LogId,
                       machine_version = MacVer,
@@ -365,17 +364,20 @@ recover(#{cfg := #cfg{log_id = LogId,
     %% disable segment read cache by setting random access pattern
     Log = ra_log:release_resources(1, random, Log0),
 
-    Nodes = maps:get(nodes, State0),
+    FilterNodes = maps:get(filter_nodes, State0),
     Cluster0 = maps:get(cluster, State0),
 
-    Cluster = case Nodes of undefined -> Cluster0;
-                            _ -> maps:filter(fun ({Name, Node}, _) -> Res = lists:member(Node, Nodes),
-                                             Res orelse ?INFO("filter cluster member name: ~s, node: ~s", [Name, Node]),
-                                             Res
-                                             end, Cluster0)
+    Cluster1 = case FilterNodes of undefined ->
+                       Cluster0;
+                   _ ->
+                       maps:filter(fun ({Name, Node}, _) ->
+                                           Res = lists:member(Node, FilterNodes),
+                                           Res orelse ?INFO("filtered node: ~s, node: ~s", [Name, Node]),
+                                           Res
+                                   end, Cluster0)
               end,
 
-    State#{cluster => Cluster,
+    State#{cluster => Cluster1,
            log => Log,
            %% reset commit latency as recovery may calculate a very old value
            commit_latency => 0}.

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -364,7 +364,7 @@ recover(#{cfg := #cfg{log_id = LogId,
     %% disable segment read cache by setting random access pattern
     Log = ra_log:release_resources(1, random, Log0),
     FilterNodes = maps:get(filter_nodes, State0),
-    Cluster0 = maps:get(cluster, State0),
+    Cluster0 = maps:get(cluster, State),
     Cluster1 = case FilterNodes of undefined ->
                        Cluster0;
                    _ ->

--- a/src/ra_server_sup_sup.erl
+++ b/src/ra_server_sup_sup.erl
@@ -18,7 +18,7 @@
          await_condition_timeout,
          max_pipeline_count,
          ra_event_formatter,
-         nodes]).
+         filter_nodes]).
 
 %% API functions
 -export([start_server/2,

--- a/src/ra_server_sup_sup.erl
+++ b/src/ra_server_sup_sup.erl
@@ -17,7 +17,8 @@
          install_snap_rpc_timeout,
          await_condition_timeout,
          max_pipeline_count,
-         ra_event_formatter]).
+         ra_event_formatter,
+         nodes]).
 
 %% API functions
 -export([start_server/2,

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -27,6 +27,7 @@ all_tests() ->
      stop_server_idemp,
      minority,
      start_servers,
+     force_restart,
      server_recovery,
      process_command,
      pipeline_command,
@@ -271,6 +272,21 @@ start_servers(Config) ->
     {ok, _, _} = ra:process_command(N3, 5, ?PROCESS_COMMAND_TIMEOUT),
     terminate_cluster([N1, N2, N3] -- [element(1, Target)]).
 
+force_restart(Config) ->
+    Name = ?config(test_name, Config),
+
+    Nodes = [ nth_server_name(Config, 1),
+              nth_server_name(Config, 2), nth_server_name(Config, 3)
+            ],
+
+    {ok, Res, Failed} = ra:start_cluster(default, Name, _Machine = add_machine(), Nodes),
+
+    terminate_cluster(Nodes),
+
+    [ begin ok = ra:force_restart_server(default, N, [node()]),
+            ok
+      end || N <- Nodes
+    ].
 
 server_recovery(Config) ->
     N1 = nth_server_name(Config, 1),

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -274,15 +274,11 @@ start_servers(Config) ->
 
 force_restart(Config) ->
     Name = ?config(test_name, Config),
-
     Nodes = [ nth_server_name(Config, 1),
               nth_server_name(Config, 2), nth_server_name(Config, 3)
             ],
-
     {ok, Res, Failed} = ra:start_cluster(default, Name, _Machine = add_machine(), Nodes),
-
     terminate_cluster(Nodes),
-
     [ begin ok = ra:force_restart_server(default, N, [node()]),
             ok
       end || N <- Nodes


### PR DESCRIPTION
## Proposed Changes

The raft protocol itself is built around the notion of a leader which handles cluster change requests and elected by the majority which forms the cluster.

There is a use case when the majority nodes is gone (during network split or outage) and we still need data back. Especially in the scenario when we have inter datacenter communication and our requirement is to keep the minority group running after the incident.

This PR introduces the next calls:

`force_restart_server(System, ServerId, FilterNodes)`
`force_restart_server(System, ServerId, FilterNodes, AddConfig)`      

Which indicate in the client codebase that cluster is forcefully reduced to the setup which is under `FilterNodes` inclusion list. We tried to make minimal adjustment to not break the general approach behind library code and Ra protocol itself.

The state machine is left deterministic and the all improvement is built behind  `filter_nodes` setting which is passed through mutable config during the restart. The overhead is minimal since `validate_cluster/1` is to be called 3 times: during the recover, receiving snapshot or processing cluster change command.   

Also this PR includes `enq_drain_recovery` in addition to the default `enq_drain_basic` test SUITE which plays the split and recovery scenario into nemesis.

The respective documentation is added (plus small fixes) and one more sanity test. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

P.S. We see quite fresh and interesting [improvement](https://github.com/rabbitmq/ra/pull/306) from @kjnilsson but still need multi DC setup running which would allow us to handle quorum queues in multiple node setup as well. 

Also we took into account this [issue](https://github.com/rabbitmq/ra/issues/167). 