### PR TITLE
Write config to temp file then move

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -436,7 +436,7 @@ start_cluster(System, [#{cluster_name := ClusterName} | _] = ServerConfigs,
             case members(TriggeredId,
                          length(ServerConfigs) * Timeout) of
                 {ok, _, Leader} ->
-                    ?INFO("ra: started cluster ~s with ~b servers~n"
+                    ?INFO("ra: started cluster ~ts with ~b servers~n"
                           "~b servers failed to start: ~w~nLeader: ~w",
                           [ClusterName, length(ServerConfigs),
                            length(NotStarted), NotStartedIds,

--- a/src/ra_directory.erl
+++ b/src/ra_directory.erl
@@ -82,7 +82,7 @@ register_name(#{directory := Directory,
             ok;
         OtherUId ->
             ok = dets:insert(DirRev, {ServerName, UId}),
-            ?WARN("ra server with name ~s UId ~s replaces prior UId ~s",
+            ?WARN("ra server with name ~ts UId ~s replaces prior UId ~s",
                   [ServerName, UId, OtherUId]),
             ok
     end.

--- a/src/ra_lib.erl
+++ b/src/ra_lib.erl
@@ -135,7 +135,7 @@ zpad_hex(Num) ->
     lists:flatten(io_lib:format("~16.16.0B", [Num])).
 
 zpad_filename("", Ext, Num) ->
-    lists:flatten(io_lib:format("~8..0B.~s", [Num, Ext]));
+    lists:flatten(io_lib:format("~8..0B.~ts", [Num, Ext]));
 zpad_filename(Prefix, Ext, Num) ->
     lists:flatten(io_lib:format("~ts_~8..0B.~ts", [Prefix, Num, Ext])).
 
@@ -502,7 +502,7 @@ lists_chink_test() ->
 make_uid_test() ->
     U1 = make_uid(),
     U2 = make_uid(),
-    ?debugFmt("U1 ~s U2 ~s", [U1, U2]),
+    ?debugFmt("U1 ~ts U2 ~s", [U1, U2]),
     ?assertNotEqual(U1, U2),
     <<"ABCD", _/binary>> = make_uid("ABCD"),
     <<"ABCD", _/binary>> = make_uid(<<"ABCD">>),

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -218,7 +218,7 @@ init(#{uid := UId,
     % initialized with a default 0 index 0 term dummy value
     % and an empty meta data map
     State = maybe_append_first_entry(State0),
-    ?DEBUG("~s: ra_log:init recovered last_index_term ~w"
+    ?DEBUG("~ts: ra_log:init recovered last_index_term ~w"
            " first index ~b",
            [State#?MODULE.cfg#cfg.log_id,
             last_index_term(State),
@@ -431,7 +431,7 @@ handle_event({written, {FromIdx, ToIdx0, Term}},
             {State#?MODULE{last_written_index_term = LastWrittenIdxTerm},
              [{next_event, {ra_log_event, {truncate_cache, FromIdx, ToIdx}}}]};
         {OtherTerm, State} ->
-            ?DEBUG("~s: written event did not find term ~b for index ~b "
+            ?DEBUG("~ts: written event did not find term ~b for index ~b "
                    "found ~w",
                    [State#?MODULE.cfg#cfg.log_id, Term, ToIdx, OtherTerm]),
             {State, []}
@@ -442,7 +442,7 @@ handle_event({written, {FromIdx, _, _}},
   when FromIdx > LastWrittenIdx + 1 ->
     % leaving a gap is not ok - resend from cache
     Expected = LastWrittenIdx + 1,
-    ?DEBUG("~s: ra_log: written gap detected at ~b expected ~b!",
+    ?DEBUG("~ts: ra_log: written gap detected at ~b expected ~b!",
            [LogId, FromIdx, Expected]),
     {resend_from(Expected, State0), []};
 handle_event({truncate_cache, FromIdx, ToIdx}, State) ->
@@ -514,7 +514,7 @@ handle_event({snapshot_written, {Idx, Term} = Snap},
                       snapshot_state = SnapState} = State0) ->
     %% if the snapshot is stale we just want to delete it
     Current = ra_snapshot:current(SnapState),
-    ?INFO("~s: old snapshot_written received for index ~b in term ~b
+    ?INFO("~ts: old snapshot_written received for index ~b in term ~b
           current snapshot ~w, deleting old snapshot",
            [LogId, Idx, Term, Current]),
     Effects = [{delete_snapshot,
@@ -753,7 +753,7 @@ delete_everything(#?MODULE{cfg = #cfg{directory = Dir}} = Log) ->
     catch
         _:_ = Err ->
             ?WARN("ra_log:delete_everything/1 failed to delete "
-                  "directory ~s~n Error: ~p", [Dir, Err])
+                  "directory ~ts~n Error: ~p", [Dir, Err])
     end,
     ok.
 
@@ -822,7 +822,7 @@ delete_segments(SnapIdx, #?MODULE{cfg = #cfg{log_id = LogId,
                                                                          UId, Pivot)
                     end),
             Active = ra_log_reader:segment_refs(Reader),
-            ?DEBUG("~s: ~b obsolete segments at ~b - remaining: ~b, pivot ~w",
+            ?DEBUG("~ts: ~b obsolete segments at ~b - remaining: ~b, pivot ~w",
                    [LogId, length(Obsolete), SnapIdx, length(Active), Pivot]),
             State = State0#?MODULE{reader = Reader},
             {State, log_update_effects(Readers, Pid, State)}
@@ -897,7 +897,7 @@ resend_from(Idx, #?MODULE{cfg = #cfg{uid = UId}} = State0) ->
         State -> State
     catch
         exit:wal_down ->
-            ?WARN("~s: ra_log: resending from ~b failed with wal_down",
+            ?WARN("~ts: ra_log: resending from ~b failed with wal_down",
                   [UId, Idx]),
             State0
     end.
@@ -906,7 +906,7 @@ resend_from0(Idx, #?MODULE{cfg = Cfg,
                            last_index = LastIdx,
                            last_resend_time = undefined,
                            cache = Cache} = State) ->
-    ?DEBUG("~s: ra_log: resending from ~b to ~b",
+    ?DEBUG("~ts: ra_log: resending from ~b to ~b",
            [State#?MODULE.cfg#cfg.log_id, Idx, LastIdx]),
     ok = incr_counter(Cfg, ?C_RA_LOG_WRITE_RESENDS, LastIdx - Idx + 1),
     lists:foldl(fun (I, Acc) ->

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -724,6 +724,7 @@ overview(#?MODULE{last_index = LastIndex,
 -spec write_config(ra_server:config(), state()) -> ok.
 write_config(Config0, #?MODULE{cfg = #cfg{directory = Dir}}) ->
     ConfigPath = filename:join(Dir, "config"),
+    TmpConfigPath = filename:join(Dir, "config.tmp"),
     % clean config of potentially unserialisable data
     Config = maps:without([parent,
                            counter,
@@ -731,8 +732,9 @@ write_config(Config0, #?MODULE{cfg = #cfg{directory = Dir}}) ->
                            %% don't write system config to disk as it will
                            %% be updated each time
                            system_config], Config0),
-    ok = ra_lib:write_file(ConfigPath,
+    ok = ra_lib:write_file(TmpConfigPath,
                            list_to_binary(io_lib:format("~p.", [Config]))),
+    ok = prim_file:rename(TmpConfigPath, ConfigPath),
     ok.
 
 -spec read_config(state() | file:filename()) ->

--- a/src/ra_log_meta.erl
+++ b/src/ra_log_meta.erl
@@ -54,7 +54,7 @@ init(#{name := System,
                                          {auto_save, ?SYNC_INTERVAL}]),
     _ = ets:new(TblName, [named_table, public, {read_concurrency, true}]),
     TblName = dets:to_ets(TblName, TblName),
-    ?INFO("ra: meta data store initialised for system ~s. ~b record(s) recovered",
+    ?INFO("ra: meta data store initialised for system ~ts. ~b record(s) recovered",
           [System, ets:info(TblName, size)]),
     {ok, #?MODULE{ref = Ref,
                   table_name = TblName}}.

--- a/src/ra_log_pre_init.erl
+++ b/src/ra_log_pre_init.erl
@@ -38,7 +38,7 @@ init([System]) ->
     %% populated before WAL recovery begins to avoid writing unnecessary
     %% indexes to segment files.
     Regd = ra_directory:list_registered(System),
-    ?INFO("ra system '~s' running pre init for ~b registered servers",
+    ?INFO("ra system '~ts' running pre init for ~b registered servers",
           [System, length(Regd)]),
     _ = [catch(pre_init(System, Name)) || {Name, _U} <- Regd],
     {ok, #state{} , hibernate}.

--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -149,7 +149,7 @@ handle_cast({mem_tables, Tables, WalFile}, State) ->
     % TODO: test scenario when server crashes after segments but before
     % deleting walfile
     % can we make segment writer idempotent somehow
-    ?DEBUG("segment_writer: deleting wal file: ~s",
+    ?DEBUG("segment_writer: deleting wal file: ~ts",
           [filename:basename(WalFile)]),
     %% temporarily disable wal deletion
     %% TODO: this should be a debug option config?
@@ -229,7 +229,7 @@ do_segment({ServerUId, StartIdx0, EndIdx, Tid},
 
     case open_file(Dir, SegConf) of
         enoent ->
-            ?DEBUG("segment_writer: skipping segment as directory ~s does "
+            ?DEBUG("segment_writer: skipping segment as directory ~ts does "
                   "not exist", [Dir]),
             %% clean up the tables for this process
             _ = ets:delete(Tid),
@@ -240,7 +240,7 @@ do_segment({ServerUId, StartIdx0, EndIdx, Tid},
                                    Segment0, State) of
                 undefined ->
                     ?WARN("segment_writer: skipping segments for ~w as
-                           directory ~s disappeared whilst writing",
+                           directory ~ts disappeared whilst writing",
                            [ServerUId, Dir]),
                     ok;
                 {Segment, Closed0} ->
@@ -279,7 +279,7 @@ send_segments(System, ServerUId, Tid, Segments) ->
         undefined ->
             ?DEBUG("ra_log_segment_writer: error sending "
                    "ra_log_event to: "
-                   "~s. Error: ~s",
+                   "~ts. Error: ~s",
                    [ServerUId, "No Pid"]),
             _ = ets:delete(Tid),
             _ = clean_closed_mem_tables(System, ServerUId, Tid),
@@ -293,7 +293,7 @@ clean_closed_mem_tables(System, UId, Tid) ->
     {ok, ClosedTbl} = ra_system:lookup_name(System, closed_mem_tbls),
     Tables = ets:lookup(ClosedTbl, UId),
     [begin
-         ?DEBUG("~w: cleaning closed table for '~s' range: ~b-~b",
+         ?DEBUG("~w: cleaning closed table for '~ts' range: ~b-~b",
                 [?MODULE, UId, From, To]),
          %% delete the entry in the closed table lookup
          true = ets:delete_object(ClosedTbl, O)
@@ -386,18 +386,18 @@ open_file(Dir, SegConf) ->
             %% a file was created by the segment header had not been
             %% synced. In this case it is typically safe to just delete
             %% and retry.
-            ?WARN("segment_writer: missing header in segment file ~s "
+            ?WARN("segment_writer: missing header in segment file ~ts "
                   "deleting file and retrying recovery", [File]),
             _ = prim_file:delete(File),
             open_file(Dir, SegConf);
         {error, enoent} ->
-            ?DEBUG("segment_writer: failed to open segment file ~s "
+            ?DEBUG("segment_writer: failed to open segment file ~ts "
                   "error: enoent", [File]),
             enoent;
         Err ->
             %% Any other error should be considered a hard error or else
             %% we'd risk data loss
-            ?WARN("segment_writer: failed to open segment file ~s "
+            ?WARN("segment_writer: failed to open segment file ~ts "
                   "error: ~W. Exiting", [File, Err, 10]),
             exit(Err)
     end.

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -301,7 +301,8 @@ do_init(#{id := Id,
             _ = spawn(fun () ->
                               [net_kernel:connect_node(N)
                                || N <- DisconnectedNodes]
-                      end)
+                      end),
+            ok
     end,
     TickTime = maps:get(tick_timeout, Config),
     InstallSnapRpcTimeout = maps:get(install_snap_rpc_timeout, Config),

--- a/src/ra_server_sup_sup.erl
+++ b/src/ra_server_sup_sup.erl
@@ -176,7 +176,7 @@ delete_data_directory(Directory) ->
                                      ok
                              catch
                                  _:_ = Err ->
-                                     ?WARN("ra: delete_server/1 failed to delete directory ~s~n"
+                                     ?WARN("ra: delete_server/1 failed to delete directory ~ts~n"
                                            "Error: ~p", [Directory, Err]),
                                      error
                              end
@@ -193,7 +193,7 @@ delete_data_directory(Directory) ->
 remove_all(System) when is_atom(System) ->
     #{names := #{server_sup := Sup}} = ra_system:fetch(System),
     _ = [begin
-             ?DEBUG("ra: terminating child ~w in system ~s~n", [Pid, System]),
+             ?DEBUG("ra: terminating child ~w in system ~ts~n", [Pid, System]),
              supervisor:terminate_child(Sup, Pid)
          end
          || {_, Pid, _, _} <- supervisor:which_children(Sup)],
@@ -244,7 +244,7 @@ start_child(Name, Config) ->
                     _ = erlang:demonitor(MRef),
                     {ok, Pid};
                 {'DOWN', MRef, _, _, Reason} ->
-                    ?ERROR("Ra: failed to start ra server ~s, err ~s",
+                    ?ERROR("Ra: failed to start ra server ~ts, err ~s",
                            [Name, Reason]),
                     {error, Reason}
             end;

--- a/src/ra_snapshot.erl
+++ b/src/ra_snapshot.erl
@@ -181,7 +181,7 @@ pick_first_valid(UId, Mod, Dir, [S | Rem]) ->
     case Mod:validate(filename:join(Dir, S)) of
         ok -> S;
         Err ->
-            ?INFO("ra_snapshot: ~s: skipping ~s as did not validate. Err: ~w",
+            ?INFO("ra_snapshot: ~ts: skipping ~s as did not validate. Err: ~w",
                   [UId, S, Err]),
             pick_first_valid(UId, Mod, Dir, Rem)
     end.


### PR DESCRIPTION
Instead of overwriting in place. This should be safer and reduce chances of config file corruptions that could cause members to become unable to restart.

Fixes: https://github.com/rabbitmq/ra/issues/381

Also includes an optimisation that avoids spawning a process during init if all nodes are connected.

And it includes some log formatting unicode compatibility fixes.