### PR TITLE
Allow non-leaders to process apply effects

### DIFF
--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1160,10 +1160,10 @@ handle_effect(RaftState, {log, Idxs, Fun, {local, Node}}, EvtType,
         false ->
             {State, Actions}
     end;
-handle_effect(leader, {append, Cmd}, _EvtType, State, Actions) ->
+handle_effect(_RaftState, {append, Cmd}, _EvtType, State, Actions) ->
     Evt = {command, normal, {'$usr', Cmd, noreply}},
     {State, [{next_event, cast, Evt} | Actions]};
-handle_effect(leader, {append, Cmd, ReplyMode}, _EvtType, State, Actions) ->
+handle_effect(_RaftState, {append, Cmd, ReplyMode}, _EvtType, State, Actions) ->
     Evt = {command, normal, {'$usr', Cmd, ReplyMode}},
     {State, [{next_event, cast, Evt} | Actions]};
 handle_effect(RaftState, {log, Idxs, Fun}, EvtType,

--- a/test/ra_machine_int_SUITE.erl
+++ b/test/ra_machine_int_SUITE.erl
@@ -40,6 +40,7 @@ all_tests() ->
      meta_data,
      append_effect,
      append_effect_with_notify,
+     append_effect_follower,
      timer_effect,
      log_effect,
      aux_eval,
@@ -398,6 +399,61 @@ append_effect_with_notify(Config) ->
     after 1000 ->
               flush(),
               exit(cmd2_timeout)
+    end,
+    ok.
+
+append_effect_follower(Config) ->
+    %% the append effect is issued against a follower from an aux handler
+    Mod = ?config(modname, Config),
+    Self = self(),
+    meck:new(Mod, [non_strict]),
+    meck:expect(Mod, init, fun (_) -> the_state end),
+    meck:expect(Mod, apply, fun
+                                (_, {cmd2, "yo"}, State) ->
+                                    {State, ok, [{send_msg, Self, got_cmd2}]}
+                            end),
+    meck:expect(Mod, handle_aux, fun
+                                     (_, _, {cmd, ReplyMode}, Aux, Log, _MacState) ->
+                                         {no_reply, Aux, Log,
+                                          [{append, {cmd2, "yo"}, ReplyMode}]};
+                                     (_, _, _Evt, Aux, Log, _MacState) ->
+                                         {no_reply, Aux, Log}
+                                 end),
+    ClusterName = ?config(cluster_name, Config),
+    ServerId = ?config(server_id, Config),
+    ServerId2 = ?config(server_id2, Config),
+    ServerId3 = ?config(server_id3, Config),
+
+    ok = start_cluster(ClusterName, {module, Mod, #{}},
+                       [ServerId, ServerId2, ServerId3]),
+    {ok, Members, Leader} = ra:members(ServerId),
+    [Follower | _] = lists:delete(Leader, Members),
+    ok = ra:cast_aux_command(Follower, {cmd, noreply}),
+    receive
+        got_cmd2 ->
+            ok
+    after 1000 ->
+              flush(),
+              exit(cmd2_timeout)
+    end,
+
+    Corr = make_ref(),
+    ok = ra:cast_aux_command(Follower, {cmd, {notify, Corr, self()}}),
+    receive
+        {ra_event, Follower, {rejected, {not_leader, Leader2, Corr}}}  ->
+            %% the command got rejected, resend to leader
+            ok = ra:cast_aux_command(Leader2, {cmd, {notify, Corr, self()}}),
+            receive
+                got_cmd2 ->
+                    flush(),
+                    ok
+            after 1000 ->
+                      flush(),
+                      exit(cmd2_timeout)
+            end
+    after 1000 ->
+              flush(),
+              exit(ra_event_timeout)
     end,
     ok.
 


### PR DESCRIPTION
An apply effect emitted by e.g. an aux handler against a follower would be dropped which isn't ideal. This commit changes it to handle apply effects in any state and delegating the handling of these commands to the ra code. (i.e. reject or divert).
