### PR TITLE
ra_system: Fix stop/1 when the `ra` application is stopped

### DIFF
--- a/test/ra_system_SUITE.erl
+++ b/test/ra_system_SUITE.erl
@@ -168,6 +168,12 @@ stop_system(Config) ->
     SysCfg = #{name => Sys,
                data_dir => DataDir,
                names => ra_system:derive_names(Sys)},
+
+    _ = application:stop(ra),
+
+    ?assertEqual(undefined, erlang:whereis(ra_systems_sup)),
+    ?assertEqual(ok, ra_system:stop(Sys)),
+
     {ok, _} = application:ensure_all_started(ra),
 
     ?assertEqual(undefined, ra_system:fetch(Sys)),


### PR DESCRIPTION
If the `ra` application is stopped, the `ra_systems_sup` supervisor is not running. This leads to a `{noproc, _}` exit exception if we try to stop a Ra system.

This exception should be caught to make sure that the function always work and is idempotent. Indeed, the Ra system is already stopped if the application is not running.

This is a followw-up to #344.