### PR TITLE
Changed logging level from WARN to DEBUG

### DIFF
--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -225,7 +225,7 @@ do_segment({ServerUId, StartIdx0, EndIdx, Tid},
 
     case open_file(Dir, SegConf) of
         enoent ->
-            ?WARN("segment_writer: skipping segment as directory ~s does "
+            ?DEBUG("segment_writer: skipping segment as directory ~s does "
                   "not exist", [Dir]),
             %% clean up the tables for this process
             _ = ets:delete(Tid),
@@ -381,7 +381,7 @@ open_file(Dir, SegConf) ->
             _ = prim_file:delete(File),
             open_file(Dir, SegConf);
         {error, enoent} ->
-            ?WARN("segment_writer: failed to open segment file ~s "
+            ?DEBUG("segment_writer: failed to open segment file ~s "
                   "error: enoent", [File]),
             enoent;
         Err ->


### PR DESCRIPTION
If a queue is removed before WAL is flushed to a segment file, two warning logs would be written. According to discussions this could be lowered to DEBUG level.

resolves rabbitmq/ra#348

## Proposed Changes

Lower loglevel to debug after comment from @kjnilsson.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #348)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Hard to test logging behaviour?

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
