### PR TITLE
Fixes to ra_leaderboard module

### DIFF
--- a/src/ra_server_sup_sup.erl
+++ b/src/ra_server_sup_sup.erl
@@ -130,12 +130,12 @@ prepare_server_stop_rpc(System, RaName) ->
             {ok, Parent, SrvSup}
     end.
 
--spec delete_server(atom(), NodeId :: ra_server_id()) ->
+-spec delete_server(atom(), ServerId :: ra_server_id()) ->
     ok | {error, term()} | {badrpc, term()}.
-delete_server(System, NodeId) when is_atom(System) ->
-    Node = ra_lib:ra_server_id_node(NodeId),
-    Name = ra_lib:ra_server_id_to_local_name(NodeId),
-    case stop_server(System, NodeId) of
+delete_server(System, ServerId) when is_atom(System) ->
+    Node = ra_lib:ra_server_id_node(ServerId),
+    Name = ra_lib:ra_server_id_to_local_name(ServerId),
+    case stop_server(System, ServerId) of
         ok ->
             rpc:call(Node, ?MODULE, delete_server_rpc, [System, Name]);
         {error, _} = Err -> Err
@@ -151,6 +151,7 @@ delete_server_rpc(System, RaName) ->
             ?INFO("Deleting server ~w and its data directory.~n",
                   [RaName]),
             %% TODO: better handle and report errors
+            %% UId could be `undefined' here
             UId = ra_directory:uid_of(Names, RaName),
             Pid = ra_directory:where_is(Names, RaName),
             ra_log_meta:delete(Meta, UId),

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -876,8 +876,8 @@ append_entries_reply_success_promotes_nonvoter(_Config) ->
                            entries = [{4, 5, {'$ra_cluster_change', _,
                                               #{N2 := #{voter_status := #{membership := voter,
                                                                           uid := <<"uid">>}}},
-                                              _}}]}}
-     ]} = ra_server:handle_leader(RaJoin, State2),
+                                              _}}]}} |
+      _]} = ra_server:handle_leader(RaJoin, State2),
 
     Ack2 = #append_entries_reply{term = 5, success = true,
                                      next_index = 5,


### PR DESCRIPTION
Ensure that the members are updated when the membership
is modifiied.

Always delete leaderboard record in ra server terminate callback
to favour accuracy of leadership information over availability.

The idea is that when a record is not found in the leaderboard
the caller falls back to some other, potentially slower, means
of leader discovery.