### PR TITLE
Use the correct counter name for segment writer.

### DIFF
--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -104,9 +104,10 @@ await(SegWriter)  ->
 %%%===================================================================
 
 init([#{data_dir := DataDir,
+        name := SegWriterName,
         system := System} = Conf]) ->
     process_flag(trap_exit, true),
-    CRef = ra_counters:new(?MODULE, ?COUNTER_FIELDS),
+    CRef = ra_counters:new(SegWriterName, ?COUNTER_FIELDS),
     SegmentConf = maps:get(segment_conf, Conf, #{}),
     {ok, #state{system = System,
                 data_dir = DataDir,


### PR DESCRIPTION
Else all Ra systems would use the same key and you would only get segment writer counters for the last system to start.
