### PR TITLE
Minor performance improvement

### DIFF
--- a/src/ra_log_meta.erl
+++ b/src/ra_log_meta.erl
@@ -68,7 +68,7 @@ handle_batch(Commands, #?MODULE{ref = Ref,
                         Inserts0#{Id => update_key(Key, Value, Data)};
                     _ ->
                         case ets:lookup(TblName, Id) of
-                            [{Id, _, _, _} = Data] ->
+                            [Data] ->
                                 Inserts0#{Id => update_key(Key, Value, Data)};
                             [] ->
                                 Data = {Id, undefined, undefined, undefined},
@@ -153,8 +153,7 @@ fetch(MetaName, Id, Key, Default) ->
 %%% internal
 
 maybe_fetch(MetaName, Id, Pos) ->
-    try ets:lookup_element(MetaName, Id, Pos) of
-        E -> E
+    try ets:lookup_element(MetaName, Id, Pos)
     catch
         _:badarg ->
             undefined


### PR DESCRIPTION
As Maxim Fedorov noted, there is no need to match against the table key when doing an ets:lookup/2 as the table key has to match anyways.

(I haven't done any measurements.)