### PR TITLE
Add reply_mode to command meta data

### DIFF
--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -196,7 +196,8 @@
                                index := ra_index(),
                                term := ra_term(),
                                machine_version => version(),
-                               from => from()}.
+                               from => from(),
+                               reply_mode => ra_server:command_reply_mode()}.
 %% extensible command meta data map
 
 


### PR DESCRIPTION
This would allow state machines to make use of, e.g. the pid in the `{notify, Corr, Pid}` reply mode to avoid having to include Pids in the command body and thus avoid them being stored twice for each command.
