### PR TITLE
Fix stale read in ra:consistent_query/2

### DIFF
--- a/src/ra.app.src
+++ b/src/ra.app.src
@@ -1,6 +1,6 @@
 {application,ra,
              [{description,"Raft library"},
-              {vsn,"2.4.3"},
+              {vsn,"2.4.4"},
               {licenses,["Apache-2.0","MPL-2.0"]},
               {links,[{"github","https://github.com/rabbitmq/ra"}]},
               {modules,[]},

--- a/src/ra_directory.erl
+++ b/src/ra_directory.erl
@@ -69,8 +69,7 @@ register_name(System, UId, Pid, ParentPid, ServerName, ClusterName)
   when is_atom(System) ->
     register_name(get_names(System), UId, Pid,
                   ParentPid, ServerName, ClusterName);
-register_name(#{
-                directory := Directory,
+register_name(#{directory := Directory,
                 directory_rev := DirRev} = System, UId, Pid, ParentPid,
               ServerName, ClusterName) ->
     true = ets:insert(Directory, {UId, Pid, ParentPid, ServerName,
@@ -78,8 +77,13 @@ register_name(#{
     case uid_of(System, ServerName) of
         undefined ->
             ok = dets:insert(DirRev, {ServerName, UId});
-        _ ->
+        UId ->
             %% no need to insert into dets table if already there
+            ok;
+        OtherUId ->
+            ok = dets:insert(DirRev, {ServerName, UId}),
+            ?WARN("ra server with name ~s UId ~s replaces prior UId ~s",
+                  [ServerName, UId, OtherUId]),
             ok
     end.
 

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -681,7 +681,7 @@ handle_leader({PeerId, #heartbeat_reply{query_index = ReplyQueryIndex,
             %% Heartbeat reply for lower term. Ignoring
             {leader, State0, []};
         {CurLower, TermHigher} when CurLower < TermHigher ->
-            %% A node with higher term confirmed heartbeat. This should not happen
+            %% A node with higher term confirmed heartbeat.
             ?NOTICE("~s leader saw heartbeat_reply from ~w for term ~b "
                     "abdicates term: ~b!",
                     [LogId, PeerId, Term, CurTerm]),
@@ -1344,16 +1344,27 @@ handle_state_enter(RaftState, #{cfg := #cfg{effective_machine_module = MacMod},
 overview(#{cfg := #cfg{effective_machine_module = MacMod} = Cfg,
            log := Log,
            machine_state := MacState,
-           aux_state := Aux
+           aux_state := Aux,
+           queries_waiting_heartbeats := Queries
           } = State) ->
-    O0 = maps:with([current_term, commit_index, last_applied,
-                    cluster, leader_id, voted_for], State),
+    NumQueries = queue:len(Queries),
+    O0 = maps:with([current_term,
+                    commit_index,
+                    last_applied,
+                    cluster,
+                    leader_id,
+                    voted_for,
+                    cluster_change_permitted,
+                    cluster_index_term,
+                    query_index
+                   ], State),
     O = maps:merge(O0, cfg_to_map(Cfg)),
     LogOverview = ra_log:overview(Log),
     MacOverview = ra_machine:overview(MacMod, MacState),
     O#{log => LogOverview,
        aux => Aux,
-       machine => MacOverview}.
+       machine => MacOverview,
+       num_waiting_queries => NumQueries}.
 
 cfg_to_map(Cfg) ->
     element(2, lists:foldl(
@@ -2069,7 +2080,10 @@ update_term_and_voted_for(Term, VotedFor, #{cfg := #cfg{uid = UId} = Cfg,
 
 update_term(Term, State = #{current_term := CurTerm})
   when Term =/= undefined andalso Term > CurTerm ->
-        update_term_and_voted_for(Term, undefined, State);
+    %% reset query index here as a new term means a new query index
+    %% sequence
+    update_term_and_voted_for(Term, undefined,
+                              State#{query_index => 0});
 update_term(_, State) ->
     State.
 
@@ -2595,9 +2609,9 @@ update_query_index(State, NewQueryIndex) ->
     State#{query_index => NewQueryIndex}.
 
 reset_query_index(#{cluster := Cluster} = State) ->
-    State#{cluster =>
-            maps:map(fun(_PeerId, Peer) -> Peer#{query_index => 0} end,
-                     Cluster)}.
+    State#{cluster => maps:map(fun(_PeerId, Peer) ->
+                                       Peer#{query_index => 0}
+                               end, Cluster)}.
 
 
 heartbeat_rpc_effects(Peers, Id, Term, QueryIndex) ->

--- a/test/ra_2_SUITE.erl
+++ b/test/ra_2_SUITE.erl
@@ -12,7 +12,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
--define(info, true).
+% -define(info, true).
 -define(SYS, ?MODULE).
 
 %% common ra_log tests to ensure behaviour is equivalent across


### PR DESCRIPTION
Certain leader change scenarios could occasionally result in a stale result being returned from `ra:consisten_query/2`. This PR fixes this by ensuring all members reset their `query_index` each time a new term is detected.

This issue also could result in poor read availability see https://github.com/rabbitmq/ra/discussions/337

This also introduces a fix in the ra registery when a member with the same registered name is declared it now overwrites the prior durable entry to match the transient state.

This also includes a slightly odd 2.4.4 commit which is something I missed to push after releasing 2.4.4. 