### PR TITLE
Quote `maybe` atoms

### DIFF
--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -546,7 +546,7 @@ next_index(#?MODULE{last_index = LastIdx}) ->
     LastIdx + 1.
 
 -spec fetch(ra_index(), state()) ->
-    {maybe(log_entry()), state()}.
+    {'maybe'(log_entry()), state()}.
 fetch(Idx, State0) ->
     case fold(Idx, Idx, fun(E, Acc) -> [E | Acc] end, [], State0) of
         {[], State} ->

--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -59,7 +59,7 @@
          data_start :: pos_integer(),
          data_offset :: pos_integer(),
          data_write_offset :: pos_integer(),
-         index = undefined :: maybe(ra_segment_index()),
+         index = undefined :: 'maybe'(ra_segment_index()),
          range :: 'maybe'({ra_index(), ra_index()}),
          pending_data = [] :: iodata(),
          pending_index = [] :: iodata(),
@@ -367,7 +367,7 @@ fold0(Cfg, Cache0, Idx, FinalIdx, Index, Fun, AccFun, Acc0) ->
                   Cfg#cfg.filename})
     end.
 
--spec range(state()) -> maybe({ra_index(), ra_index()}).
+-spec range(state()) -> 'maybe'({ra_index(), ra_index()}).
 range(#state{range = Range}) ->
     Range.
 


### PR DESCRIPTION
## Proposed Changes

Basically, `ra` codebase quotes `maybe` atoms (to support the maybe feature in the future I guess). 
However there are some `maybe` atoms that are not quoted, and `ra` can't be compiled if the maybe feature is enabled.
This PR fixes this problem.
Of course, this is not a critical problem. So, feel free to close this PR if it seems not needed.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
