### PR TITLE
Remove machine monitors

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1843,8 +1843,8 @@ handle_down(RaftState, aux, Pid, Info, State)
   when is_pid(Pid) ->
     handle_aux(RaftState, cast, {down, Pid, Info}, State);
 handle_down(RaftState, Type, Pid, Info, #{cfg := #cfg{log_id = LogId}} = State) ->
-    ?INFO("~s: handle_down: unexpected ~w ~w exited with ~W",
-          [LogId, Type, Pid, Info, 10]),
+    ?DEBUG("~s: handle_down: unexpected ~w ~w exited with ~W",
+           [LogId, Type, Pid, Info, 10]),
     {RaftState, State, []}.
 
 -spec handle_node_status(ra_state(), machine | aux,

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -516,10 +516,6 @@ leader(EventType, Msg, State0) ->
         {leader, State1, Effects1} ->
             {State, Actions} = ?HANDLE_EFFECTS(Effects1, EventType, State1),
             {keep_state, State, Actions};
-        {follower, State1, Effects1} ->
-            {State, Actions} = ?HANDLE_EFFECTS(Effects1, EventType, State1),
-            Monitors = ra_monitors:remove_all(machine, State#state.monitors),
-            next_state(follower, State#state{monitors = Monitors}, Actions);
         {stop, State1, Effects} ->
             % interact before shutting down in case followers need
             % to know about the new commit index
@@ -534,9 +530,9 @@ leader(EventType, Msg, State0) ->
                 false ->
                     next_state(terminating_leader, State, Actions)
             end;
-        {await_condition, State1, Effects1} ->
+        {NextState, State1, Effects1} ->
             {State, Actions} = ?HANDLE_EFFECTS(Effects1, EventType, State1),
-            next_state(await_condition, State, Actions)
+            next_state(NextState, State, Actions)
     end.
 
 candidate(enter, OldState, State0) ->
@@ -662,7 +658,9 @@ follower(enter, OldState, #state{server_state = ServerState} = State0) ->
                                maybe_set_election_timeout(TimeoutLen, State1,
                                                           Actions0)
                        end,
-    {keep_state, State#state{delayed_commands = queue:new()}, Actions};
+    Monitors = ra_monitors:remove_all(machine, State#state.monitors),
+    {keep_state, State#state{delayed_commands = queue:new(),
+                             monitors = Monitors}, Actions};
 follower({call, From}, {leader_call, Msg}, State) ->
     maybe_redirect(From, Msg, State);
 follower(EventType, {local_call, Msg}, State) ->

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -674,8 +674,8 @@ follower(_, {command, Priority, {_CmdType, Data, noreply}},
                   "Command is dropped.", [log_id(State)]),
             {keep_state, State, []};
         LeaderId ->
-            ?INFO("~s: follower leader cast - redirecting to ~w ",
-                  [log_id(State), LeaderId]),
+            ?DEBUG("~s: follower leader cast - redirecting to ~w ",
+                   [log_id(State), LeaderId]),
             ok = ra:pipeline_command(LeaderId, Data, no_correlation, Priority),
             {keep_state, State, []}
     end;
@@ -1524,9 +1524,9 @@ maybe_redirect(From, Msg, #state{pending_commands = Pending,
     Leader = leader_id(State),
     case LeaderMon of
         undefined ->
-            ?INFO("~s: leader call - leader not known. "
-                  "Command will be forwarded once leader is known.",
-                  [log_id(State)]),
+            ?DEBUG("~s: leader call - leader not known. "
+                   "Command will be forwarded once leader is known.",
+                   [log_id(State)]),
             {keep_state,
              State#state{pending_commands = [{From, Msg} | Pending]}};
         _ when Leader =/= undefined ->


### PR DESCRIPTION
Ensure machine monitors are removed when member steps down.

This moves the call to `ra_members:remove_all/2` to be called whenever
a node enters follower state rather than exiting leader as was done
before. When performing leadership transfer the old leader passes
via the await_condition state and would have left machine monitors behind.