### PR TITLE
Retire ra file handle

### DIFF
--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -220,6 +220,8 @@
           "Total number of snapshots written"},
          {snapshot_installed, ?C_RA_LOG_SNAPSHOTS_INSTALLED, counter,
           "Total number of snapshots installed"},
+         {snapshot_bytes_written, ?C_RA_LOG_SNAPSHOT_BYTES_WRITTEN, counter,
+          "Number of snapshot bytes written (not installed)"},
          {reserved_1, ?C_RA_LOG_RESERVED, counter, "Reserved counter"}
          ]).
 -define(C_RA_LOG_WRITE_OPS, 1).
@@ -232,7 +234,8 @@
 -define(C_RA_LOG_FETCH_TERM, 8).
 -define(C_RA_LOG_SNAPSHOTS_WRITTEN, 9).
 -define(C_RA_LOG_SNAPSHOTS_INSTALLED, 10).
--define(C_RA_LOG_RESERVED, 11).
+-define(C_RA_LOG_SNAPSHOT_BYTES_WRITTEN, 11).
+-define(C_RA_LOG_RESERVED, 12).
 
 -define(C_RA_SRV_AER_RECEIVED_FOLLOWER, ?C_RA_LOG_RESERVED + 1).
 -define(C_RA_SRV_AER_REPLIES_SUCCESS, ?C_RA_LOG_RESERVED + 2).

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -131,7 +131,7 @@ pre_init(#{uid := UId,
     Dir = server_data_dir(DataDir, UId),
     SnapModule = maps:get(snapshot_module, Conf, ?DEFAULT_SNAPSHOT_MODULE),
     SnapshotsDir = filename:join(Dir, "snapshots"),
-    _ = ra_snapshot:init(UId, SnapModule, SnapshotsDir),
+    _ = ra_snapshot:init(UId, SnapModule, SnapshotsDir, undefined),
     ok.
 
 -spec init(ra_log_init_args()) -> state().
@@ -155,7 +155,7 @@ init(#{uid := UId,
     ok = ra_lib:make_dir(SnapshotsDir),
     % initialise metrics for this server
     true = ets:insert(ra_log_metrics, {UId, 0, 0, 0, 0}),
-    SnapshotState = ra_snapshot:init(UId, SnapModule, SnapshotsDir),
+    SnapshotState = ra_snapshot:init(UId, SnapModule, SnapshotsDir, Counter),
     {SnapIdx, SnapTerm} = case ra_snapshot:current(SnapshotState) of
                               undefined -> {-1, -1};
                               Curr -> Curr

--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -107,7 +107,7 @@ open(Filename, Options) ->
                 read ->
                     [read, raw, binary]
             end,
-    case ra_file_handle:open(Filename, Modes) of
+    case file:open(Filename, Modes) of
         {ok, Fd} ->
             process_file(FileExists, Mode, Filename, Fd, Options);
         Err -> Err
@@ -171,7 +171,8 @@ process_file(false, Mode, Filename, Fd, Options) ->
                 data_write_offset = ?HEADER_SIZE + IndexSize
                }}.
 
--spec append(state(), ra_index(), ra_term(), iodata()) ->
+-spec append(state(), ra_index(), ra_term(),
+             iodata() | {non_neg_integer(), iodata()}) ->
     {ok, state()} | {error, full | inet:posix()}.
 append(#state{cfg = #cfg{max_pending = PendingCount},
               pending_count = PendingCount} = State0,
@@ -191,11 +192,10 @@ append(#state{cfg = #cfg{version = Version,
               pending_count = PendCnt,
               pending_index = IdxPend0,
               pending_data = DataPend0} = State,
-       Index, Term, Data) ->
+       Index, Term, {Length, Data}) ->
     % check if file is full
     case IndexOffset < DataStart of
         true ->
-            Length = erlang:iolist_size(Data),
             % TODO: check length is less than #FFFFFFFF ??
             Checksum = compute_checksum(Cfg, Data),
             OSize = offset_size(Version),
@@ -213,12 +213,17 @@ append(#state{cfg = #cfg{version = Version,
             };
         false ->
             {error, full}
-     end.
+     end;
+append(State, Index, Term, Data)
+  when is_list(Data) orelse
+       is_binary(Data) ->
+    %% convert into {Size, Data} tuple
+    append(State, Index, Term, {iolist_size(Data), Data}).
 
 -spec sync(state()) -> {ok, state()} | {error, term()}.
 sync(#state{cfg = #cfg{fd = Fd},
             pending_index = []} = State) ->
-    case ra_file_handle:sync(Fd) of
+    case file:sync(Fd) of
         ok ->
             {ok, State};
         {error, _} = Err ->
@@ -240,9 +245,9 @@ flush(#state{cfg = #cfg{fd = Fd},
              data_offset = DataOffs,
              index_write_offset = IdxWriteOffs,
              data_write_offset = DataWriteOffs} = State) ->
-    case ra_file_handle:pwrite(Fd, DataWriteOffs, PendData) of
+    case file:pwrite(Fd, DataWriteOffs, PendData) of
         ok ->
-            case ra_file_handle:pwrite(Fd, IdxWriteOffs, PendIndex) of
+            case file:pwrite(Fd, IdxWriteOffs, PendIndex) of
                 ok ->
                     {ok, State#state{pending_data = [],
                                      pending_index = [],
@@ -319,7 +324,7 @@ prepare_cache(#cfg{fd = Fd} = _Cfg, [FirstIdx | Rem], SegIndex) ->
             % %% read at least the remainder of the block from
             % %% the first position or the length of the first record
             CacheLen = cache_length(FstPos, FstLength, LastPos, LastLength),
-            {ok, CacheData} = ra_file_handle:pread(Fd, FstPos, CacheLen),
+            {ok, CacheData} = file:pread(Fd, FstPos, CacheLen),
             {FstPos, byte_size(CacheData), CacheData}
     end.
 
@@ -392,10 +397,10 @@ close(#state{cfg = #cfg{fd = Fd, mode = append}} = State) ->
     % close needs to be defensive and idempotent so we ignore the return
     % values here
     _ = sync(State),
-    _ = ra_file_handle:close(Fd),
+    _ = file:close(Fd),
     ok;
 close(#state{cfg = #cfg{fd = Fd}}) ->
-    _ = ra_file_handle:close(Fd),
+    _ = file:close(Fd),
     ok.
 
 %%% Internal
@@ -415,7 +420,7 @@ update_range({First, _Last}, Idx) ->
 recover_index(Fd, Version, MaxCount) ->
     IndexSize = MaxCount * index_record_size(Version),
     DataOffset = ?HEADER_SIZE + IndexSize,
-    case ra_file_handle:pread(Fd, ?HEADER_SIZE, IndexSize) of
+    case file:pread(Fd, ?HEADER_SIZE, IndexSize) of
         {ok, Data} ->
             parse_index_data(Version, Data, DataOffset);
         eof ->
@@ -520,12 +525,12 @@ parse_index_data_v1(<<Idx:64/unsigned, Term:64/unsigned,
 
 write_header(MaxCount, Fd) ->
     Header = <<?MAGIC, ?VERSION:16/unsigned, MaxCount:16/unsigned>>,
-    {ok, 0} = ra_file_handle:position(Fd, 0),
-    ok = ra_file_handle:write(Fd, Header),
-    ok = ra_file_handle:sync(Fd).
+    {ok, 0} = file:position(Fd, 0),
+    ok = file:write(Fd, Header),
+    ok = file:sync(Fd).
 
 read_header(Fd) ->
-    case ra_file_handle:pread(Fd, 0, ?HEADER_SIZE) of
+    case file:pread(Fd, 0, ?HEADER_SIZE) of
         {ok, Buffer} ->
             case Buffer of
                 <<?MAGIC, Version:16/unsigned, MaxCount:16/unsigned>>
@@ -543,7 +548,7 @@ read_header(Fd) ->
 pread(#cfg{access_pattern = random,
            fd = Fd}, Cache, Pos, Length) ->
     %% no cache
-    {ok, Data} = ra_file_handle:pread(Fd, Pos, Length),
+    {ok, Data} = file:pread(Fd, Pos, Length),
     case byte_size(Data)  of
         Length ->
             {ok, Data, Cache};
@@ -558,7 +563,7 @@ pread(#cfg{}, {CPos, CLen, Bin} = Cache, Pos, Length)
 pread(#cfg{access_pattern = sequential,
            fd = Fd} = Cfg, undefined, Pos, Length) ->
     CacheLen = max(Length, ?READ_AHEAD_B),
-    {ok, CacheData} = ra_file_handle:pread(Fd, Pos, CacheLen),
+    {ok, CacheData} = file:pread(Fd, Pos, CacheLen),
     case byte_size(CacheData) >= Length  of
         true ->
             pread(Cfg, {Pos, byte_size(CacheData), CacheData}, Pos, Length);

--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -37,6 +37,7 @@
 -define(C_MEM_TABLES, 1).
 -define(C_SEGMENTS, 2).
 -define(C_ENTRIES, 3).
+-define(C_BYTES_WRITTEN, 4).
 
 -define(COUNTER_FIELDS,
         [{mem_tables, ?C_MEM_TABLES, counter,
@@ -44,7 +45,9 @@
          {segments, ?C_SEGMENTS, counter,
           "Number of segments written"},
          {entries, ?C_ENTRIES, counter,
-          "Number of entries written"}
+          "Number of entries written"},
+         {bytes_written, ?C_BYTES_WRITTEN, counter,
+          "Number of bytes written"}
         ]).
 
 
@@ -311,9 +314,15 @@ append_to_segment(_, _, StartIdx, EndIdx, Seg, Closed, _State)
 append_to_segment(UId, Tid, Idx, EndIdx, Seg0, Closed, State) ->
     [{_, Term, Data0}] = ets:lookup(Tid, Idx),
     Data = term_to_iovec(Data0),
-    case ra_log_segment:append(Seg0, Idx, Term, Data) of
+    DataSize = iolist_size(Data),
+    case ra_log_segment:append(Seg0, Idx, Term, {DataSize, Data}) of
         {ok, Seg} ->
             ok = counters:add(State#state.counter, ?C_ENTRIES, 1),
+            %% this isn't completely accurate as firstly the segment may not
+            %% have written it to disk and it doesn't include data written to
+            %% the segment index but is probably good enough to get comparative
+            %% data rates for different Ra components
+            ok = counters:add(State#state.counter, ?C_BYTES_WRITTEN, DataSize),
             append_to_segment(UId, Tid, Idx+1, EndIdx, Seg, Closed, State);
         {error, full} ->
             % close and open a new segment

--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -33,10 +33,12 @@
 -define(C_WAL_FILES, 1).
 -define(C_BATCHES, 2).
 -define(C_WRITES, 3).
+-define(C_BYTES_WRITTEN, 4).
 -define(COUNTER_FIELDS,
         [{wal_files, ?C_WAL_FILES, counter, "Number of write-ahead log files created"},
          {batches, ?C_BATCHES, counter, "Number of batches written"},
-         {writes, ?C_WRITES, counter, "Number of entries written"}
+         {writes, ?C_WRITES, counter, "Number of entries written"},
+         {bytes_written, ?C_BYTES_WRITTEN, counter, "Number of bytes written"}
          ]).
 
 % a writer_id consists of a unqique local name (see ra_directory) and a writer's
@@ -285,17 +287,22 @@ terminate(_Reason, State) ->
     ok.
 
 format_status(#state{conf = #conf{write_strategy = Strat,
+                                  sync_method = SyncMeth,
                                   compute_checksums = Cs,
+                                  names = #{wal := WalName},
                                   max_size_bytes = MaxSize},
                      writers = Writers,
                      file_size = FSize,
                      wal = #wal{filename = Fn}}) ->
     #{write_strategy => Strat,
+      sync_method => SyncMeth,
       compute_checksums => Cs,
       writers => maps:size(Writers),
       filename => filename:basename(Fn),
       current_size => FSize,
-      max_size_bytes => MaxSize}.
+      max_size_bytes => MaxSize,
+      counters => ra_counters:overview(WalName)
+     }.
 
 %% Internal
 
@@ -369,7 +376,7 @@ extract_file_num([F | _]) ->
 cleanup(#state{wal = #wal{fd = undefined}}) ->
     ok;
 cleanup(#state{wal = #wal{fd = Fd}}) ->
-    _ = ra_file_handle:sync(Fd),
+    _ = file:sync(Fd),
     ok.
 
 serialize_header(UId, Trunc, {Next, Cache} = WriterCache) ->
@@ -450,13 +457,14 @@ handle_msg({truncate, Id, Idx, Term, Entry}, State0) ->
 handle_msg(rollover, State) ->
     roll_over(State).
 
-append_data(#state{conf = Cfg,
+append_data(#state{conf = #conf{counter = C} = Cfg,
                    file_size = FileSize,
                    batch = Batch0,
                    writers = Writers} = State,
             {UId, Pid}, Idx, Term, Entry, DataSize, Data, Truncate) ->
     Batch = incr_batch(Cfg, Batch0, UId, Pid,
                        {Idx, Term, Entry}, Data, Truncate),
+    counters:add(C, ?C_BYTES_WRITTEN, DataSize),
     State#state{file_size = FileSize + DataSize,
                 batch = Batch,
                 writers = Writers#{UId => {in_seq, Idx}} }.
@@ -604,7 +612,7 @@ prepare_file(File, Modes) ->
     %% rename is atomic-ish so we will never accidentally write an empty wal file
     %% using prim_file here as file:rename/2 uses the file server
     ok = prim_file:rename(Tmp, File),
-    case ra_file_handle:open(File, Modes) of
+    case file:open(File, Modes) of
         {ok, Fd2} ->
             {ok, ?HEADER_SIZE} = file:position(Fd2, ?HEADER_SIZE),
             {ok, Fd2};
@@ -643,8 +651,8 @@ maybe_pre_allocate(Conf, _Fd, _Max) ->
 close_file(undefined) ->
     ok;
 close_file(Fd) ->
-    % ok = ra_file_handle:sync(Fd),
-    ra_file_handle:close(Fd).
+    % ok = file:sync(Fd),
+    file:close(Fd).
 
 close_open_mem_tables(MemTables,
                       #conf{segment_writer = TblWriter,
@@ -695,27 +703,32 @@ start_batch(#state{conf = #conf{counter = CRef}} = State) ->
 
 
 post_notify_flush(#state{wal = #wal{fd = Fd},
-                         conf =  #conf{write_strategy = sync_after_notify,
-                                       sync_method = SyncMeth}}) ->
-    ok = ra_file_handle:SyncMeth(Fd);
+                         conf = #conf{write_strategy = sync_after_notify,
+                                      sync_method = SyncMeth}}) ->
+    sync(Fd, SyncMeth);
 post_notify_flush(_State) ->
     ok.
 
-
 flush_pending(#state{wal = #wal{fd = Fd},
                      batch = #batch{pending = Pend},
-                     conf =  #conf{write_strategy = WriteStrategy,
-                                   sync_method = SyncMeth}} = State0) ->
+                     conf = #conf{write_strategy = WriteStrategy,
+                                  sync_method = SyncMeth}} = State0) ->
 
     case WriteStrategy of
         default ->
-            ok = ra_file_handle:write(Fd, Pend),
-            ok = ra_file_handle:SyncMeth(Fd),
-            ok;
+            ok = file:write(Fd, Pend),
+            sync(Fd, SyncMeth);
         _ ->
-            ok = ra_file_handle:write(Fd, Pend)
+            ok = file:write(Fd, Pend)
     end,
     State0#state{batch = undefined}.
+
+sync(_Fd, none) ->
+    ok;
+sync(Fd, Meth) ->
+    ok = file:Meth(Fd),
+    _ = file:advise(Fd, 0, 0, dont_need),
+    ok.
 
 complete_batch(#state{batch = undefined} = State) ->
     State;

--- a/src/ra_snapshot.erl
+++ b/src/ra_snapshot.erl
@@ -21,6 +21,7 @@
          delete/2,
 
          init/3,
+         init/4,
          init_ets/0,
          current/1,
          pending/1,
@@ -50,6 +51,7 @@
 
 -record(?MODULE,
         {uid :: ra_uid(),
+         counter :: undefined | counters:counter(),
          module :: module(),
          %% the snapshot directory
          %% typically <data_dir>/snapshots
@@ -78,7 +80,9 @@
 -callback write(Location :: file:filename(),
                 Meta :: meta(),
                 Ref :: term()) ->
-    ok | {error, file_err() | term()}.
+    ok |
+    {ok, Bytes :: non_neg_integer()} |
+    {error, file_err() | term()}.
 
 
 %% Read the snapshot metadata and initialise a read state used in read_chunk/1
@@ -129,8 +133,15 @@
 
 -spec init(ra_uid(), module(), file:filename()) ->
     state().
-init(UId, Module, SnapshotsDir) ->
+init(UId, Mod, File) ->
+    init(UId, Mod, File, undefined).
+
+-spec init(ra_uid(), module(), file:filename(),
+           undefined | counters:counter()) ->
+    state().
+init(UId, Module, SnapshotsDir, Counter) ->
     State = #?MODULE{uid = UId,
+                     counter = Counter,
                      module = Module,
                      directory = SnapshotsDir},
     true = ra_lib:is_dir(SnapshotsDir),
@@ -205,6 +216,7 @@ last_index_for(UId) ->
     {state(), [effect()]}.
 begin_snapshot(#{index := Idx, term := Term} = Meta, MacRef,
                #?MODULE{module = Mod,
+                        counter = Counter,
                         directory = Dir} = State) ->
     %% create directory for this snapshot
     SnapDir = make_snapshot_dir(Dir, Idx, Term),
@@ -216,7 +228,14 @@ begin_snapshot(#{index := Idx, term := Term} = Meta, MacRef,
     Self = self(),
     Pid = spawn(fun () ->
                         ok = ra_lib:make_dir(SnapDir),
-                        ok = Mod:write(SnapDir, Meta, Ref),
+                        case Mod:write(SnapDir, Meta, Ref) of
+                            ok -> ok;
+                            {ok, BytesWritten} ->
+                                counters_add(Counter,
+                                             ?C_RA_LOG_SNAPSHOT_BYTES_WRITTEN,
+                                             BytesWritten),
+                                ok
+                        end,
                         Self ! {ra_log_event,
                                 {snapshot_written, {Idx, Term}}},
                         ok
@@ -373,3 +392,8 @@ make_snapshot_dir(Dir, Index, Term) ->
     I = ra_lib:zpad_hex(Index),
     T = ra_lib:zpad_hex(Term),
     filename:join(Dir, T ++ "_" ++ I).
+
+counters_add(undefined, _, _) ->
+    ok;
+counters_add(Counter, Ix, Incr) ->
+    counters:add(Counter, Ix, Incr).

--- a/test/ra_snapshot_SUITE.erl
+++ b/test/ra_snapshot_SUITE.erl
@@ -73,7 +73,7 @@ end_per_testcase(_TestCase, _Config) ->
 
 init_empty(Config) ->
     UId = ?config(uid, Config),
-    State = ra_snapshot:init(UId, ?MODULE, ?config(snap_dir, Config)),
+    State = ra_snapshot:init(UId, ?MODULE, ?config(snap_dir, Config), undefined),
     %% no pending, no current
     undefined = ra_snapshot:current(State),
     undefined = ra_snapshot:pending(State),
@@ -84,7 +84,7 @@ init_empty(Config) ->
 take_snapshot(Config) ->
     UId = ?config(uid, Config),
     State0 = ra_snapshot:init(UId, ra_log_snapshot,
-                              ?config(snap_dir, Config)),
+                              ?config(snap_dir, Config), undefined),
     Meta = meta(55, 2, [node()]),
     MacRef = ?FUNCTION_NAME,
     {State1, [{monitor, process, snapshot_writer, Pid}]} =
@@ -106,7 +106,7 @@ take_snapshot(Config) ->
 take_snapshot_crash(Config) ->
     UId = ?config(uid, Config),
     SnapDir = ?config(snap_dir, Config),
-    State0 = ra_snapshot:init(UId, ra_log_snapshot, SnapDir),
+    State0 = ra_snapshot:init(UId, ra_log_snapshot, SnapDir, undefined),
     Meta = meta(55, 2, [node()]),
     MacRef = ?FUNCTION_NAME,
     {State1, [{monitor, process, snapshot_writer, Pid}]} =
@@ -136,7 +136,7 @@ take_snapshot_crash(Config) ->
 init_recover(Config) ->
     UId = ?config(uid, Config),
     State0 = ra_snapshot:init(UId, ra_log_snapshot,
-                              ?config(snap_dir, Config)),
+                              ?config(snap_dir, Config), undefined),
     Meta = meta(55, 2, [node()]),
     {State1, [{monitor, process, snapshot_writer, _}]} =
          ra_snapshot:begin_snapshot(Meta, ?FUNCTION_NAME, State0),
@@ -150,7 +150,7 @@ init_recover(Config) ->
 
     %% open a new snapshot state to simulate a restart
     Recover = ra_snapshot:init(UId, ra_log_snapshot,
-                               ?config(snap_dir, Config)),
+                               ?config(snap_dir, Config), undefined),
     %% ensure last snapshot is recovered
     %% it also needs to be validated as could have crashed mid write
     undefined = ra_snapshot:pending(Recover),
@@ -164,7 +164,7 @@ init_recover(Config) ->
 init_multi(Config) ->
     UId = ?config(uid, Config),
     State0 = ra_snapshot:init(UId, ra_log_snapshot,
-                              ?config(snap_dir, Config)),
+                              ?config(snap_dir, Config), undefined),
     Meta1 = meta(55, 2, [node()]),
     Meta2 = meta(165, 2, [node()]),
     {State1, _} = ra_snapshot:begin_snapshot(Meta1, ?FUNCTION_NAME, State0),
@@ -189,7 +189,7 @@ init_multi(Config) ->
 
     %% open a new snapshot state to simulate a restart
     Recover = ra_snapshot:init(UId, ra_log_snapshot,
-                               ?config(snap_dir, Config)),
+                               ?config(snap_dir, Config), undefined),
     %% ensure last snapshot is recovered
     %% it also needs to be validated as could have crashed mid write
     undefined = ra_snapshot:pending(Recover),
@@ -203,7 +203,7 @@ init_multi(Config) ->
 init_recover_multi_corrupt(Config) ->
     UId = ?config(uid, Config),
     SnapsDir = ?config(snap_dir, Config),
-    State0 = ra_snapshot:init(UId, ra_log_snapshot, SnapsDir),
+    State0 = ra_snapshot:init(UId, ra_log_snapshot, SnapsDir, undefined),
     Meta1 = meta(55, 2, [node()]),
     Meta2 = meta(165, 2, [node()]),
     {State1, _} = ra_snapshot:begin_snapshot(Meta1, ?FUNCTION_NAME, State0),
@@ -232,7 +232,7 @@ init_recover_multi_corrupt(Config) ->
 
     %% open a new snapshot state to simulate a restart
     Recover = ra_snapshot:init(UId, ra_log_snapshot,
-                               ?config(snap_dir, Config)),
+                               ?config(snap_dir, Config), undefined),
     %% ensure last snapshot is recovered
     %% it also needs to be validated as could have crashed mid write
     undefined = ra_snapshot:pending(Recover),
@@ -250,7 +250,7 @@ init_recover_corrupt(Config) ->
     UId = ?config(uid, Config),
     Meta = meta(55, 2, [node()]),
     SnapsDir = ?config(snap_dir, Config),
-    State0 = ra_snapshot:init(UId, ra_log_snapshot, SnapsDir),
+    State0 = ra_snapshot:init(UId, ra_log_snapshot, SnapsDir, undefined),
     {State1, _} = ra_snapshot:begin_snapshot(Meta, ?FUNCTION_NAME, State0),
     _ = receive
                  {ra_log_event, {snapshot_written, IdxTerm}} ->
@@ -268,7 +268,7 @@ init_recover_corrupt(Config) ->
     ets:delete_all_objects(ra_log_snapshot_state),
     %% open a new snapshot state to simulate a restart
     Recover = ra_snapshot:init(UId, ra_log_snapshot,
-                               ?config(snap_dir, Config)),
+                               ?config(snap_dir, Config), undefined),
     %% ensure the corrupt snapshot isn't recovered
     undefined = ra_snapshot:pending(Recover),
     undefined = ra_snapshot:current(Recover),
@@ -280,7 +280,7 @@ init_recover_corrupt(Config) ->
 read_snapshot(Config) ->
     UId = ?config(uid, Config),
     State0 = ra_snapshot:init(UId, ra_log_snapshot,
-                              ?config(snap_dir, Config)),
+                              ?config(snap_dir, Config), undefined),
     Meta = meta(55, 2, [node()]),
     MacRef = crypto:strong_rand_bytes(1024 * 4),
     {State1, _} =
@@ -310,7 +310,7 @@ read_all_chunks(ChunkState, State, Size, Acc) ->
 accept_snapshot(Config) ->
     UId = ?config(uid, Config),
     State0 = ra_snapshot:init(UId, ra_log_snapshot,
-                              ?config(snap_dir, Config)),
+                              ?config(snap_dir, Config), undefined),
     Meta = meta(55, 2, [node()]),
     MetaBin = term_to_binary(Meta),
     MacRef = crypto:strong_rand_bytes(1024 * 4),
@@ -343,7 +343,7 @@ accept_snapshot(Config) ->
 abort_accept(Config) ->
     UId = ?config(uid, Config),
     State0 = ra_snapshot:init(UId, ra_log_snapshot,
-                              ?config(snap_dir, Config)),
+                              ?config(snap_dir, Config), undefined),
     Meta = meta(55, 2, [node()]),
     MacRef = crypto:strong_rand_bytes(1024 * 4),
     MacBin = term_to_binary(MacRef),
@@ -369,7 +369,7 @@ abort_accept(Config) ->
 accept_receives_snapshot_written_with_lower_index(Config) ->
     UId = ?config(uid, Config),
     SnapDir = ?config(snap_dir, Config),
-    State0 = ra_snapshot:init(UId, ra_log_snapshot, SnapDir),
+    State0 = ra_snapshot:init(UId, ra_log_snapshot, SnapDir, undefined),
     MetaLocal = meta(55, 2, [node()]),
     MetaRemote = meta(165, 2, [node()]),
     MetaRemoteBin = term_to_binary(MetaRemote),
@@ -409,7 +409,7 @@ accept_receives_snapshot_written_with_lower_index(Config) ->
 accept_receives_snapshot_written_with_higher_index(Config) ->
     UId = ?config(uid, Config),
     SnapDir = ?config(snap_dir, Config),
-    State0 = ra_snapshot:init(UId, ra_log_snapshot, SnapDir),
+    State0 = ra_snapshot:init(UId, ra_log_snapshot, SnapDir, undefined),
     MetaRemote = meta(55, 2, [node()]),
     MetaLocal = meta(165, 2, [node()]),
     %% begin a local snapshot


### PR DESCRIPTION
As it adds fixed overhead to each disk IO operation and duplicates
information that is better accessed by the operation system.

To compensate this adds a "bytes written" counter to the wal and
segment writer processes respectively. This will allow of inspection
of Ra component specific IO use to some degree.

Also refactored the WAL sync method to also include an fadvise
instruction to purge page cache after fsync as we do no need it.