### PR TITLE
Validate command reply modes

### DIFF
--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -253,6 +253,7 @@
 -define(C_RA_SRV_AER_RECEIVED_FOLLOWER_EMPTY, ?C_RA_LOG_RESERVED + 17).
 -define(C_RA_SRV_TERM_AND_VOTED_FOR_UPDATES, ?C_RA_LOG_RESERVED + 18).
 -define(C_RA_SRV_LOCAL_QUERIES, ?C_RA_LOG_RESERVED + 19).
+-define(C_RA_SRV_INVALID_REPLY_MODE_COMMANDS, ?C_RA_LOG_RESERVED + 20).
 
 
 -define(RA_SRV_COUNTER_FIELDS,
@@ -294,7 +295,9 @@
          {term_and_voted_for_updates, ?C_RA_SRV_TERM_AND_VOTED_FOR_UPDATES, counter,
           "Total number of updates of term and voted for"},
          {local_queries, ?C_RA_SRV_LOCAL_QUERIES, counter,
-          "Total number of local queries"}
+          "Total number of local queries"},
+         {invalid_reply_mode_commands, ?C_RA_SRV_INVALID_REPLY_MODE_COMMANDS, counter,
+          "Total number of commands received with an invalid reply-mode"}
          ]).
 
 -define(RA_COUNTER_FIELDS, ?RA_LOG_COUNTER_FIELDS ++ ?RA_SRV_COUNTER_FIELDS).

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -842,7 +842,7 @@ wait_for_gen_statem_status(Ref, ExpectedStatus, Timeout)
     case get_gen_statem_status(Ref) of
         ExpectedStatus ->
             ok;
-        OtherStatus when Timeout >= 0 ->
+        _OtherStatus when Timeout >= 0 ->
             timer:sleep(500),
             wait_for_gen_statem_status(Ref, ExpectedStatus, Timeout - 500);
         OtherStatus ->

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -300,7 +300,7 @@ process_command(Config) ->
     [A, _B, _C] = Cluster =
         start_local_cluster(3, ?config(test_name, Config),
                             {simple, fun erlang:'+'/2, 9}),
-        {ok, 14, _Leader} = ra:process_command(A, 5, ?PROCESS_COMMAND_TIMEOUT),
+    {ok, 14, _Leader} = ra:process_command(A, 5, ?PROCESS_COMMAND_TIMEOUT),
     terminate_cluster(Cluster).
 
 pipeline_command(Config) ->


### PR DESCRIPTION
## Proposed Changes

Command reply modes (`ra_server:command_reply_mode()`) were not previously validated. If an old Ra system were sent a reply mode introduced in some new change, the Ra system would never reply or notify the caller. With this change, the caller receives an error tuple reply for the unknown mode.

This is necessary to mitigate the effects of adding new reply modes as in #314 in cases where senders of commands may be running newer Ra versions than a running Ra system.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
