### PR TITLE
Allow mem table compression to be configurable

### DIFF
--- a/src/ra_log_sup.erl
+++ b/src/ra_log_sup.erl
@@ -70,6 +70,7 @@ make_wal_conf(#{data_dir := DataDir,
     PreAlloc = maps:get(wal_pre_allocate, Cfg, false),
     MinBinVheapSize = maps:get(wal_min_bin_vheap_size, Cfg,
                                ?WAL_MIN_BIN_VHEAP_SIZE),
+    CompressMemTables = maps:get(compress_mem_tables, Cfg, false),
     #{name => WalName,
       names => Names,
       dir => WalDir,
@@ -83,5 +84,6 @@ make_wal_conf(#{data_dir := DataDir,
       hibernate_after => HibAfter,
       garbage_collect => Gc,
       pre_allocate => PreAlloc,
-      min_bin_vheap_size => MinBinVheapSize
+      min_bin_vheap_size => MinBinVheapSize,
+      compress_mem_tables => CompressMemTables
      }.

--- a/src/ra_system.erl
+++ b/src/ra_system.erl
@@ -45,7 +45,8 @@
                     default_max_pipeline_count => non_neg_integer(),
                     default_max_append_entries_rpc_batch_size => non_neg_integer(),
                     message_queue_data => on_heap | off_heap,
-                    wal_min_bin_vheap_size => non_neg_integer()
+                    wal_min_bin_vheap_size => non_neg_integer(),
+                    compress_mem_tables => boolean()
                    }.
 
 -export_type([
@@ -85,6 +86,7 @@ default_config() ->
                                               ?AER_CHUNK_SIZE),
 
     MessageQueueData = application:get_env(ra, server_message_queue_data, on_heap),
+    CompressMemTables = application:get_env(ra, compress_mem_tables, false),
     #{name => default,
       data_dir => DataDir,
       wal_data_dir => WalDataDir,
@@ -101,6 +103,7 @@ default_config() ->
       default_max_pipeline_count => DefaultMaxPipelineCount,
       default_max_append_entries_rpc_batch_size => DefaultAERBatchSize,
       message_queue_data => MessageQueueData,
+      compress_mem_tables => CompressMemTables,
       names =>
       #{wal => ra_log_wal,
         wal_sup => ra_log_wal_sup,


### PR DESCRIPTION
Using a new system configuration key: `compress_mem_tables`