### PR TITLE
Checkpoints

### DIFF
--- a/docs/internals/STATE_MACHINE_TUTORIAL.md
+++ b/docs/internals/STATE_MACHINE_TUTORIAL.md
@@ -218,3 +218,11 @@ or similar.
 To (potentially) trigger a snapshot return the `{release_cursor, RaftIndex, MachineState}`
 effect. This is why the raft index is included in the `apply/3` function. Ra will
 only create a snapshot if doing so will result in log segments being deleted.
+
+For machines that must keep log segments on disk for some time, the
+`{checkpoint, RaftIndex, MachineState}` effect can be used. This creates a
+snapshot-like view of the machine state on disk but doesn't trigger log
+truncation. Checkpoints can later be promoted to snapshots and trigger log
+truncation by emitting a `{release_cursor, RaftIndex}` effect. The most
+recent checkpoint with an index smaller than or equal to `RaftIndex` will be
+promoted.

--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -254,6 +254,10 @@
          {snapshot_bytes_written, ?C_RA_LOG_SNAPSHOT_BYTES_WRITTEN, counter,
           "Number of snapshot bytes written (not installed)"},
          {open_segments, ?C_RA_LOG_OPEN_SEGMENTS, gauge, "Number of open segments"},
+         {checkpoints_written, ?C_RA_LOG_CHECKPOINTS_WRITTEN, counter,
+          "Total number of checkpoints written"},
+         {checkpoint_bytes_written, ?C_RA_LOG_CHECKPOINT_BYTES_WRITTEN, counter,
+          "Number of checkpoint bytes written"},
          {reserved_1, ?C_RA_LOG_RESERVED, counter, "Reserved counter"}
          ]).
 -define(C_RA_LOG_WRITE_OPS, 1).
@@ -268,7 +272,9 @@
 -define(C_RA_LOG_SNAPSHOTS_INSTALLED, 10).
 -define(C_RA_LOG_SNAPSHOT_BYTES_WRITTEN, 11).
 -define(C_RA_LOG_OPEN_SEGMENTS, 12).
--define(C_RA_LOG_RESERVED, 13).
+-define(C_RA_LOG_CHECKPOINTS_WRITTEN, 13).
+-define(C_RA_LOG_CHECKPOINT_BYTES_WRITTEN, 14).
+-define(C_RA_LOG_RESERVED, 15).
 
 -define(C_RA_SRV_AER_RECEIVED_FOLLOWER, ?C_RA_LOG_RESERVED + 1).
 -define(C_RA_SRV_AER_REPLIES_SUCCESS, ?C_RA_LOG_RESERVED + 2).
@@ -290,7 +296,8 @@
 -define(C_RA_SRV_TERM_AND_VOTED_FOR_UPDATES, ?C_RA_LOG_RESERVED + 18).
 -define(C_RA_SRV_LOCAL_QUERIES, ?C_RA_LOG_RESERVED + 19).
 -define(C_RA_SRV_INVALID_REPLY_MODE_COMMANDS, ?C_RA_LOG_RESERVED + 20).
--define(C_RA_SRV_RESERVED, ?C_RA_LOG_RESERVED + 21).
+-define(C_RA_SRV_CHECKPOINTS, ?C_RA_LOG_RESERVED + 21).
+-define(C_RA_SRV_RESERVED, ?C_RA_LOG_RESERVED + 22).
 
 
 -define(RA_SRV_COUNTER_FIELDS,
@@ -335,6 +342,8 @@
           "Total number of local queries"},
          {invalid_reply_mode_commands, ?C_RA_SRV_INVALID_REPLY_MODE_COMMANDS, counter,
           "Total number of commands received with an invalid reply-mode"},
+         {checkpoints, ?C_RA_SRV_CHECKPOINTS, counter,
+          "The number of checkpoint effects executed"},
          {reserved_2, ?C_RA_SRV_RESERVED, counter, "Reserved counter"}
          ]).
 
@@ -345,6 +354,7 @@
 -define(C_RA_SVR_METRIC_LAST_WRITTEN_INDEX, ?C_RA_SRV_RESERVED + 5).
 -define(C_RA_SVR_METRIC_COMMIT_LATENCY, ?C_RA_SRV_RESERVED + 6).
 -define(C_RA_SVR_METRIC_TERM, ?C_RA_SRV_RESERVED + 7).
+-define(C_RA_SVR_METRIC_CHECKPOINT_INDEX, ?C_RA_SRV_RESERVED + 8).
 
 -define(RA_SRV_METRICS_COUNTER_FIELDS,
         [
@@ -360,7 +370,9 @@
           "The last fully written and fsynced index of the log."},
          {commit_latency, ?C_RA_SVR_METRIC_COMMIT_LATENCY, gauge,
           "Approximate time taken from an entry being written to the log until it is committed."},
-         {term, ?C_RA_SVR_METRIC_TERM, counter, "The current term."}
+         {term, ?C_RA_SVR_METRIC_TERM, counter, "The current term."},
+         {checkpoint_index, ?C_RA_SVR_METRIC_CHECKPOINT_INDEX, counter,
+          "The current checkpoint index."}
         ]).
 
 -define(RA_COUNTER_FIELDS,

--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -230,6 +230,8 @@
 
 -define(DEFAULT_SNAPSHOT_MODULE, ra_log_snapshot).
 
+-define(DEFAULT_MAX_CHECKPOINTS, 10).
+
 -define(RA_LOG_COUNTER_FIELDS,
         [{write_ops, ?C_RA_LOG_WRITE_OPS, counter,
           "Total number of write ops"},

--- a/src/ra_lib.erl
+++ b/src/ra_lib.erl
@@ -41,6 +41,7 @@
          write_file/2,
          lists_chunk/2,
          lists_detect_sort/1,
+         lists_shuffle/1,
          is_dir/1,
          is_file/1,
          ensure_dir/1,
@@ -381,6 +382,12 @@ do_ascending(A, [B | Rem])
     do_ascending(B, Rem);
 do_ascending(_A, _) ->
     unsorted.
+
+%% Reorder a list randomly.
+-spec lists_shuffle(list()) -> list().
+lists_shuffle(List0) ->
+    List1 = [{rand:uniform(), Elem} || Elem <- List0],
+    [Elem || {_, Elem} <- lists:keysort(1, List1)].
 
 is_dir(Dir) ->
     case prim_file:read_file_info(Dir) of

--- a/src/ra_lib.erl
+++ b/src/ra_lib.erl
@@ -39,6 +39,8 @@
          retry/2,
          retry/3,
          write_file/2,
+         write_file/3,
+         sync_file/1,
          lists_chunk/2,
          lists_detect_sort/1,
          lists_shuffle/1,
@@ -49,6 +51,10 @@
          maps_foreach/2,
          maps_merge_with/3
         ]).
+
+-type file_err() :: file:posix() | badarg | terminated | system_limit.
+
+-export_type([file_err/0]).
 
 -include_lib("kernel/include/file.hrl").
 
@@ -314,24 +320,50 @@ retry(Func, Attempt, Sleep) ->
             retry(Func, Attempt - 1)
     end.
 
-
+-spec write_file(file:name_all(), iodata()) ->
+    ok | file_err().
 write_file(Name, IOData) ->
+    write_file(Name, IOData, true).
+
+-spec write_file(file:name_all(), iodata(), Sync :: boolean()) ->
+    ok | file_err().
+write_file(Name, IOData, Sync) ->
     case file:open(Name, [binary, write, raw]) of
         {ok, Fd} ->
             case file:write(Fd, IOData) of
                 ok ->
-                    case file:sync(Fd) of
-                        ok ->
-                            file:close(Fd);
-                        Err ->
-                            _ = file:close(Fd),
-                            Err
+                    case Sync of
+                        true ->
+                            sync_and_close_fd(Fd);
+                        false ->
+                            ok
                     end;
                 Err ->
                     _ = file:close(Fd),
                     Err
             end;
         Err ->
+            Err
+    end.
+
+-spec sync_file(file:name_all()) ->
+    ok | file_err().
+sync_file(Name) ->
+    case file:open(Name, [binary, write, raw]) of
+        {ok, Fd} ->
+            sync_and_close_fd(Fd);
+        Err ->
+            Err
+    end.
+
+-spec sync_and_close_fd(file:fd()) ->
+    ok | file_err().
+sync_and_close_fd(Fd) ->
+    case file:sync(Fd) of
+        ok ->
+            file:close(Fd);
+        Err ->
+            _ = file:close(Fd),
             Err
     end.
 

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -31,6 +31,7 @@
          recover_snapshot/1,
          snapshot_index_term/1,
          update_release_cursor/5,
+         checkpoint/5,
          needs_cache_flush/1,
 
          can_write/1,
@@ -624,6 +625,14 @@ update_release_cursor(Idx, Cluster, MacVersion, MacState,
             % if a snapshot is in progress don't even evaluate
             {State, []}
     end.
+
+-spec checkpoint(Idx :: ra_index(), Cluster :: ra_cluster(),
+                 MacVersion :: ra_machine:version(),
+                 MacState :: term(), State :: state()) ->
+    {state(), effects()}.
+checkpoint(Idx, Cluster, MacVersion, MacState,
+           #?MODULE{checkpoint_state = CheckpointState} = State) ->
+    todo.
 
 -spec flush_cache(state()) -> state().
 flush_cache(#?MODULE{cache = Cache} = State) ->

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -796,6 +796,11 @@ overview(#?MODULE{last_index = LastIndex,
                             undefined -> undefined;
                             {I, _} -> I
                         end,
+      latest_checkpoint_index =>
+      case ra_snapshot:latest_checkpoint(SnapshotState) of
+          undefined -> undefined;
+          {I, _} -> I
+      end,
       cache_size => ra_log_cache:size(Cache)
      }.
 

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -133,7 +133,9 @@ pre_init(#{uid := UId,
     Dir = server_data_dir(DataDir, UId),
     SnapModule = maps:get(snapshot_module, Conf, ?DEFAULT_SNAPSHOT_MODULE),
     SnapshotsDir = filename:join(Dir, "snapshots"),
-    _ = ra_snapshot:init(UId, SnapModule, SnapshotsDir, undefined),
+    CheckpointsDir = filename:join(Dir, "checkpoints"),
+    _ = ra_snapshot:init(UId, SnapModule, SnapshotsDir,
+                         CheckpointsDir, undefined),
     ok.
 
 -spec init(ra_log_init_args()) -> state().
@@ -150,14 +152,17 @@ init(#{uid := UId,
     ResendWindow = maps:get(resend_window, Conf, ?DEFAULT_RESEND_WINDOW_SEC),
     SnapInterval = maps:get(snapshot_interval, Conf, ?SNAPSHOT_INTERVAL),
     SnapshotsDir = filename:join(Dir, "snapshots"),
+    CheckpointsDir = filename:join(Dir, "checkpoints"),
     Counter = maps:get(counter, Conf, undefined),
 
     %% ensure directories are there
     ok = ra_lib:make_dir(Dir),
     ok = ra_lib:make_dir(SnapshotsDir),
+    ok = ra_lib:make_dir(CheckpointsDir),
     % initialise metrics for this server
     true = ets:insert(ra_log_metrics, {UId, 0, 0, 0, 0}),
-    SnapshotState = ra_snapshot:init(UId, SnapModule, SnapshotsDir, Counter),
+    SnapshotState = ra_snapshot:init(UId, SnapModule, SnapshotsDir,
+                                     CheckpointsDir, Counter),
     {SnapIdx, SnapTerm} = case ra_snapshot:current(SnapshotState) of
                               undefined -> {-1, -1};
                               Curr -> Curr

--- a/src/ra_log_snapshot.erl
+++ b/src/ra_log_snapshot.erl
@@ -11,7 +11,8 @@
 
 -export([
          prepare/2,
-         write/3,
+         write/4,
+         sync/1,
          begin_accept/2,
          accept_chunk/2,
          complete_accept/2,
@@ -42,9 +43,9 @@ prepare(_Index, State) -> State.
 %% Snapshot Data (binary)
 %% @end
 
--spec write(file:filename(), meta(), term()) ->
+-spec write(file:filename(), meta(), term(), Sync :: boolean()) ->
     ok | {error, file_err()}.
-write(Dir, Meta, MacState) ->
+write(Dir, Meta, MacState, Sync) ->
     %% no compression on meta data to make sure reading it is as fast
     %% as possible
     MetaBin = term_to_binary(Meta),
@@ -55,7 +56,13 @@ write(Dir, Meta, MacState) ->
     ra_lib:write_file(File, [<<?MAGIC,
                                ?VERSION:8/unsigned,
                                Checksum:32/integer>>,
-                             Data]).
+                             Data], Sync).
+
+-spec sync(file:filename()) ->
+    ok | {error, file_err()}.
+sync(Dir) ->
+    File = filename(Dir),
+    ra_lib:sync_file(File).
 
 begin_accept(SnapDir, Meta) ->
     File = filename(SnapDir),

--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -135,6 +135,7 @@
     {log, [ra_index()], fun(([user_command()]) -> effects())} |
     {log, [ra_index()], fun(([user_command()]) -> effects()), {local, node()}} |
     {release_cursor, ra_index(), state()} |
+    {release_cursor, ra_index()} |
     {checkpoint, ra_index(), state()} |
     {aux, term()} |
     garbage_collection.

--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -146,8 +146,13 @@
 %% forcing a GC run.
 %%
 %% Although both leaders and followers will process the same commands, effects
-%% are typically only applied on the leader. The only exception to this is
-%% the `release_cursor' and `garbage_collect' effects. The former is realised on all
+%% are typically only applied on the leader. The only exceptions to this are:
+%% <ul>
+%% <li>`release_cursor'</li>
+%% <li>`checkpoint'</li>
+%% <li>`garbage_collect'</li>
+%% </ul>
+%% The former two are realised on all
 %% nodes as it is a part of the Ra implementation log truncation mechanism.
 %% The `garbage_collect' effects that is used to explicitly triggering a GC run
 %% in the Ra servers' process.

--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -135,6 +135,7 @@
     {log, [ra_index()], fun(([user_command()]) -> effects())} |
     {log, [ra_index()], fun(([user_command()]) -> effects()), {local, node()}} |
     {release_cursor, ra_index(), state()} |
+    {checkpoint, ra_index(), state()} |
     {aux, term()} |
     garbage_collection.
 

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -46,6 +46,7 @@
          % TODO: hide behind a handle_leader
          make_rpcs/1,
          update_release_cursor/3,
+         checkpoint/3,
          persist_last_applied/1,
          update_peer/3,
          register_external_log_reader/2,
@@ -1643,6 +1644,8 @@ evaluate_commit_index_follower(State, Effects) ->
 filter_follower_effects(Effects) ->
     lists:foldr(fun ({release_cursor, _, _} = C, Acc) ->
                         [C | Acc];
+                    ({checkpoint, _, _} = C, Acc) ->
+                        [C | Acc];
                     ({record_leader_msg, _} = C, Acc) ->
                         [C | Acc];
                     ({aux, _} = C, Acc) ->
@@ -1844,6 +1847,15 @@ update_release_cursor(Index, MacState,
     {Log, Effects} = ra_log:update_release_cursor(Index, Cluster,
                                                   MacVersion,
                                                   MacState, Log0),
+    {State#{log => Log}, Effects}.
+
+-spec checkpoint(ra_index(), term(), ra_server_state()) ->
+      {ra_server_state(), effects()}.
+checkpoint(Index, MacState,
+           State = #{log := Log0, cluster := Cluster}) ->
+    MacVersion = index_machine_version(Index, State),
+    {Log, Effects} = ra_log:checkpoint(Index, Cluster,
+                                       MacVersion, MacState, Log0),
     {State#{log => Log}, Effects}.
 
 % Persist last_applied - as there is an inherent race we cannot

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1329,6 +1329,12 @@ handle_effect(RaftState, {release_cursor, Index, MacState}, EvtType,
                                                              ServerState0),
     State1 = State0#state{server_state = ServerState},
     handle_effects(RaftState, Effects, EvtType, State1, Actions0);
+handle_effect(RaftState, {release_cursor, Index}, EvtType,
+              #state{server_state = ServerState0} = State0, Actions0) ->
+    incr_counter(State0#state.conf, ?C_RA_SRV_RELEASE_CURSORS, 1),
+    {ServerState, Effects} = ra_server:promote_checkpoint(Index, ServerState0),
+    State1 = State0#state{server_state = ServerState},
+    handle_effects(RaftState, Effects, EvtType, State1, Actions0);
 handle_effect(RaftState, {checkpoint, Index, MacState}, EvtType,
               #state{server_state = ServerState0} = State0, Actions0) ->
     incr_counter(State0#state.conf, ?C_RA_SRV_CHECKPOINTS, 1),

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1329,6 +1329,13 @@ handle_effect(RaftState, {release_cursor, Index, MacState}, EvtType,
                                                              ServerState0),
     State1 = State0#state{server_state = ServerState},
     handle_effects(RaftState, Effects, EvtType, State1, Actions0);
+handle_effect(RaftState, {checkpoint, Index, MacState}, EvtType,
+              #state{server_state = ServerState0} = State0, Actions0) ->
+    incr_counter(State0#state.conf, ?C_RA_SRV_CHECKPOINTS, 1),
+    {ServerState, Effects} = ra_server:checkpoint(Index, MacState,
+                                                  ServerState0),
+    State1 = State0#state{server_state = ServerState},
+    handle_effects(RaftState, Effects, EvtType, State1, Actions0);
 handle_effect(_, garbage_collection, _EvtType, State, Actions) ->
     true = erlang:garbage_collect(),
     incr_counter(State#state.conf, ?C_RA_SRV_GCS, 1),

--- a/src/ra_snapshot.erl
+++ b/src/ra_snapshot.erl
@@ -38,7 +38,9 @@
          context/2,
 
          handle_down/3,
-         current_snapshot_dir/1
+         current_snapshot_dir/1,
+
+         latest_checkpoint/1
         ]).
 
 -type effect() :: {monitor, process, snapshot_writer, pid()}.
@@ -256,6 +258,10 @@ init_ets() ->
 
 -spec current(state()) -> option(ra_idxterm()).
 current(#?MODULE{current = Current}) -> Current.
+
+-spec latest_checkpoint(state()) -> option(checkpoint()).
+latest_checkpoint(#?MODULE{checkpoints = [Current | _]}) -> Current;
+latest_checkpoint(#?MODULE{checkpoints = _}) -> undefined.
 
 -spec pending(state()) -> option({pid(), ra_idxterm(), kind()}).
 pending(#?MODULE{pending = Pending}) ->

--- a/test/ra_checkpoint_SUITE.erl
+++ b/test/ra_checkpoint_SUITE.erl
@@ -11,6 +11,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include("src/ra.hrl").
 
 %%%===================================================================
 %%% Common Test callbacks
@@ -61,7 +62,8 @@ init_per_testcase(TestCase, Config) ->
     ok = ra_lib:make_dir(CheckpointDir),
     [{uid, ra_lib:to_binary(TestCase)},
      {snap_dir, SnapDir},
-     {checkpoint_dir, CheckpointDir} | Config].
+     {checkpoint_dir, CheckpointDir},
+     {max_checkpoints, ?DEFAULT_MAX_CHECKPOINTS} | Config].
 
 end_per_testcase(_TestCase, _Config) ->
     ok.
@@ -338,7 +340,7 @@ init_state(Config) ->
                      ra_log_snapshot,
                      ?config(snap_dir, Config),
                      ?config(checkpoint_dir, Config),
-                     undefined).
+                     undefined, ?config(max_checkpoints, Config)).
 
 meta(Idx, Term, Cluster) ->
     #{index => Idx,

--- a/test/ra_checkpoint_SUITE.erl
+++ b/test/ra_checkpoint_SUITE.erl
@@ -1,0 +1,355 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2024 Broadcom. All Rights Reserved. The term Broadcom refers to Broadcom Inc. and/or its subsidiaries.
+%%
+-module(ra_checkpoint_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [
+     {group, tests}
+    ].
+
+
+all_tests() ->
+    [
+     init_empty,
+     take_checkpoint,
+     take_checkpoint_crash,
+     recover_from_checkpoint_only,
+     recover_from_checkpoint_and_snapshot,
+     newer_snapshot_deletes_older_checkpoints,
+     init_recover_corrupt,
+     init_recover_multi_corrupt
+    ].
+
+groups() ->
+    [
+     {tests, [], all_tests()}
+    ].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(TestCase, Config) ->
+    ok = ra_snapshot:init_ets(),
+    SnapDir = filename:join([?config(priv_dir, Config),
+                             TestCase, "snapshots"]),
+    CheckpointDir = filename:join([?config(priv_dir, Config),
+                                   TestCase, "checkpoints"]),
+    ok = ra_lib:make_dir(SnapDir),
+    ok = ra_lib:make_dir(CheckpointDir),
+    [{uid, ra_lib:to_binary(TestCase)},
+     {snap_dir, SnapDir},
+     {checkpoint_dir, CheckpointDir} | Config].
+
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+init_empty(Config) ->
+    State = init_state(Config),
+    undefined = ra_snapshot:latest_checkpoint(State),
+
+    ok.
+
+take_checkpoint(Config) ->
+    State0 = init_state(Config),
+
+    Meta = meta(55, 2, [node()]),
+    MacRef = ?FUNCTION_NAME,
+    {State1, [{monitor, process, snapshot_writer, Pid}]} =
+         ra_snapshot:begin_snapshot(Meta, MacRef, checkpoint, State0),
+    undefined = ra_snapshot:latest_checkpoint(State1),
+    {Pid, {55, 2}, checkpoint} = ra_snapshot:pending(State1),
+    receive
+        {ra_log_event, {snapshot_written, {55, 2} = IdxTerm, checkpoint}} ->
+            State = ra_snapshot:complete_snapshot(IdxTerm, checkpoint, State1),
+            undefined = ra_snapshot:pending(State),
+            {55, 2} = ra_snapshot:latest_checkpoint(State),
+            ok
+    after 1000 ->
+            error(snapshot_event_timeout)
+    end,
+
+    ok.
+
+take_checkpoint_crash(Config) ->
+    State0 = init_state(Config),
+    Meta = meta(55, 2, [node()]),
+    MacRef = ?FUNCTION_NAME,
+    {State1, [{monitor, process, snapshot_writer, Pid}]} =
+         ra_snapshot:begin_snapshot(Meta, MacRef, checkpoint, State0),
+    undefined = ra_snapshot:latest_checkpoint(State1),
+    {Pid, {55, 2}, checkpoint} = ra_snapshot:pending(State1),
+    receive
+        {ra_log_event, _} ->
+            %% Just pretend the snapshot event didn't happen
+            %% and the process instead crashed.
+            ok
+    after 10 -> ok
+    end,
+
+    State = ra_snapshot:handle_down(Pid, it_crashed_dawg, State1),
+    %% If the checkpoint process crashed we just have to consider the
+    %% checkpoint as faulty and clear it up.
+    undefined = ra_snapshot:pending(State),
+    undefined = ra_snapshot:latest_checkpoint(State),
+
+    %% The written checkpoint should be removed.
+    ?assertEqual([], list_checkpoint_dirs(Config)),
+
+    ok.
+
+recover_from_checkpoint_only(Config) ->
+    State0 = init_state(Config),
+    {error, no_current_snapshot} = ra_snapshot:recover(State0),
+
+    Meta = meta(55, 2, [node()]),
+    {State1, [{monitor, process, snapshot_writer, _}]} =
+        ra_snapshot:begin_snapshot(Meta, ?FUNCTION_NAME, checkpoint, State0),
+    receive
+        {ra_log_event, {snapshot_written, IdxTerm, checkpoint}} ->
+            _ = ra_snapshot:complete_snapshot(IdxTerm, checkpoint, State1),
+            ok
+    after 1000 ->
+              error(snapshot_event_timeout)
+    end,
+
+    %% Open a new snapshot state to simulate a restart.
+    Recover = init_state(Config),
+    undefined = ra_snapshot:pending(Recover),
+    {55, 2} = ra_snapshot:latest_checkpoint(Recover),
+    undefined = ra_snapshot:current(Recover),
+
+    {ok, Meta, ?FUNCTION_NAME} = ra_snapshot:recover(Recover),
+
+    ok.
+
+recover_from_checkpoint_and_snapshot(Config) ->
+    State0 = init_state(Config),
+    {error, no_current_snapshot} = ra_snapshot:recover(State0),
+
+    %% Snapshot.
+    SnapMeta = meta(55, 2, [node()]),
+    {State1, [{monitor, process, snapshot_writer, _}]} =
+         ra_snapshot:begin_snapshot(SnapMeta, ?FUNCTION_NAME, snapshot, State0),
+    State2 = receive
+                 {ra_log_event, {snapshot_written, IdxTerm1, snapshot}} ->
+                       ra_snapshot:complete_snapshot(IdxTerm1, snapshot, State1)
+             after 1000 ->
+                       error(snapshot_event_timeout)
+             end,
+
+    %% Checkpoint at a later index.
+    CPMeta = meta(105, 3, [node()]),
+    {State3, [{monitor, process, snapshot_writer, _}]} =
+         ra_snapshot:begin_snapshot(CPMeta, ?FUNCTION_NAME, checkpoint, State2),
+    receive
+        {ra_log_event, {snapshot_written, IdxTerm2, checkpoint}} ->
+             _ = ra_snapshot:complete_snapshot(IdxTerm2, checkpoint, State3),
+             ok
+    after 1000 ->
+              error(snapshot_event_timeout)
+    end,
+
+    %% Open a new snapshot state to simulate a restart.
+    Recover = init_state(Config),
+    undefined = ra_snapshot:pending(Recover),
+    %% Both the checkpoint and the snapshot exist.
+    {105, 3} = ra_snapshot:latest_checkpoint(Recover),
+    {55, 2} = ra_snapshot:current(Recover),
+    %% The checkpoint is used for recovery since it is newer.
+    {ok, CPMeta, ?FUNCTION_NAME} = ra_snapshot:recover(Recover),
+
+    ok.
+
+newer_snapshot_deletes_older_checkpoints(Config) ->
+    State0 = init_state(Config),
+    {error, no_current_snapshot} = ra_snapshot:recover(State0),
+
+    %% Checkpoint at 25.
+    CP1Meta = meta(25, 2, [node()]),
+    {State1, [{monitor, process, snapshot_writer, _}]} =
+         ra_snapshot:begin_snapshot(CP1Meta, ?FUNCTION_NAME, checkpoint, State0),
+    State2 = receive
+                 {ra_log_event, {snapshot_written, IdxTerm1, checkpoint}} ->
+                       ra_snapshot:complete_snapshot(IdxTerm1, checkpoint, State1)
+             after 1000 ->
+                       error(snapshot_event_timeout)
+             end,
+
+    %% Checkpoint at 35.
+    CP2Meta = meta(35, 3, [node()]),
+    {State3, [{monitor, process, snapshot_writer, _}]} =
+         ra_snapshot:begin_snapshot(CP2Meta, ?FUNCTION_NAME, checkpoint, State2),
+    State4 = receive
+                 {ra_log_event, {snapshot_written, IdxTerm2, checkpoint}} ->
+                       ra_snapshot:complete_snapshot(IdxTerm2, checkpoint, State3)
+             after 1000 ->
+                       error(snapshot_event_timeout)
+             end,
+
+    %% Checkpoint at 55.
+    CP3Meta = meta(55, 5, [node()]),
+    {State5, [{monitor, process, snapshot_writer, _}]} =
+         ra_snapshot:begin_snapshot(CP3Meta, ?FUNCTION_NAME, checkpoint, State4),
+    State6 = receive
+                 {ra_log_event, {snapshot_written, IdxTerm3, checkpoint}} ->
+                       ra_snapshot:complete_snapshot(IdxTerm3, checkpoint, State5)
+             after 1000 ->
+                       error(snapshot_event_timeout)
+             end,
+
+    %% Snapshot at 45.
+    SnapMeta = meta(45, 4, [node()]),
+    {State7, [{monitor, process, snapshot_writer, _}]} =
+         ra_snapshot:begin_snapshot(SnapMeta, ?FUNCTION_NAME, snapshot, State6),
+    State8 = receive
+                 {ra_log_event, {snapshot_written, IdxTerm4, snapshot}} ->
+                      ra_snapshot:complete_snapshot(IdxTerm4, snapshot, State7)
+             after 1000 ->
+                       error(snapshot_event_timeout)
+             end,
+
+    %% The first and second checkpoint are older than the snapshot.
+    {_State, [{35, 3}, {25, 2}]} =
+        ra_snapshot:take_older_checkpoints(45, State8),
+
+    %% Open a new snapshot state to simulate a restart.
+    Recover = init_state(Config),
+    undefined = ra_snapshot:pending(Recover),
+    %% Both the latest checkpoint and the snapshot exist.
+    {55, 5} = ra_snapshot:latest_checkpoint(Recover),
+    {45, 4} = ra_snapshot:current(Recover),
+    %% The latest checkpoint has the highest index so it is used for recovery.
+    {ok, CP3Meta, ?FUNCTION_NAME} = ra_snapshot:recover(Recover),
+
+    %% Initializing the state removes any checkpoints older than the snapshot,
+    %% so there should be one snapshot and one checkpoint only.
+    ?assertMatch([_], list_snap_dirs(Config)),
+    ?assertMatch([_], list_checkpoint_dirs(Config)),
+
+    ok.
+
+init_recover_corrupt(Config) ->
+    State0 = init_state(Config),
+
+    %% Take a checkpoint.
+    Meta = meta(55, 2, [node()]),
+    MacRef = ?FUNCTION_NAME,
+    {State1, _} = ra_snapshot:begin_snapshot(Meta, MacRef, checkpoint, State0),
+    receive
+        {ra_log_event, {snapshot_written, {55, 2} = IdxTerm, checkpoint}} ->
+            _ = ra_snapshot:complete_snapshot(IdxTerm, checkpoint, State1),
+            ok
+    after 1000 ->
+            error(snapshot_event_timeout)
+    end,
+
+    %% Delete the file but leave the directory intact.
+    CorruptDir = filename:join(?config(checkpoint_dir, Config),
+                               ra_lib:zpad_hex(2) ++ "_" ++ ra_lib:zpad_hex(55)),
+    ok = file:delete(filename:join(CorruptDir, "snapshot.dat")),
+
+    Recover = init_state(Config),
+    %% The checkpoint isn't recovered and the directory is cleaned up.
+    undefined = ra_snapshot:pending(Recover),
+    undefined = ra_snapshot:current(Recover),
+    undefined = ra_snapshot:latest_checkpoint(Recover),
+    {error, no_current_snapshot} = ra_snapshot:recover(Recover),
+    false = filelib:is_dir(CorruptDir),
+
+    ok.
+
+init_recover_multi_corrupt(Config) ->
+    State0 = init_state(Config),
+    {error, no_current_snapshot} = ra_snapshot:recover(State0),
+
+    %% Checkpoint at 55.
+    CP1Meta = meta(55, 2, [node()]),
+    {State1, _} =
+         ra_snapshot:begin_snapshot(CP1Meta, ?FUNCTION_NAME, checkpoint, State0),
+    State2 = receive
+                 {ra_log_event, {snapshot_written, IdxTerm1, checkpoint}} ->
+                     ra_snapshot:complete_snapshot(IdxTerm1, checkpoint, State1)
+             after 1000 ->
+                     error(snapshot_event_timeout)
+             end,
+
+    %% Checkpoint at 165.
+    CP2Meta = meta(165, 2, [node()]),
+    {State3, _} =
+         ra_snapshot:begin_snapshot(CP2Meta, ?FUNCTION_NAME, checkpoint, State2),
+    State4 = receive
+                 {ra_log_event, {snapshot_written, IdxTerm2, checkpoint}} ->
+                      ra_snapshot:complete_snapshot(IdxTerm2, checkpoint, State3)
+             after 1000 ->
+                       error(snapshot_event_timeout)
+             end,
+    {165, 2} = ra_snapshot:latest_checkpoint(State4),
+
+    %% Corrupt the latest checkpoint.
+    Corrupt = filename:join(?config(checkpoint_dir, Config),
+                            ra_lib:zpad_hex(2) ++ "_" ++ ra_lib:zpad_hex(165)),
+    ok = file:delete(filename:join(Corrupt, "snapshot.dat")),
+
+    %% Open a new snapshot state to simulate a restart.
+    Recover = init_state(Config),
+    undefined = ra_snapshot:pending(Recover),
+    %% The latest non-corrupt checkpoint is now the latest checkpoint.
+    {55, 2} = ra_snapshot:latest_checkpoint(Recover),
+    %% The corrupt checkpoint is cleaned up.
+    false = filelib:is_dir(Corrupt),
+
+    {ok, CP1Meta, ?FUNCTION_NAME} = ra_snapshot:recover(Recover),
+
+    ok.
+
+%%%===================================================================
+%%% Helper functions
+%%%===================================================================
+
+init_state(Config) ->
+    ra_snapshot:init(?config(uid, Config),
+                     ra_log_snapshot,
+                     ?config(snap_dir, Config),
+                     ?config(checkpoint_dir, Config),
+                     undefined).
+
+meta(Idx, Term, Cluster) ->
+    #{index => Idx,
+      term => Term,
+      cluster => Cluster,
+      machine_version => 1}.
+
+list_checkpoint_dirs(Config) ->
+    CPDir = ?config(checkpoint_dir, Config),
+    filelib:wildcard(filename:join(CPDir, "*")).
+
+list_snap_dirs(Config) ->
+    SnapDir = ?config(snap_dir, Config),
+    filelib:wildcard(filename:join(SnapDir, "*")).

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -1370,7 +1370,7 @@ create_snapshot_chunk(Config, #{index := Idx} = Meta, Context) ->
     ok = ra_lib:make_dir(OthDir),
     ok = ra_lib:make_dir(CPDir),
     Sn0 = ra_snapshot:init(<<"someotheruid_adsfasdf">>, ra_log_snapshot,
-                           OthDir, CPDir, undefined),
+                           OthDir, CPDir, undefined, ?DEFAULT_MAX_CHECKPOINTS),
     MacRef = <<"9">>,
     {Sn1, _} = ra_snapshot:begin_snapshot(Meta, MacRef, snapshot, Sn0),
     Sn2 =

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -311,7 +311,8 @@ sparse_read_out_of_range_2(Config) ->
     {Log2, _} = ra_log:update_release_cursor(SnapIdx, #{}, 2,
                                              <<"snap@10">>, Log1),
     {Log3, _} = receive
-                    {ra_log_event, {snapshot_written, {10, 2}} = Evt} ->
+                    {ra_log_event, {snapshot_written, {10, 2},
+                                    snapshot} = Evt} ->
                         ra_log:handle_event(Evt, Log2)
                 after 5000 ->
                           flush(),
@@ -397,7 +398,8 @@ written_event_after_snapshot(Config) ->
     {Log2, _} = ra_log:update_release_cursor(2, #{}, 1,
                                              <<"one+two">>, Log1b),
     {Log3, _} = receive
-                    {ra_log_event, {snapshot_written, {2, 1}} = Evt} ->
+                    {ra_log_event, {snapshot_written, {2, 1},
+                                    snapshot} = Evt} ->
                         ra_log:handle_event(Evt, Log2)
                 after 500 ->
                           exit(snapshot_written_timeout)
@@ -412,7 +414,7 @@ written_event_after_snapshot(Config) ->
                                              <<"one+two+three+four">>,
                                              Log6b),
     _ = receive
-            {ra_log_event, {snapshot_written, {4, 1}} = E} ->
+            {ra_log_event, {snapshot_written, {4, 1}, snapshot} = E} ->
                 ra_log:handle_event(E, Log7)
         after 500 ->
                   exit(snapshot_written_timeout)
@@ -699,7 +701,8 @@ snapshot_written_after_installation(Config) ->
     {Log2, _} = ra_log:update_release_cursor(5, #{}, 1,
                                              <<"one-five">>, Log1),
     DelayedSnapWritten = receive
-                             {ra_log_event, {snapshot_written, {5, 1}} = Evt} ->
+                             {ra_log_event, {snapshot_written, {5, 1},
+                                             snapshot} = Evt} ->
                                  Evt
                          after 1000 ->
                                    flush(),
@@ -1369,10 +1372,10 @@ create_snapshot_chunk(Config, #{index := Idx} = Meta, Context) ->
     Sn0 = ra_snapshot:init(<<"someotheruid_adsfasdf">>, ra_log_snapshot,
                            OthDir, CPDir, undefined),
     MacRef = <<"9">>,
-    {Sn1, _} = ra_snapshot:begin_snapshot(Meta, MacRef, Sn0),
+    {Sn1, _} = ra_snapshot:begin_snapshot(Meta, MacRef, snapshot, Sn0),
     Sn2 =
         receive
-            {ra_log_event, {snapshot_written, {Idx, 2} = IdxTerm}} ->
+            {ra_log_event, {snapshot_written, {Idx, 2} = IdxTerm, snapshot}} ->
                 ra_snapshot:complete_snapshot(IdxTerm, Sn1)
         after 1000 ->
                   exit(snapshot_timeout)

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -1376,7 +1376,7 @@ create_snapshot_chunk(Config, #{index := Idx} = Meta, Context) ->
     Sn2 =
         receive
             {ra_log_event, {snapshot_written, {Idx, 2} = IdxTerm, snapshot}} ->
-                ra_snapshot:complete_snapshot(IdxTerm, Sn1)
+                ra_snapshot:complete_snapshot(IdxTerm, snapshot, Sn1)
         after 1000 ->
                   exit(snapshot_timeout)
         end,

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -1363,9 +1363,11 @@ meta(Idx, Term, Cluster) ->
 
 create_snapshot_chunk(Config, #{index := Idx} = Meta, Context) ->
     OthDir = filename:join(?config(priv_dir, Config), "snapshot_installation"),
+    CPDir = filename:join(?config(priv_dir, Config), "checkpoints"),
     ok = ra_lib:make_dir(OthDir),
+    ok = ra_lib:make_dir(CPDir),
     Sn0 = ra_snapshot:init(<<"someotheruid_adsfasdf">>, ra_log_snapshot,
-                           OthDir),
+                           OthDir, CPDir, undefined),
     MacRef = <<"9">>,
     {Sn1, _} = ra_snapshot:begin_snapshot(Meta, MacRef, Sn0),
     Sn2 =

--- a/test/ra_log_snapshot_SUITE.erl
+++ b/test/ra_log_snapshot_SUITE.erl
@@ -73,7 +73,7 @@ roundtrip(Config) ->
     Dir = ?config(dir, Config),
     SnapshotMeta = meta(33, 94, [{banana, node@jungle}, {banana, node@savanna}]),
     SnapshotRef = my_state,
-    ok = ra_log_snapshot:write(Dir, SnapshotMeta, SnapshotRef),
+    ok = ra_log_snapshot:write(Dir, SnapshotMeta, SnapshotRef, true),
     Context = #{can_accept_full_file => true},
     ?assertEqual({SnapshotMeta, SnapshotRef}, read(Dir, Context)),
     ok.
@@ -82,7 +82,7 @@ roundtrip_compat(Config) ->
     Dir = ?config(dir, Config),
     SnapshotMeta = meta(33, 94, [{banana, node@jungle}, {banana, node@savanna}]),
     SnapshotRef = my_state,
-    ok = ra_log_snapshot:write(Dir, SnapshotMeta, SnapshotRef),
+    ok = ra_log_snapshot:write(Dir, SnapshotMeta, SnapshotRef, true),
     ?assertEqual({SnapshotMeta, SnapshotRef}, read(Dir)),
     ok.
 
@@ -107,7 +107,7 @@ test_accept(Config, Name, DataSize, FullFile, ChunkSize) ->
     ct:pal("test_accept ~w ~b ~w ~b", [Name, DataSize, FullFile, ChunkSize]),
     SnapshotMeta = meta(33, 94, [{banana, node@jungle}, {banana, node@savanna}]),
     SnapshotRef = crypto:strong_rand_bytes(DataSize),
-    ok = ra_log_snapshot:write(Dir, SnapshotMeta, SnapshotRef),
+    ok = ra_log_snapshot:write(Dir, SnapshotMeta, SnapshotRef, true),
     Context = #{can_accept_full_file => FullFile},
     {ok, Meta, St} =  ra_log_snapshot:begin_read(Dir, Context),
     %% how to ensure
@@ -180,7 +180,7 @@ read_meta_data(Config) ->
     Dir = ?config(dir, Config),
     SnapshotMeta = meta(33, 94, [{banana, node@jungle}, {banana, node@savanna}]),
     SnapshotRef = my_state,
-    ok = ra_log_snapshot:write(Dir, SnapshotMeta, SnapshotRef),
+    ok = ra_log_snapshot:write(Dir, SnapshotMeta, SnapshotRef, true),
     {ok, SnapshotMeta} = ra_log_snapshot:read_meta(Dir),
     ok.
 
@@ -188,7 +188,7 @@ recover_same_as_read(Config) ->
     Dir = ?config(dir, Config),
     SnapshotMeta = meta(33, 94, [{banana, node@jungle}, {banana, node@savanna}]),
     SnapshotData = my_state,
-    ok = ra_log_snapshot:write(Dir, SnapshotMeta, SnapshotData),
+    ok = ra_log_snapshot:write(Dir, SnapshotMeta, SnapshotData, true),
     {ok, SnapshotMeta, SnapshotData} = ra_log_snapshot:recover(Dir),
     ok.
 

--- a/test/ra_snapshot_SUITE.erl
+++ b/test/ra_snapshot_SUITE.erl
@@ -14,6 +14,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include("src/ra.hrl").
 
 %%%===================================================================
 %%% Common Test callbacks
@@ -68,7 +69,8 @@ init_per_testcase(TestCase, Config) ->
     ok = ra_lib:make_dir(CheckpointDir),
     [{uid, ra_lib:to_binary(TestCase)},
      {snap_dir, SnapDir},
-     {checkpoint_dir, CheckpointDir} | Config].
+     {checkpoint_dir, CheckpointDir},
+     {max_checkpoints, ?DEFAULT_MAX_CHECKPOINTS} | Config].
 
 end_per_testcase(_TestCase, _Config) ->
     ok.
@@ -472,7 +474,7 @@ init_state(Config) ->
     ra_snapshot:init(?config(uid, Config), ra_log_snapshot,
                      ?config(snap_dir, Config),
                      ?config(checkpoint_dir, Config),
-                     undefined).
+                     undefined, ?config(max_checkpoints, Config)).
 
 meta(Idx, Term, Cluster) ->
     #{index => Idx,

--- a/test/ra_snapshot_SUITE.erl
+++ b/test/ra_snapshot_SUITE.erl
@@ -104,7 +104,7 @@ take_snapshot(Config) ->
     {Pid, {55, 2}, snapshot} = ra_snapshot:pending(State1),
     receive
         {ra_log_event, {snapshot_written, {55, 2} = IdxTerm, snapshot}} ->
-            State = ra_snapshot:complete_snapshot(IdxTerm, State1),
+            State = ra_snapshot:complete_snapshot(IdxTerm, snapshot, State1),
             undefined = ra_snapshot:pending(State),
             {55, 2} = ra_snapshot:current(State),
             55 = ra_snapshot:last_index_for(UId),
@@ -156,7 +156,7 @@ init_recover(Config) ->
          ra_snapshot:begin_snapshot(Meta, ?FUNCTION_NAME, snapshot, State0),
     receive
         {ra_log_event, {snapshot_written, IdxTerm, snapshot}} ->
-            _ = ra_snapshot:complete_snapshot(IdxTerm, State1),
+            _ = ra_snapshot:complete_snapshot(IdxTerm, snapshot, State1),
             ok
     after 1000 ->
               error(snapshot_event_timeout)
@@ -188,7 +188,7 @@ init_recover_voter_status(Config) ->
          ra_snapshot:begin_snapshot(Meta, ?FUNCTION_NAME, snapshot, State0),
     receive
         {ra_log_event, {snapshot_written, IdxTerm, snapshot}} ->
-            _ = ra_snapshot:complete_snapshot(IdxTerm, State1),
+            _ = ra_snapshot:complete_snapshot(IdxTerm, snapshot, State1),
             ok
     after 1000 ->
               error(snapshot_event_timeout)
@@ -221,7 +221,7 @@ init_multi(Config) ->
                                              State0),
     receive
         {ra_log_event, {snapshot_written, IdxTerm, snapshot}} ->
-            State2 = ra_snapshot:complete_snapshot(IdxTerm, State1),
+            State2 = ra_snapshot:complete_snapshot(IdxTerm, snapshot, State1),
             {State3, _} = ra_snapshot:begin_snapshot(Meta2, ?FUNCTION_NAME,
                                                      snapshot, State2),
             {_, {165, 2}, snapshot} = ra_snapshot:pending(State3),
@@ -264,7 +264,7 @@ init_recover_multi_corrupt(Config) ->
                                              State0),
     receive
         {ra_log_event, {snapshot_written, IdxTerm, snapshot}} ->
-            State2 = ra_snapshot:complete_snapshot(IdxTerm, State1),
+            State2 = ra_snapshot:complete_snapshot(IdxTerm, snapshot, State1),
             {State3, _} = ra_snapshot:begin_snapshot(Meta2, ?FUNCTION_NAME,
                                                      snapshot, State2),
             {_, {165, 2}, snapshot} = ra_snapshot:pending(State3),
@@ -313,7 +313,7 @@ init_recover_corrupt(Config) ->
                                              State0),
     _ = receive
                  {ra_log_event, {snapshot_written, IdxTerm, snapshot}} ->
-                     ra_snapshot:complete_snapshot(IdxTerm, State1)
+                     ra_snapshot:complete_snapshot(IdxTerm, snapshot, State1)
              after 1000 ->
                        error(snapshot_event_timeout)
              end,
@@ -350,7 +350,7 @@ read_snapshot(Config) ->
          ra_snapshot:begin_snapshot(Meta, MacRef, snapshot, State0),
      State = receive
                  {ra_log_event, {snapshot_written, IdxTerm, snapshot}} ->
-                     ra_snapshot:complete_snapshot(IdxTerm, State1)
+                     ra_snapshot:complete_snapshot(IdxTerm, snapshot, State1)
              after 1000 ->
                        error(snapshot_event_timeout)
              end,
@@ -462,7 +462,7 @@ accept_receives_snapshot_written_with_lower_index(Config) ->
     %% then the snapshot written event is received
     receive
         {ra_log_event, {snapshot_written, {55, 2} = IdxTerm, snapshot}} ->
-            State4 = ra_snapshot:complete_snapshot(IdxTerm, State3),
+            State4 = ra_snapshot:complete_snapshot(IdxTerm, snapshot, State3),
             undefined = ra_snapshot:pending(State4),
             {55, 2} = ra_snapshot:current(State4),
             55 = ra_snapshot:last_index_for(UId),
@@ -501,7 +501,7 @@ accept_receives_snapshot_written_with_higher_index(Config) ->
     %% then the snapshot written event is received
     receive
         {ra_log_event, {snapshot_written, {55, 2} = IdxTerm, snapshot}} ->
-            State4 = ra_snapshot:complete_snapshot(IdxTerm, State3),
+            State4 = ra_snapshot:complete_snapshot(IdxTerm, snapshot, State3),
             undefined = ra_snapshot:pending(State4),
             {55, 2} = ra_snapshot:current(State4),
             55 = ra_snapshot:last_index_for(UId),


### PR DESCRIPTION
As described in #141, we add a new effect that machines may emit:

```erl
{checkpoint, CheckpointIndex, MachineState}
```

This suggests that Ra should add a checkpoint. Checkpoints are essentially the same as snapshots except that they don't trigger log truncation. They reuse the `ra_snapshot` behavior, so they are exactly the same as snapshots on disk. They can later be promoted to actual snapshots by emitting another new effect:

```erl
{release_cursor, ReleaseCursorIndex}
```

which suggests that Ra should find the checkpoint with the highest index lower than or equal to `ReleaseCursorIndex` and rename the checkpoint file so that it moves to `snapshots/` from `checkpoints/`. Any checkpoints lower than that index are then deleted, and log can be truncated up to that index. There is a configurable maximum number of checkpoints allowed. Adding more checkpoints after that maximum will trigger a "thinning out" where checkpoints are deleted randomly from the middle of the checkpoint list.

`rabbit_fifo` currently has an ad-hoc checkpointing system where it queues snapshot effects (`{release_cursor, RaftIndex, DehydratedState}`) regularly and emits those effects when it moves up the release cursor. The advantage of building this into Ra is that we can store the checkpoints on disk, so we can use them for machine recovery and reduce memory consumption (albeit at the cost of disk / IO).

This is useful for machines like `rabbit_fifo` that need to keep the log around on disk for a potentially long time (for use with the `{log, Idxs, Fun, Opts}` effect). If we take checkpoints regularly then recovery becomes constant-time rather than linear on the number of messages in the queue. Testing this locally on my machine against the server with a QQ containing 5 million messages[^1] gives a recovery time of 10ms while `main` takes around 24s.

Closes https://github.com/rabbitmq/ra/issues/141

[^1]: use the [`md-ra-checkpoints`](https://github.com/rabbitmq/rabbitmq-server/tree/md-ra-checkpoints) branch, fill the queue with `perf-test -x 1 -y 0 -qq -u qq -c 3000 -C 5000000`, restart the broker and grep the log file for "recovery of state machine version"