### PR TITLE
Fail the OCI workflow if the ra version is not injected properly

### DIFF
--- a/.github/workflows/rabbitmq-oci.yaml
+++ b/.github/workflows/rabbitmq-oci.yaml
@@ -34,6 +34,9 @@ jobs:
         working-directory: deps/ra
         run: |
           sed -i"_orig" "/vsn,/ s/2\\.[0-9]\\.[0-9]/${{ github.event.pull_request.head.sha || github.sha }}/" src/ra.app.src
+          if git diff --exit-code; then
+            exit 1
+          fi
       - name: Configure Erlang
         uses: erlef/setup-beam@v1
         with:


### PR DESCRIPTION
the ra version is set to the git sha