### PR TITLE
Handle shutdown exits in gen_statem:call/3

### DIFF
--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -65,7 +65,7 @@
 
 -type consistent_query_ref() :: {From :: term(), Query :: ra:query_fun(), ConmmitIndex :: ra_index()}.
 
--type safe_call_ret(T) :: timeout | {error, noproc | nodedown} | T.
+-type safe_call_ret(T) :: timeout | {error, noproc | nodedown | shutdown} | T.
 
 -type states() :: leader | follower | candidate | await_condition.
 

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1499,7 +1499,9 @@ gen_statem_safe_call(ServerId, Msg, Timeout) ->
          exit:{noproc, _} ->
             {error, noproc};
          exit:{{nodedown, _}, _} ->
-            {error, nodedown}
+            {error, nodedown};
+         exit:{shutdown, _} ->
+            {error, shutdown}
     end.
 
 do_state_query(all, State) -> State;


### PR DESCRIPTION
## Proposed Changes

`gen_statem:call/3` can fail if the server shuts down before replying to the call, exiting with `{shutdown, Location}`. We can handle this exit like the other exits in the `gen_statem_safe_call/3`. I think it makes sense to return `{error, noproc}` in this case since it's effectively the same as the server not being alive, but I think an `{error, shutdown}` return could be ok as well.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Cosmetics

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories