### PR TITLE
Exclude `non_voter` server from quorum calculation

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -2827,9 +2827,7 @@ query_indexes(#{cfg := #cfg{id = Id},
                 query_index := QueryIndex}) ->
     maps:fold(fun (PeerId, _, Acc) when PeerId == Id ->
                       Acc;
-                  (_K, #{voter_status := #{membership := non_voter}}, Acc) ->
-                      Acc;
-                  (_K, #{voter_status := #{membership := promotable}}, Acc) ->
+                  (_K, #{voter_status := #{membership := Membership}}, Acc) when Membership =/= voter ->
                       Acc;
                   (_K, #{query_index := Idx}, Acc) ->
                       [Idx | Acc]
@@ -2841,9 +2839,7 @@ match_indexes(#{cfg := #cfg{id = Id},
     {LWIdx, _} = ra_log:last_written(Log),
     maps:fold(fun (PeerId, _, Acc) when PeerId == Id ->
                       Acc;
-                  (_K, #{voter_status := #{membership := non_voter}}, Acc) ->
-                      Acc;
-                  (_K, #{voter_status := #{membership := promotable}}, Acc) ->
+                  (_K, #{voter_status := #{membership := Membership}}, Acc) when Membership =/= voter ->
                       Acc;
                   (_K, #{match_index := Idx}, Acc) ->
                       [Idx | Acc]
@@ -3153,9 +3149,7 @@ required_quorum(Cluster) ->
 
 count_voters(Cluster) ->
     maps:fold(
-      fun (_, #{voter_status := #{membership := non_voter}}, Count) ->
-              Count;
-          (_, #{voter_status := #{membership := promotable}}, Count) ->
+      fun (_, #{voter_status := #{membership := Membership}}, Count) when Membership =/= voter ->
               Count;
           (_, _, Count) ->
               Count + 1

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -2827,6 +2827,8 @@ query_indexes(#{cfg := #cfg{id = Id},
                 query_index := QueryIndex}) ->
     maps:fold(fun (PeerId, _, Acc) when PeerId == Id ->
                       Acc;
+                  (_K, #{voter_status := #{membership := non_voter}}, Acc) ->
+                      Acc;
                   (_K, #{voter_status := #{membership := promotable}}, Acc) ->
                       Acc;
                   (_K, #{query_index := Idx}, Acc) ->
@@ -2838,6 +2840,8 @@ match_indexes(#{cfg := #cfg{id = Id},
                 log := Log}) ->
     {LWIdx, _} = ra_log:last_written(Log),
     maps:fold(fun (PeerId, _, Acc) when PeerId == Id ->
+                      Acc;
+                  (_K, #{voter_status := #{membership := non_voter}}, Acc) ->
                       Acc;
                   (_K, #{voter_status := #{membership := promotable}}, Acc) ->
                       Acc;
@@ -3149,7 +3153,9 @@ required_quorum(Cluster) ->
 
 count_voters(Cluster) ->
     maps:fold(
-      fun (_, #{voter_status := #{membership := promotable}}, Count) ->
+      fun (_, #{voter_status := #{membership := non_voter}}, Count) ->
+              Count;
+          (_, #{voter_status := #{membership := promotable}}, Count) ->
               Count;
           (_, _, Count) ->
               Count + 1

--- a/test/ra_2_SUITE.erl
+++ b/test/ra_2_SUITE.erl
@@ -713,7 +713,7 @@ force_start_follower_as_single_member_nonvoter(Config) ->
     {ok, [_], ServerId3} = ra:members(ServerId3),
     ok = enqueue(ServerId3, msg2),
 
-    %% add a member
+    %% add a promotable member
     ServerId4 = ?config(server_id4, Config),
     UId4 = ?config(uid4, Config),
     Conf4 = conf(ClusterName, UId4, ServerId4, PrivDir, [ServerId3]),


### PR DESCRIPTION
## Proposed Changes

In my understanding, `non_voter` servers (introduced in https://github.com/rabbitmq/ra/pull/375) have to be handled as same as `promotable` servers except for the latter could promote to `voter`.
However, the current implementation seems to include `non_voter` servers in the quorum (while `promotable` servers are excluded from that).
This PR fixes the issue by excluding `non_voter` server from quorum calculation.
Feel free to close this PR if I misunderstand something.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
