### PR TITLE
Make pre_vote machine version logic less strict

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1965,14 +1965,14 @@ process_pre_vote(FsmState, #pre_vote_rpc{term = Term, candidate_id = Cand,
   when Term >= CurTerm  ->
     State = update_term(Term, State0),
     LastIdxTerm = last_idx_term(State),
-    MaxLocalVersion = max(OurMacVer, EffMacVer),
     case is_candidate_log_up_to_date(LLIdx, LLTerm, LastIdxTerm) of
         true when Version > ?RA_PROTO_VERSION->
             ?DEBUG("~s: declining pre-vote for ~w for protocol version ~b",
                    [log_id(State0), Cand, Version]),
             {FsmState, State, [{reply, pre_vote_result(Term, Token, false)}]};
         true when TheirMacVer == EffMacVer orelse
-                  TheirMacVer == MaxLocalVersion ->
+                  (TheirMacVer >= EffMacVer andalso
+                   TheirMacVer =< OurMacVer) ->
             ?DEBUG("~s: granting pre-vote for ~w"
                    " machine version (their:ours:effective) ~b:~b:~b"
                    " with last indexterm ~w"

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -976,12 +976,22 @@ follower_pre_vote(_Config) ->
                                                         machine_version = 1}}),
 
     %% disallow pre votes for any version in between local and effective
+    %% when effective is higher
     {follower, _,
      [{reply, #pre_vote_result{term = Term, token = Token,
                                vote_granted = false}} | _]} =
         ra_server:handle_follower(Msg#pre_vote_rpc{machine_version = 2},
                                   State#{cfg => Cfg#cfg{effective_machine_version = 3,
                                                         machine_version = 2}}),
+
+    %% allow pre votes for any version higher than the effective and lower
+    %% than local when effective is lower than local
+    {follower, _,
+     [{reply, #pre_vote_result{term = Term, token = Token,
+                               vote_granted = true}} | _]} =
+        ra_server:handle_follower(Msg#pre_vote_rpc{machine_version = 2},
+                                  State#{cfg => Cfg#cfg{effective_machine_version = 1,
+                                                        machine_version = 3}}),
 
     % allow votes from a lower machine version when the effective machine
     % version is lower too


### PR DESCRIPTION
So that votes will be given whenever the candidate version is higher than the effective version and lower than the local version.
