### PR TITLE
Seshat 0.6.0 + new ra:key_metrics/1 function to ensure key metrics are retrievable even when a ra server is recovering (or otherwise blocked)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -72,7 +72,7 @@ erlang_package.git_package(
 
 erlang_package.hex_package(
     name = "seshat",
-    version = "0.4.0",
+    version = "0.6.0",
 )
 
 use_repo(

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ESCRIPT_EMU_ARGS = -noinput -setcookie ra_fifo_cli
 
 dep_gen_batch_server = hex 0.8.8
 dep_aten = hex 0.5.8
-dep_seshat = hex 0.4.0
+dep_seshat = hex 0.6.0
 DEPS = aten gen_batch_server seshat
 
 TEST_DEPS = proper meck eunit_formatters inet_tcp_proxy

--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -269,6 +269,7 @@
 -define(C_RA_SRV_TERM_AND_VOTED_FOR_UPDATES, ?C_RA_LOG_RESERVED + 18).
 -define(C_RA_SRV_LOCAL_QUERIES, ?C_RA_LOG_RESERVED + 19).
 -define(C_RA_SRV_INVALID_REPLY_MODE_COMMANDS, ?C_RA_LOG_RESERVED + 20).
+-define(C_RA_SRV_RESERVED, ?C_RA_LOG_RESERVED + 21).
 
 
 -define(RA_SRV_COUNTER_FIELDS,
@@ -312,7 +313,38 @@
          {local_queries, ?C_RA_SRV_LOCAL_QUERIES, counter,
           "Total number of local queries"},
          {invalid_reply_mode_commands, ?C_RA_SRV_INVALID_REPLY_MODE_COMMANDS, counter,
-          "Total number of commands received with an invalid reply-mode"}
+          "Total number of commands received with an invalid reply-mode"},
+         {reserved_2, ?C_RA_SRV_RESERVED, counter, "Reserved counter"}
          ]).
 
--define(RA_COUNTER_FIELDS, ?RA_LOG_COUNTER_FIELDS ++ ?RA_SRV_COUNTER_FIELDS).
+-define(C_RA_SVR_METRIC_LAST_APPLIED, ?C_RA_SRV_RESERVED + 1).
+-define(C_RA_SVR_METRIC_COMMIT_INDEX, ?C_RA_SRV_RESERVED + 2).
+-define(C_RA_SVR_METRIC_SNAPSHOT_INDEX, ?C_RA_SRV_RESERVED + 3).
+-define(C_RA_SVR_METRIC_LAST_INDEX, ?C_RA_SRV_RESERVED + 4).
+-define(C_RA_SVR_METRIC_LAST_WRITTEN_INDEX, ?C_RA_SRV_RESERVED + 5).
+-define(C_RA_SVR_METRIC_COMMIT_LATENCY, ?C_RA_SRV_RESERVED + 6).
+-define(C_RA_SVR_METRIC_TERM, ?C_RA_SRV_RESERVED + 7).
+
+-define(RA_SRV_METRICS_COUNTER_FIELDS,
+        [
+         {last_applied, ?C_RA_SVR_METRIC_LAST_APPLIED, gauge,
+          "The last applied index. Can go backwards if a ra server is restarted."},
+         {commit_index, ?C_RA_SVR_METRIC_COMMIT_INDEX, counter,
+          "The current commit index."},
+         {snapshot_index, ?C_RA_SVR_METRIC_SNAPSHOT_INDEX, counter,
+          "The current snapshot index."},
+         {last_index, ?C_RA_SVR_METRIC_LAST_INDEX, counter,
+          "The last index of the log."},
+         {last_written_index, ?C_RA_SVR_METRIC_LAST_WRITTEN_INDEX, counter,
+          "The last fully written and fsynced index of the log."},
+         {commit_latency, ?C_RA_SVR_METRIC_COMMIT_LATENCY, gauge,
+          "Approximate time taken from an entry being written to the log until it is committed."},
+         {term, ?C_RA_SVR_METRIC_TERM, counter, "The current term."}
+        ]).
+
+-define(RA_COUNTER_FIELDS,
+        ?RA_LOG_COUNTER_FIELDS ++
+        ?RA_SRV_COUNTER_FIELDS ++
+        ?RA_SRV_METRICS_COUNTER_FIELDS).
+
+-define(FIELDSPEC_KEY, ra_seshat_fields_spec).

--- a/src/ra_counters.erl
+++ b/src/ra_counters.erl
@@ -5,6 +5,7 @@
 %% Copyright (c) 2017-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 -module(ra_counters).
+-include("ra.hrl").
 
 -export([
          init/0,
@@ -12,25 +13,24 @@
          fetch/1,
          overview/0,
          overview/1,
+         counters/2,
          delete/1
          ]).
 
 -type name() :: term().
--type seshat_field_spec() ::
-    {Name :: atom(), Position :: pos_integer(),
-     Type :: counter | gauge, Description :: string()}.
+
 
 -spec init() -> ok.
 init() ->
     _ = application:ensure_all_started(seshat),
     _ = seshat:new_group(ra),
+    persistent_term:put(?FIELDSPEC_KEY, ?RA_COUNTER_FIELDS),
     ok.
 
--spec new(name(),  [seshat_field_spec()]) ->
+-spec new(name(), seshat:fields_spec()) ->
     counters:counters_ref().
-new(Name, Fields)
-  when is_list(Fields) ->
-    seshat:new(ra, Name, Fields).
+new(Name, FieldsSpec) ->
+    seshat:new(ra, Name, FieldsSpec).
 
 -spec fetch(name()) -> undefined | counters:counters_ref().
 fetch(Name) ->
@@ -47,3 +47,8 @@ overview() ->
 -spec overview(name()) -> #{atom() => non_neg_integer()}.
 overview(Name) ->
     seshat:overview(ra, Name).
+
+-spec counters(name(), [atom()]) ->
+    #{atom() => non_neg_integer()} | undefined.
+counters(Name, Fields) ->
+    seshat:counters(ra, Name, Fields).

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -270,6 +270,8 @@ init(Config) ->
 
 do_init(#{id := Id,
           cluster_name := ClusterName} = Config0) ->
+    Key = ra_lib:ra_server_id_to_local_name(Id),
+    true = ets:insert(ra_state, {Key, init}),
     process_flag(trap_exit, true),
     Config = #{counter := Counter,
                system_config := SysConf} = maps:merge(config_defaults(Id),
@@ -283,7 +285,6 @@ do_init(#{id := Id,
     UId = ra_server:uid(ServerState),
     % ensure ra_directory has the new pid
     #{names := Names} = SysConf,
-    Key = ra_lib:ra_server_id_to_local_name(Id),
     ok = ra_directory:register_name(Names, UId, self(),
                                     maps:get(parent, Config, undefined), Key,
                                     ClusterName),
@@ -1527,7 +1528,7 @@ config_defaults(ServerId) ->
       install_snap_rpc_timeout => ?INSTALL_SNAP_RPC_TIMEOUT,
       await_condition_timeout => ?DEFAULT_AWAIT_CONDITION_TIMEOUT,
       initial_members => [],
-      counter => ra_counters:new(ServerId, ?RA_COUNTER_FIELDS),
+      counter => ra_counters:new(ServerId, {persistent_term, ?FIELDSPEC_KEY}),
       system_config => ra_system:default_config()
      }.
 


### PR DESCRIPTION
Update to use seshat 0.6.0

`ra:key_metrics/1` will return key metrics, previously inserted into
the ra_metrics table (which remains for now). The aim is to allow
this function to always return and use counters instead to be able
to see progress during recovery.