### PR TITLE
Add a gauge for the effective machine version in ra_counters

### DIFF
--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -357,6 +357,7 @@
 -define(C_RA_SVR_METRIC_COMMIT_LATENCY, ?C_RA_SRV_RESERVED + 6).
 -define(C_RA_SVR_METRIC_TERM, ?C_RA_SRV_RESERVED + 7).
 -define(C_RA_SVR_METRIC_CHECKPOINT_INDEX, ?C_RA_SRV_RESERVED + 8).
+-define(C_RA_SVR_METRIC_EFFECTIVE_MACHINE_VERSION, ?C_RA_SRV_RESERVED + 9).
 
 -define(RA_SRV_METRICS_COUNTER_FIELDS,
         [
@@ -374,7 +375,9 @@
           "Approximate time taken from an entry being written to the log until it is committed."},
          {term, ?C_RA_SVR_METRIC_TERM, counter, "The current term."},
          {checkpoint_index, ?C_RA_SVR_METRIC_CHECKPOINT_INDEX, counter,
-          "The current checkpoint index."}
+          "The current checkpoint index."},
+         {effective_machine_version, ?C_RA_SVR_METRIC_EFFECTIVE_MACHINE_VERSION,
+          gauge, "The current effective version number of the machine."}
         ]).
 
 -define(RA_COUNTER_FIELDS,

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -339,6 +339,7 @@ init(#{id := Id,
     put_counter(Cfg, ?C_RA_SVR_METRIC_COMMIT_INDEX, CommitIndex),
     put_counter(Cfg, ?C_RA_SVR_METRIC_LAST_APPLIED, SnapshotIdx),
     put_counter(Cfg, ?C_RA_SVR_METRIC_TERM, CurrentTerm),
+    put_counter(Cfg, ?C_RA_SVR_METRIC_EFFECTIVE_MACHINE_VERSION, MacVer),
 
     NonVoter = get_membership(Cluster0, Id, UId,
                              maps:get(membership, Config, voter)),
@@ -1302,6 +1303,7 @@ handle_receive_snapshot(#install_snapshot_rpc{term = Term,
             %% we also need to update the current effective machine configuration
             Cfg = case SnapMacVer > CurEffMacVer of
                       true ->
+                          put_counter(Cfg0, ?C_RA_SVR_METRIC_EFFECTIVE_MACHINE_VERSION, SnapMacVer),
                           EffMacMod = ra_machine:which_module(Machine, SnapMacVer),
                           Cfg0#cfg{effective_machine_version = SnapMacVer,
                                    machine_versions = [{SnapIndex, SnapMacVer}
@@ -2553,6 +2555,7 @@ apply_with({Idx, Term, {noop, CmdMeta, NextMacVer}},
                                 true;
                             _ -> ClusterChangePerm0
                         end,
+    put_counter(Cfg0, ?C_RA_SVR_METRIC_EFFECTIVE_MACHINE_VERSION, NextMacVer),
     %% can we understand the next machine version
     IsOk = MacVer >= NextMacVer,
     case NextMacVer > OldMacVer of


### PR DESCRIPTION
This allows callers to cheaply query a server's current effective machine version.

Closes #424
This should be useful for https://github.com/rabbitmq/khepri/pull/250