### PR TITLE
Add rabbitmq/bazel-central-registry@erlang-packages bzlmod registry

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,8 @@
 build --enable_bzlmod
 
+build --registry=https://bcr.bazel.build/
+build --registry=https://raw.githubusercontent.com/rabbitmq/bazel-central-registry/erlang-packages/
+
 build --incompatible_strict_action_env
 build --local_test_jobs=1
 


### PR DESCRIPTION
Allows bazel to find our internal packages that may or may not be on BCR