### PR TITLE
Add command reply modes for replying from a given member

### DIFF
--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -66,6 +66,9 @@
 
 -type states() :: leader | follower | candidate | await_condition.
 
+%% A member of the cluster from which replies should be sent.
+-type ra_reply_from() :: leader | local | {member, ra_server_id()}.
+
 -define(RA_PROTO_VERSION, 1).
 %% the protocol version should be incremented whenever extensions need to be
 %% done to the core protocol records (below). It is only ever exchanged by the


### PR DESCRIPTION
## Proposed Changes

This is a new effect which works the same as prior `reply` effects but is only executed by the given server. A caller may wish to block until a command has replicated to an arbitrary server, for example if that server is on the local node. This new reply mode ensures that the call to process the command will only return when the command is replicated to that given node.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
