### PR TITLE
Don't rely on the order of lists returned by maps

### DIFF
--- a/src/ra_monitors.erl
+++ b/src/ra_monitors.erl
@@ -135,10 +135,11 @@ basics_test() ->
     M1 = add(self(), machine, M0),
     [machine] = components(self(), M1),
     M2 = add(self(), aux, M1),
-    [aux, machine] = components(self(), M2),
+    [aux, machine] = lists:sort(components(self(), M2)),
     M3 = remove(self(), machine, M2),
     [aux] = components(self(), M3),
-    {[aux, machine], M5} = handle_down(self(), M2),
+    {Components, M5} = handle_down(self(), M2),
+    [aux, machine] = lists:sort(Components),
     [] = components(self(), M5),
     ok.
 


### PR DESCRIPTION
For reference:
```
OTP-18414    Application(s): erts, stdlib
               Related Id(s): PR-6151

               *** HIGHLIGHT ***

               Some map operations have been optimized by changing the
               internal sort order of atom keys. This changes the
               (undocumented) order of how atom keys in small maps are
               printed and returned by maps:to_list/1 and maps:next/1.
               The new order is unpredictable and may change between
               different invocations of the Erlang VM.
```