### PR TITLE
Fix otp version indentifier to match rabbitmq-server main

### DIFF
--- a/.github/workflows/rabbitmq-oci.yaml
+++ b/.github/workflows/rabbitmq-oci.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - image_tag_suffix: otp-max-bazel
-            otp_version_id: 26
+            otp_version_id: 26_1
     steps:
       - name: Checkout Ra
         uses: actions/checkout@v3


### PR DESCRIPTION
There was a rename in rabbitmq-server that was not accounted for previously here