### PR TITLE
ra_machine: Allow the `version/0` callback to return 0

### DIFF
--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -251,7 +251,7 @@
 
 -callback snapshot_module() -> module().
 
--callback version() -> pos_integer().
+-callback version() -> version().
 
 -callback which_module(version()) -> module().
 
@@ -291,11 +291,17 @@ overview(Mod, State) ->
 %% code
 -spec version(machine()) -> version().
 version({machine, Mod, _}) ->
-    ?OPT_CALL(assert_integer(Mod:version()), ?DEFAULT_VERSION).
+    ?OPT_CALL(assert_version(Mod:version()), ?DEFAULT_VERSION).
 
 -spec is_versioned(machine()) -> boolean().
-is_versioned(Machine) ->
-    version(Machine) /= ?DEFAULT_VERSION.
+is_versioned({machine, Mod, _}) ->
+    try
+        _ = Mod:version(),
+        true
+    catch
+        error:undef ->
+            false
+    end.
 
 -spec which_module(machine(), version()) -> module().
 which_module({machine, Mod, _}, Version) ->
@@ -349,5 +355,5 @@ snapshot_module({machine, Mod, _}) ->
 
 %% internals
 
-assert_integer(I) when is_integer(I) andalso I > 0 ->
+assert_version(I) when is_integer(I) andalso I >= 0 ->
     I.


### PR DESCRIPTION
## Why

0 is now a valid value the `version/0` callback can return. It has always been a valid value, but the callback couldn't return that.

This allows a Ra machine module to explicitly set the initial version, even though it is the default implicit one.

## How

The `assert_integer/1` function, renamed to `assert_version/1` in the progress, now accepts 0 as a valid value.

The `version/0` callback spec is improved to return the `version()` type.

The `is_versioned/1` helper behavior changes: an unversioned Ra machine is a module which doesn't export the `version/0` callback.