### PR TITLE
Handle post_init and unknown terminate crash

### DIFF
--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1006,6 +1006,19 @@ terminate(Reason, StateName,
     end,
     _ = ets:delete(ra_metrics, MetricsKey),
     _ = ets:delete(ra_state, Key),
+    ok;
+%% This occurs if there is a crash in the init callback of the ra_machine,
+%% before a state has been built
+terminate(Reason, StateName, #{id := Id} = Config) ->
+    LogId = maps:get(friendly_name, Config,
+                     lists:flatten(io_lib:format("~w", [Id]))),
+    ?DEBUG("~ts: terminating with ~w in state ~w",
+           [LogId, Reason, StateName]),
+    ok;
+%% Unknown reason for termination
+terminate(Reason, StateName, State) ->
+    ?DEBUG("Terminating with ~w in state ~w with state ~w",
+           [Reason, StateName, State]),
     ok.
 
 code_change(_OldVsn, StateName, State, _Extra) ->


### PR DESCRIPTION
## Proposed Changes

Noticed that if a crash happens in the init callback in a ra_machine, the actual error gets obfuscated by the
`ra_server_proc` not handling a `terminate` without a state record.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
