### PR TITLE
Fix a problem that non-voters could become leader

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1264,7 +1264,7 @@ handle_follower(election_timeout, State) ->
 handle_follower(try_become_leader,
                 #{cfg := #cfg{log_id = LogId},
                   membership := Membership} = State) when Membership =/= voter ->
-    ?DEBUG("~s: follower ignored try_become_leader, non-voter: ~p0",
+    ?DEBUG("~s: follower ignored try_become_leader, non-voter: ~p",
            [LogId, Membership]),
     {follower, State, []};
 handle_follower(try_become_leader, State) ->
@@ -1275,7 +1275,7 @@ handle_follower({register_external_log_reader, Pid}, #{log := Log0} = State) ->
 handle_follower(force_member_change,
                 #{cfg := #cfg{log_id = LogId},
                   membership := Membership} = State) when Membership =/= voter ->
-    ?DEBUG("~s: follower ignored force_member_change, non-voter: ~p0",
+    ?DEBUG("~s: follower ignored force_member_change, non-voter: ~p",
            [LogId, Membership]),
     {follower, State, []};
 handle_follower(force_member_change,
@@ -1383,7 +1383,7 @@ handle_await_condition(#pre_vote_rpc{} = PreVote, State) ->
 handle_await_condition(election_timeout,
                 #{cfg := #cfg{log_id = LogId},
                   membership := Membership} = State) when Membership =/= voter ->
-    ?DEBUG("~s: await_condition ignored election_timeout, non-voter: ~p0",
+    ?DEBUG("~s: await_condition ignored election_timeout, non-voter: ~p",
            [LogId, Membership]),
     {await_condition, State, []};
 handle_await_condition(election_timeout, State) ->

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1261,11 +1261,23 @@ handle_follower(election_timeout,
     {follower, State, []};
 handle_follower(election_timeout, State) ->
     call_for_election(pre_vote, State);
+handle_follower(try_become_leader,
+                #{cfg := #cfg{log_id = LogId},
+                  membership := Membership} = State) when Membership =/= voter ->
+    ?DEBUG("~s: follower ignored try_become_leader, non-voter: ~p0",
+           [LogId, Membership]),
+    {follower, State, []};
 handle_follower(try_become_leader, State) ->
     call_for_election(pre_vote, State);
 handle_follower({register_external_log_reader, Pid}, #{log := Log0} = State) ->
     {Log, Effs} = ra_log:register_reader(Pid, Log0),
     {follower, State#{log => Log}, Effs};
+handle_follower(force_member_change,
+                #{cfg := #cfg{log_id = LogId},
+                  membership := Membership} = State) when Membership =/= voter ->
+    ?DEBUG("~s: follower ignored force_member_change, non-voter: ~p0",
+           [LogId, Membership]),
+    {follower, State, []};
 handle_follower(force_member_change,
                 #{cfg := #cfg{id = Id,
                               log_id = LogId}} = State0) ->
@@ -1368,6 +1380,12 @@ handle_await_condition(#request_vote_rpc{} = Msg, State) ->
     {follower, State, [{next_event, Msg}]};
 handle_await_condition(#pre_vote_rpc{} = PreVote, State) ->
     process_pre_vote(await_condition, PreVote, State);
+handle_await_condition(election_timeout,
+                #{cfg := #cfg{log_id = LogId},
+                  membership := Membership} = State) when Membership =/= voter ->
+    ?DEBUG("~s: await_condition ignored election_timeout, non-voter: ~p0",
+           [LogId, Membership]),
+    {await_condition, State, []};
 handle_await_condition(election_timeout, State) ->
     call_for_election(pre_vote, State);
 handle_await_condition(await_condition_timeout,

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -285,6 +285,7 @@ election_timeout(_Config) ->
     % non-voters ignore election_timeout
     NVState = State#{membership => promotable},
     {follower, NVState, []} = ra_server:handle_follower(Msg, NVState),
+    {await_condition, NVState, []} = ra_server:handle_await_condition(Msg, NVState),
 
     % pre_vote
     {pre_vote, #{current_term := 5, votes := 0,


### PR DESCRIPTION
## Proposed Changes

In my understanding, `ra` doesn't assume that non-voters become the cluster leader.
(If the understanding is not correct, [self vote by non-voters](https://github.com/rabbitmq/ra/blob/main/src/ra_server.erl#L2128) should be fixed instead to prevent potential quorum violation.)

However, the current implementation sometimes allows non-voters to transition into `pre_vote` state. 
For instance, a non-voter can become the leader by calling `ra:transfer_leadership/2`. 
This PR addresses this problem by adding checks that prevent non-voters from transitioning into `pre_vote` state.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
