### PR TITLE
Fix snapshot installation CRC failure

### DIFF
--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -39,7 +39,10 @@
 %% after node restart). Pids are not stable in this sense.
 -type ra_server_id() :: {Name :: atom(), Node :: node()}.
 
--type ra_peer_status() :: normal | {sending_snapshot, pid()} | suspended.
+-type ra_peer_status() :: normal |
+                          {sending_snapshot, pid()} |
+                          suspended |
+                          disconnected.
 
 -type ra_peer_state() :: #{next_index := non_neg_integer(),
                            match_index := non_neg_integer(),

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1565,11 +1565,12 @@ fold_log(From, Fun, Term, State) ->
 
 send_snapshots(Me, Id, Term, {_, ToNode} = To, ChunkSize,
                InstallTimeout, SnapState, Machine) ->
+    Context = ra_snapshot:context(SnapState, ToNode),
     {ok, #{machine_version := SnapMacVer} = Meta, ReadState} =
-        ra_snapshot:begin_read(SnapState),
+        ra_snapshot:begin_read(SnapState, Context),
 
     %% only send the snapshot if the target server can accept it
-    TheirMacVer = rpc:call(ToNode, ra_machine, version, [Machine]),
+    TheirMacVer = erpc:call(ToNode, ra_machine, version, [Machine]),
 
     case SnapMacVer > TheirMacVer of
         true ->

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1229,40 +1229,49 @@ handle_effect(_, {reply, Reply}, {call, From}, State, Actions) ->
     {State, Actions};
 handle_effect(_, {reply, Reply}, EvtType, _, _) ->
     exit({undefined_reply, Reply, EvtType});
-handle_effect(leader, {send_snapshot, To, {SnapState, Id, Term}}, _,
+handle_effect(leader, {send_snapshot, {_, ToNode} = To, {SnapState, Id, Term}}, _,
               #state{server_state = SS0,
                      monitors = Monitors,
                      conf = #conf{snapshot_chunk_size = ChunkSize,
                      install_snap_rpc_timeout = InstallSnapTimeout} = Conf} = State0,
               Actions) ->
-    ok = incr_counter(Conf, ?C_RA_SRV_SNAPSHOTS_SENT, 1),
-    %% leader effect only
-    Self = self(),
-    Machine = ra_server:machine(SS0),
-    Pid = spawn(fun () ->
-                        try send_snapshots(Self, Id, Term, To,
-                                           ChunkSize, InstallSnapTimeout,
-                                           SnapState, Machine) of
-                            _ -> ok
-                        catch
-                            C:timeout:S ->
-                                %% timeout is ok as we've already blocked
-                                %% for a while
-                                erlang:raise(C, timeout, S);
-                            C:E:S ->
-                                %% insert an arbitrary pause here as a primitive
-                                %% throttling operation as certain errors
-                                %% happen quickly
-                                ok = timer:sleep(5000),
-                                erlang:raise(C, E, S)
-                        end
-                end),
-    %% update the peer state so that no pipelined entries are sent during
-    %% the snapshot sending phase
-    SS = ra_server:update_peer(To, #{status => {sending_snapshot, Pid}}, SS0),
-    {State0#state{server_state = SS,
-                  monitors = ra_monitors:add(Pid, snapshot_sender, Monitors)},
-                  Actions};
+    case lists:member(ToNode, [node() | nodes()]) of
+        true ->
+            %% node is connected
+            %% leader effect only
+            Self = self(),
+            Machine = ra_server:machine(SS0),
+            Pid = spawn(fun () ->
+                                try send_snapshots(Self, Id, Term, To,
+                                                   ChunkSize, InstallSnapTimeout,
+                                                   SnapState, Machine) of
+                                    _ -> ok
+                                catch
+                                    C:timeout:S ->
+                                        %% timeout is ok as we've already blocked
+                                        %% for a while
+                                        erlang:raise(C, timeout, S);
+                                    C:E:S ->
+                                        %% insert an arbitrary pause here as a primitive
+                                        %% throttling operation as certain errors
+                                        %% happen quickly
+                                        ok = timer:sleep(5000),
+                                        erlang:raise(C, E, S)
+                                end
+                        end),
+            ok = incr_counter(Conf, ?C_RA_SRV_SNAPSHOTS_SENT, 1),
+            %% update the peer state so that no pipelined entries are sent during
+            %% the snapshot sending phase
+            SS = ra_server:update_peer(To, #{status => {sending_snapshot, Pid}}, SS0),
+            {State0#state{server_state = SS,
+                          monitors = ra_monitors:add(Pid, snapshot_sender, Monitors)},
+             Actions};
+        false ->
+            ?DEBUG("~s: send_snapshot node ~s disconnected",
+                   [log_id(State0), ToNode]),
+            SS = ra_server:update_peer(To, #{status => disconnected}, SS0),
+            {State0#state{server_state = SS}, Actions}
+    end;
 handle_effect(_, {delete_snapshot, Dir,  SnapshotRef}, _, State0, Actions) ->
     %% delete snapshots in separate process
     _ = spawn(fun() ->
@@ -1721,7 +1730,7 @@ handle_node_status_change(Node, Status, InfoList, RaftState,
                           #state{monitors = Monitors0,
                                  server_state = ServerState0} = State0) ->
     {Comps, Monitors} = ra_monitors:handle_down(Node, Monitors0),
-    {_, ServerState, Effects} =
+    {_, ServerState1, Effects} =
         lists:foldl(
           fun (Comp, {R, S0, E0}) ->
                   {R, S, E} = ra_server:handle_node_status(R, Comp, Node,
@@ -1729,6 +1738,8 @@ handle_node_status_change(Node, Status, InfoList, RaftState,
                                                            S0),
                   {R, S, E0 ++ E}
           end, {RaftState, ServerState0, []}, Comps),
+    ServerState = ra_server:update_disconnected_peers(Node, Status,
+                                                      ServerState1),
     {State, Actions} = handle_effects(RaftState, Effects, cast,
                                       State0#state{server_state = ServerState,
                                                    monitors = Monitors}),

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -678,7 +678,8 @@ snapshot_written_after_installation(Config) ->
                          end,
 
     Meta = meta(15, 2, [?N1]),
-    Chunk = create_snapshot_chunk(Config, Meta),
+    Context = #{},
+    Chunk = create_snapshot_chunk(Config, Meta, Context),
     SnapState0 = ra_log:snapshot_state(Log2),
     {ok, SnapState1} = ra_snapshot:begin_accept(Meta, SnapState0),
     {ok, SnapState} = ra_snapshot:accept_chunk(Chunk, 1, last, SnapState1),
@@ -726,7 +727,7 @@ snapshot_installation(Config) ->
 
     %% create snapshot chunk
     Meta = meta(15, 2, [?N1]),
-    Chunk = create_snapshot_chunk(Config, Meta),
+    Chunk = create_snapshot_chunk(Config, Meta, #{}),
     SnapState0 = ra_log:snapshot_state(Log2),
     {ok, SnapState1} = ra_snapshot:begin_accept(Meta, SnapState0),
     {ok, SnapState} = ra_snapshot:accept_chunk(Chunk, 1, last, SnapState1),
@@ -775,7 +776,7 @@ append_after_snapshot_installation(Config) ->
                              end),
     %% do snapshot
     Meta = meta(15, 2, [?N1]),
-    Chunk = create_snapshot_chunk(Config, Meta),
+    Chunk = create_snapshot_chunk(Config, Meta, #{}),
     SnapState0 = ra_log:snapshot_state(Log1),
     {ok, SnapState1} = ra_snapshot:begin_accept(Meta, SnapState0),
     {ok, SnapState} = ra_snapshot:accept_chunk(Chunk, 1, last, SnapState1),
@@ -806,7 +807,7 @@ written_event_after_snapshot_installation(Config) ->
     SnapIdx = 10,
     %% do snapshot in
     Meta = meta(SnapIdx, 2, [?N1]),
-    Chunk = create_snapshot_chunk(Config, Meta),
+    Chunk = create_snapshot_chunk(Config, Meta, #{}),
     SnapState0 = ra_log:snapshot_state(Log1),
     {ok, SnapState1} = ra_snapshot:begin_accept(Meta, SnapState0),
     {ok, SnapState} = ra_snapshot:accept_chunk(Chunk, 1, last, SnapState1),
@@ -1274,7 +1275,7 @@ meta(Idx, Term, Cluster) ->
       cluster => Cluster,
       machine_version => 1}.
 
-create_snapshot_chunk(Config, #{index := Idx} =  Meta) ->
+create_snapshot_chunk(Config, #{index := Idx} = Meta, Context) ->
     OthDir = filename:join(?config(priv_dir, Config), "snapshot_installation"),
     ok = ra_lib:make_dir(OthDir),
     Sn0 = ra_snapshot:init(<<"someotheruid_adsfasdf">>, ra_log_snapshot,
@@ -1288,7 +1289,7 @@ create_snapshot_chunk(Config, #{index := Idx} =  Meta) ->
         after 1000 ->
                   exit(snapshot_timeout)
         end,
-    {ok, Meta, ChunkSt} = ra_snapshot:begin_read(Sn2),
+    {ok, Meta, ChunkSt} = ra_snapshot:begin_read(Sn2, Context),
     {ok, Chunk, _} = ra_snapshot:read_chunk(ChunkSt, 1000000000, Sn2),
     Chunk.
 

--- a/test/ra_log_snapshot_SUITE.erl
+++ b/test/ra_log_snapshot_SUITE.erl
@@ -6,6 +6,7 @@
 %%
 -module(ra_log_snapshot_SUITE).
 
+-compile(nowarn_export_all).
 -compile(export_all).
 
 -export([
@@ -27,6 +28,8 @@ all() ->
 all_tests() ->
     [
      roundtrip,
+     roundtrip_compat,
+     accept,
      read_missing,
      read_other_file,
      read_invalid_version,
@@ -53,9 +56,11 @@ end_per_group(_Group, _Config) ->
     ok.
 
 init_per_testcase(TestCase, Config) ->
-    Dir = filename:join(?config(priv_dir, Config), TestCase),
+    Dir = filename:join([?config(priv_dir, Config), TestCase, write]),
     ok = ra_lib:make_dir(Dir),
-    [{dir, Dir} | Config].
+    AcceptDir = filename:join([?config(priv_dir, Config), TestCase, accept]),
+    ok = ra_lib:make_dir(AcceptDir),
+    [{accept_dir, AcceptDir}, {dir, Dir} | Config].
 
 end_per_testcase(_TestCase, _Config) ->
     ok.
@@ -69,23 +74,76 @@ roundtrip(Config) ->
     SnapshotMeta = meta(33, 94, [{banana, node@jungle}, {banana, node@savanna}]),
     SnapshotRef = my_state,
     ok = ra_log_snapshot:write(Dir, SnapshotMeta, SnapshotRef),
+    Context = #{can_accept_full_file => true},
+    ?assertEqual({SnapshotMeta, SnapshotRef}, read(Dir, Context)),
+    ok.
+
+roundtrip_compat(Config) ->
+    Dir = ?config(dir, Config),
+    SnapshotMeta = meta(33, 94, [{banana, node@jungle}, {banana, node@savanna}]),
+    SnapshotRef = my_state,
+    ok = ra_log_snapshot:write(Dir, SnapshotMeta, SnapshotRef),
     ?assertEqual({SnapshotMeta, SnapshotRef}, read(Dir)),
     ok.
 
+dir(Base, Dir0) ->
+    Dir = filename:join(Base, Dir0),
+    ok = ra_lib:make_dir(Dir),
+    Dir.
+
+
+accept(Config) ->
+    test_accept(Config, one, 1024, true, 128),
+    test_accept(Config, two, 1024, false, 128),
+    test_accept(Config, three, 8, true, 64),
+    test_accept(Config, four, 8, false, 64),
+    ok.
+
+
+
+test_accept(Config, Name, DataSize, FullFile, ChunkSize) ->
+    Dir = dir(?config(dir, Config), Name),
+    AcceptDir = dir(?config(accept_dir, Config), Name),
+    ct:pal("test_accept ~w ~b ~w ~b", [Name, DataSize, FullFile, ChunkSize]),
+    SnapshotMeta = meta(33, 94, [{banana, node@jungle}, {banana, node@savanna}]),
+    SnapshotRef = crypto:strong_rand_bytes(DataSize),
+    ok = ra_log_snapshot:write(Dir, SnapshotMeta, SnapshotRef),
+    Context = #{can_accept_full_file => FullFile},
+    {ok, Meta, St} =  ra_log_snapshot:begin_read(Dir, Context),
+    %% how to ensure
+    [LastChunk | Chunks] = lists:reverse(read_all_chunks(St, Dir, ChunkSize, [])),
+    {ok, A0} = ra_log_snapshot:begin_accept(AcceptDir, Meta),
+    A1 = lists:foldl(fun (Ch, Acc0) ->
+                             {ok, Acc} = ra_log_snapshot:accept_chunk(Ch, Acc0),
+                             Acc
+                     end, A0, lists:reverse(Chunks)),
+    ok = ra_log_snapshot:complete_accept(LastChunk, A1),
+    ok.
+
 read(Dir) ->
-    case ra_log_snapshot:begin_read(Dir) of
-        {ok, Meta, St} ->
-            <<_Crc:32/integer, Snap/binary>> = read_all_snapshot(St, Dir, 128, <<>>),
-            {Meta, binary_to_term(Snap)};
+    read(Dir, #{}).
+
+read(Dir, Context) ->
+    case ra_log_snapshot:begin_read(Dir, Context) of
+        {ok, _Meta, St} ->
+            case iolist_to_binary(
+                   read_all_chunks(St, Dir, 128, [])) of
+                <<"RASN", 1:8, _Crc:32/integer,
+                  MetaSz:32/integer, Meta:MetaSz/binary,
+                  Snap/binary>> ->
+                    {binary_to_term(Meta), binary_to_term(Snap)};
+                <<_Crc:32/integer, Snap/binary>> ->
+                    {_Meta, binary_to_term(Snap)}
+            end;
         Err -> Err
     end.
 
-read_all_snapshot(St, Dir, Size, Acc) ->
+read_all_chunks(St, Dir, Size, Acc) ->
     case ra_log_snapshot:read_chunk(St, Size, Dir) of
         {ok, Data, {next, St1}} ->
-            read_all_snapshot(St1, Dir, Size, <<Acc/binary, Data/binary>>);
+            read_all_chunks(St1, Dir, Size, [Data | Acc]);
         {ok, Data, last} ->
-            <<Acc/binary, Data/binary>>;
+            lists:reverse([Data | Acc]);
         Err -> Err
     end.
 

--- a/test/ra_snapshot_SUITE.erl
+++ b/test/ra_snapshot_SUITE.erl
@@ -6,6 +6,7 @@
 %%
 -module(ra_snapshot_SUITE).
 
+-compile(nowarn_export_all).
 -compile(export_all).
 
 -export([
@@ -291,13 +292,14 @@ read_snapshot(Config) ->
              after 1000 ->
                        error(snapshot_event_timeout)
              end,
+     Context = #{},
 
-    {ok, Meta, InitChunkState} = ra_snapshot:begin_read(State),
+     {ok, Meta, InitChunkState} = ra_snapshot:begin_read(State, Context),
 
-    <<_Crc:32/integer, Data/binary>> = read_all_chunks(InitChunkState, State, 1024, <<>>),
-    ?assertEqual(MacRef, binary_to_term(Data)),
+     <<_:32/integer, Data/binary>> = read_all_chunks(InitChunkState, State, 1024, <<>>),
+     ?assertEqual(MacRef, binary_to_term(Data)),
 
-    ok.
+     ok.
 
 read_all_chunks(ChunkState, State, Size, Acc) ->
     case ra_snapshot:read_chunk(ChunkState, Size, State) of

--- a/test/ra_system_SUITE.erl
+++ b/test/ra_system_SUITE.erl
@@ -6,6 +6,7 @@
 %%
 -module(ra_system_SUITE).
 
+-compile(nowarn_export_all).
 -compile(export_all).
 
 -export([
@@ -14,7 +15,6 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--define(info, true).
 
 %%%===================================================================
 %%% Common Test callbacks


### PR DESCRIPTION
Due to the unwise use of term_to_binary rather than using the original binary data in the replication of snapshot states.

This change:

Introduces a new optional ra_snapshot callback: context/0

This is called by the sending Ra leader node to discover context and capabilities of the receiver. In this case it is used to indicate if the receiver is capabable of receiving the entire snapshot file.

Receiving the entire file is the updated approach that ensures the CRC check will be done on the same binary data it was generated from.

If the receiver does not have the context/0 callback or does not indicate support the old approach of sending the deserialised metat data map and any data following that is used.

When a snapshot is received from an old node (i.e. _not_ including the entire file) the receiver will not validate the checksum (as it may fail due to differences in map serialisation) and instead patch up it's local file with it's own calculcated checksum.

The scenario where a snapshot taken by a newer version of OTP and is then sent to a member using the old code cannot be handled and the old node will fail at snapshot checksum validation.

Fixes #368 
