### PR TITLE
Fix a bug that `ra:restart_server/2` could raise an exception

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -175,6 +175,7 @@ restart_server(System, ServerId)
         {ok, _} -> ok;
         {ok, _, _} -> ok;
         {error, _} = Err -> Err;
+        {badrpc, Reason} -> {error, Reason};
         {'EXIT', Err} -> {error, Err}
     end.
 
@@ -197,6 +198,7 @@ restart_server(System, ServerId, AddConfig)
         {ok, _} -> ok;
         {ok, _, _} -> ok;
         {error, _} = Err -> Err;
+        {badrpc, Reason} -> {error, Reason};
         {'EXIT', Err} -> {error, Err}
     end.
 

--- a/src/ra_server_sup_sup.erl
+++ b/src/ra_server_sup_sup.erl
@@ -39,7 +39,7 @@
 -include("ra.hrl").
 
 -spec start_server(System :: atom(), ra_server:ra_server_config()) ->
-    supervisor:startchild_ret() | {error, not_new | system_not_started}.
+    supervisor:startchild_ret() | {error, not_new | system_not_started} | {badrpc, term()}.
 start_server(System, #{id := NodeId,
                        uid := UId} = Config)
   when is_atom(System) ->
@@ -47,7 +47,7 @@ start_server(System, #{id := NodeId,
     rpc:call(Node, ?MODULE, start_server_rpc, [System, UId, Config]).
 
 -spec restart_server(atom(), ra_server_id(), ra_server:mutable_config()) ->
-    supervisor:startchild_ret() | {error, system_not_started}.
+    supervisor:startchild_ret() | {error, system_not_started} | {badrpc, term()}.
 restart_server(System, {RaName, Node}, AddConfig) ->
     rpc:call(Node, ?MODULE, restart_server_rpc,
              [System, {RaName, Node}, AddConfig]).


### PR DESCRIPTION
## Proposed Changes

This PR fixes a bug that `ra:restart_server/2` could raise a `case_clause` exception as the function doesn't handle `{badrpc, _}` (a possible return value of `ra_server_sup_sup:restart_server()`).

I ran into this bug when I tested how `ra` works if disk failure happens (as an example of the exception, see the stacktrace below).

```erlang
{{case_clause,
  {badrpc,
   {'EXIT',
    {badarg,
     [{dets,lookup,
       [ra_directory_reverse, foo],
       [{file,"dets.erl"},{line,1269}]},
      {ra_directory,uid_of,2,
       [{file,
         "/foo/_build/default/lib/ra/src/ra_directory.erl"},
        {line,166}]},
      {ra_server_sup_sup,recover_config,2,
       [{file,
         "/foo/_build/default/lib/ra/src/ra_server_sup_sup.erl"},
        {line,203}]},
      {ra_server_sup_sup,restart_server_rpc,3,
       [{file,
         "/foo/_build/default/lib/ra/src/ra_server_sup_sup.erl"},
        {line,86}]}]}}}},
 [{ra,restart_server,2,
   [{file,
     "/foo/_build/default/lib/ra/src/ra.erl"},
    {line,174}]}, ...
```

I could not make a reproducing code or a test case that cover this case as it's too rare and hard.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
