### PR TITLE
Aten 0.6.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -50,8 +50,8 @@ erlang_package = use_extension(
 
 erlang_package.hex_package(
     name = "aten",
-    version = "0.5.8",
-    sha256 = "64d40a8cf0ddfea4e13af00b7327f0925147f83612d0627d9506cbffe90c13ef",
+    version = "0.6.0",
+    sha256 = "5f39a164206ae3f211ef5880b1f7819415686436e3229d30b6a058564fbaa168",
 )
 
 erlang_package.hex_package(

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ESCRIPT_NAME = ra_fifo_cli
 ESCRIPT_EMU_ARGS = -noinput -setcookie ra_fifo_cli
 
 dep_gen_batch_server = hex 0.8.8
-dep_aten = hex 0.5.8
+dep_aten = hex 0.6.0
 dep_seshat = hex 0.6.0
 DEPS = aten gen_batch_server seshat
 

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1486,7 +1486,7 @@ follower_leader_change(Old, #state{pending_commands = Pending,
             LeaderNode = ra_lib:ra_server_id_node(NewLeader),
             ok = aten_register(LeaderNode),
             OldLeaderNode = ra_lib:ra_server_id_node(OldLeader),
-            ok = aten:unregister(OldLeaderNode),
+            _ = aten:unregister(OldLeaderNode),
             ok = record_leader_change(NewLeader, New),
             % leader has either changed or just been set
             ?INFO("~ts: detected a new leader ~w in term ~b",
@@ -1502,7 +1502,12 @@ aten_register(Node) ->
     case node() of
         Node -> ok;
         _ ->
-            aten:register(Node)
+            case aten:register(Node) of
+                ignore ->
+                    ok;
+                Res ->
+                    Res
+            end
     end.
 
 swap_monitor(MRef, L) ->


### PR DESCRIPTION
This includes:

* use of monotonic time instead of system time which should result in more accurate time keeping by the aten sink.
* fixed a case of double down notification when a node was terminated
