### PR TITLE
Fix stale consistent read result after server restart

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1483,7 +1483,8 @@ machine_query(QueryFun, #{cfg := #cfg{effective_machine_module = MacMod},
 
 become(leader, #{cluster := Cluster, log := Log0} = State) ->
     Log = ra_log:release_resources(maps:size(Cluster) + 2, random, Log0),
-    State#{log => Log};
+    State#{log => Log,
+           cluster_change_permitted => false};
 become(follower, #{log := Log0} = State) ->
     %% followers should only ever need a single segment open at any one
     %% time

--- a/test/ra_log_segment_writer_SUITE.erl
+++ b/test/ra_log_segment_writer_SUITE.erl
@@ -5,6 +5,7 @@
 %% Copyright (c) 2017-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 -module(ra_log_segment_writer_SUITE).
+-compile(nowarn_export_all).
 -compile(export_all).
 
 -include_lib("common_test/include/ct.hrl").


### PR DESCRIPTION
Reset cluster_change_permitted when becoming leader

As if there had been a leader change before this could reset to true
even before the leader has fully applied it's `noop` command for the new
term. This could result in occasional stale consistent read results.