### PR TITLE
Fix crash caused by receiving `#append_entries_reply{success=false}` from unknown peer

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -462,6 +462,13 @@ handle_leader({PeerId, #append_entries_reply{term = Term}},
                     [LogId, PeerId, Term, CurTerm]),
             {follower, update_term(Term, State0#{leader_id => undefined}), []}
     end;
+handle_leader({PeerId, #append_entries_reply{success = false}},
+              State0 = #{cfg := #cfg{log_id = LogId},
+                         cluster := Nodes})
+  when not is_map_key(PeerId, Nodes) ->
+    ?WARN("~ts: saw append_entries_reply from unknown peer ~w",
+          [LogId, PeerId]),
+    {leader, State0, []};
 handle_leader({PeerId, #append_entries_reply{success = false,
                                              next_index = NextIdx,
                                              last_index = LastIdx,
@@ -469,60 +476,55 @@ handle_leader({PeerId, #append_entries_reply{success = false,
               State0 = #{cfg := #cfg{log_id = LogId} = Cfg,
                          cluster := Nodes, log := Log0}) ->
     ok = incr_counter(Cfg, ?C_RA_SRV_AER_REPLIES_FAILED, 1),
-    case peer(PeerId, State0) of
-        undefined ->
-            ?WARN("~ts: saw append_entries_reply from unknown peer ~w",
-                  [LogId, PeerId]),
-            {leader, State0, []};
-        Peer0 = #{match_index := MI, next_index := NI} ->
-            % if the last_index exists and has a matching term we can forward
-            % match_index and update next_index directly
-            {Peer, Log} = case ra_log:fetch_term(LastIdx, Log0) of
-                              {undefined, L} ->
-                                  % entry was not found - simply set next index to
-                                  ?DEBUG("~ts: setting next index for ~w ~b",
-                                         [LogId, PeerId, NextIdx]),
-                                  {Peer0#{match_index => LastIdx,
-                                          next_index => NextIdx}, L};
-                              % entry exists we can forward
-                              {LastTerm, L} when LastIdx >= MI ->
-                                  ?DEBUG("~ts: setting last index to ~b, "
-                                         " next_index ~b for ~w",
-                                         [LogId, LastIdx, NextIdx, PeerId]),
-                                  {Peer0#{match_index => LastIdx,
-                                          next_index => NextIdx}, L};
-                              {_Term, L} when LastIdx < MI ->
-                                  % TODO: this can only really happen when peers are
-                                  % non-persistent.
-                                  % should they turn-into non-voters when this sitution
-                                  % is detected
-                                  ?WARN("~ts: leader saw peer with last_index [~b in ~b]"
-                                        " lower than recorded match index [~b]."
-                                        "Resetting peer's state to last_index.",
-                                        [LogId, LastIdx, LastTerm, MI]),
-                                  {Peer0#{match_index => LastIdx,
-                                          next_index => LastIdx + 1}, L};
-                              {EntryTerm, L} ->
-                                  NextIndex = max(min(NI-1, LastIdx), MI),
-                                  ?DEBUG("~ts: leader received last_index ~b"
-                                         " from ~w with term ~b "
-                                         "- expected term ~b. Setting "
-                                         "next_index to ~b",
-                                         [LogId, LastIdx, PeerId, LastTerm, EntryTerm,
-                                          NextIndex]),
-                                  % last_index has a different term or entry does not
-                                  % exist
-                                  % The peer must have received an entry from a previous
-                                  % leader and the current leader wrote a different
-                                  % entry at the same index in a different term.
-                                  % decrement next_index but don't go lower than
-                                  % match index.
-                                  {Peer0#{next_index => NextIndex}, L}
-                          end,
-            State1 = State0#{cluster => Nodes#{PeerId => Peer}, log => Log},
-            {State, _, Effects} = make_pipelined_rpc_effects(State1, []),
-            {leader, State, Effects}
-    end;
+    #{PeerId := Peer0 = #{match_index := MI,
+                          next_index := NI}} = Nodes,
+    % if the last_index exists and has a matching term we can forward
+    % match_index and update next_index directly
+    {Peer, Log} = case ra_log:fetch_term(LastIdx, Log0) of
+                      {undefined, L} ->
+                          % entry was not found - simply set next index to
+                          ?DEBUG("~ts: setting next index for ~w ~b",
+                                 [LogId, PeerId, NextIdx]),
+                          {Peer0#{match_index => LastIdx,
+                                  next_index => NextIdx}, L};
+                      % entry exists we can forward
+                      {LastTerm, L} when LastIdx >= MI ->
+                          ?DEBUG("~ts: setting last index to ~b, "
+                                 " next_index ~b for ~w",
+                                 [LogId, LastIdx, NextIdx, PeerId]),
+                          {Peer0#{match_index => LastIdx,
+                                  next_index => NextIdx}, L};
+                      {_Term, L} when LastIdx < MI ->
+                          % TODO: this can only really happen when peers are
+                          % non-persistent.
+                          % should they turn-into non-voters when this sitution
+                          % is detected
+                          ?WARN("~ts: leader saw peer with last_index [~b in ~b]"
+                                " lower than recorded match index [~b]."
+                                "Resetting peer's state to last_index.",
+                                [LogId, LastIdx, LastTerm, MI]),
+                          {Peer0#{match_index => LastIdx,
+                                  next_index => LastIdx + 1}, L};
+                      {EntryTerm, L} ->
+                          NextIndex = max(min(NI-1, LastIdx), MI),
+                          ?DEBUG("~ts: leader received last_index ~b"
+                                 " from ~w with term ~b "
+                                 "- expected term ~b. Setting "
+                                 "next_index to ~b",
+                                 [LogId, LastIdx, PeerId, LastTerm, EntryTerm,
+                                  NextIndex]),
+                          % last_index has a different term or entry does not
+                          % exist
+                          % The peer must have received an entry from a previous
+                          % leader and the current leader wrote a different
+                          % entry at the same index in a different term.
+                          % decrement next_index but don't go lower than
+                          % match index.
+                          {Peer0#{next_index => NextIndex}, L}
+                  end,
+    State1 = State0#{cluster => Nodes#{PeerId => Peer}, log => Log},
+    {State, _, Effects} = make_pipelined_rpc_effects(State1, []),
+    {leader, State, Effects};
 handle_leader({command, Cmd}, #{cfg := #cfg{log_id = LogId} = Cfg} = State00) ->
     ok = incr_counter(Cfg, ?C_RA_SRV_COMMANDS, 1),
     case append_log_leader(Cmd, State00, []) of

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -23,6 +23,7 @@ all() ->
      append_entries_reply_success_promotes_nonvoter,
      append_entries_reply_success,
      append_entries_reply_no_success,
+     append_entries_reply_no_success_from_unknown_peer,
      follower_request_vote,
      follower_pre_vote,
      pre_vote_receives_pre_vote,
@@ -972,6 +973,21 @@ append_entries_reply_no_success(_Config) ->
                                       {3, 5, {'$usr', _, <<"hi3">>, _}}]}},
         {send_rpc, N2, _}
       ]} = ra_server:handle_leader(Msg, State),
+    ok.
+
+append_entries_reply_no_success_from_unknown_peer(_Config) ->
+    N1 = ?N1, N2 = ?N2,
+    Cluster = #{N1 => new_peer()},
+    State = (base_state(3, ?FUNCTION_NAME))#{commit_index => 1,
+                             last_applied => 1,
+                             cluster => Cluster,
+                             machine_state => <<"hi1">>},
+    % n2 is an unknown peer
+    Msg = {N2, #append_entries_reply{term = 5, success = false, next_index = 2,
+                                     last_index = 1, last_term = 1}},
+    % The reply from n2 is ignored
+    {leader, State, []} = ra_server:handle_leader(Msg, State),
+
     ok.
 
 follower_request_vote(_Config) ->


### PR DESCRIPTION
## Proposed Changes

This PR fixes a ra server process (leader) crash caused by receiving a `#append_entries_reply{success=false}` message from an unknown peer.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If the patch in this PR is not applied, the following crash log will be generated by the `append_entries_reply_no_success_from_unknown_peer` test case.

```
=== Location: [{ra_server,handle_leader,472},
              {ra_server_SUITE,append_entries_reply_no_success_from_unknown_peer,989},
              {test_server,ts_tc,1794},
              {test_server,run_test_case_eval1,1303},
              {test_server,run_test_case_eval,1235}]
=== === Reason: no match of right hand side value 
                 #{{n1,'ct_ra@localhost'} =>
                       #{status => normal,next_index => 1,match_index => 0,
                         query_index => 0,commit_index_sent => 0}}
  in function  ra_server:handle_leader/2 (src/ra_server.erl, line 472)
  in call from ra_server_SUITE:append_entries_reply_no_success_from_unknown_peer/1 (test/ra_server_SUITE.erl, line 989)
  in call from test_server:ts_tc/3 (test_server.erl, line 1794)
  in call from test_server:run_test_case_eval1/6 (test_server.erl, line 1303)
  in call from test_server:run_test_case_eval/9 (test_server.erl, line 1235)
```

