### PR TITLE
Fix a bug where the leader is never elected even if the majority of the members are alive.

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -920,7 +920,8 @@ handle_candidate(#request_vote_rpc{}, State = #{current_term := Term}) ->
     Reply = #request_vote_result{term = Term, vote_granted = false},
     {candidate, State, [{reply, Reply}]};
 handle_candidate(#pre_vote_rpc{} = PreVote, State) ->
-    %% unlink request_vote_rpc, candidate cannot simply reject pre_vote_rpc that does not have a higher term
+    %% unlike request_vote_rpc, a candidate cannot simply reject 
+    %% a pre_vote_rpc that does not have a higher term
     %% (see https://github.com/rabbitmq/ra/issues/439 for the detail)
     process_pre_vote(candidate, PreVote, State);
 handle_candidate(#request_vote_result{}, State) ->

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -919,6 +919,23 @@ handle_candidate(#pre_vote_rpc{term = Term} = Msg,
 handle_candidate(#request_vote_rpc{}, State = #{current_term := Term}) ->
     Reply = #request_vote_result{term = Term, vote_granted = false},
     {candidate, State, [{reply, Reply}]};
+handle_candidate(#pre_vote_rpc{term = Term, last_log_index = PeerLastIdx} = Msg,
+                 #{current_term := CurTerm,
+                   cfg := #cfg{log_id = LogId}} = State0)
+  when Term =:= CurTerm ->
+    {LastIdx, _} = last_idx_term(State0),
+    case PeerLastIdx > LastIdx of
+        true ->
+            %% To prevent the liveness issue reported in https://github.com/rabbitmq/ra/issues/439,
+            %% if a candidate member receives a `#pre_vote_rpc{}` with a higher last index,
+            %% it should transition to the follower state.
+            ?INFO("~ts: candidate pre_vote_rpc with higher last index received ~b -> ~b",
+                  [LogId, LastIdx, PeerLastIdx]),
+            State = update_term_and_voted_for(Term, undefined, State0),
+            {follower, State, [{next_event, Msg}]};
+        false ->
+            {candidate, State0, []}
+    end;
 handle_candidate(#pre_vote_rpc{}, State) ->
     %% just ignore pre_votes that aren't of a higher term
     {candidate, State, []};

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1936,17 +1936,19 @@ candidate_receives_pre_vote(_Config) ->
                                token = Token,
                                machine_version = 0,
                                last_log_index = 3, last_log_term = 5},
-    {candidate, #{}, []}
+    % candidate replies `#pre_vote_result{vote_granted=true}` for not lower index
+    {candidate, #{},
+     [{reply, #pre_vote_result{token = Token, vote_granted = true}}]}
         = ra_server:handle_candidate(PreVoteRpc, State),
+
+    % candidate replies `#pre_vote_result{vote_granted=false}` for lower index
+    {candidate, #{},
+     [{reply, #pre_vote_result{token = Token, vote_granted = false}}]}
+        = ra_server:handle_candidate(PreVoteRpc#pre_vote_rpc{last_log_index = 2}, State),
 
     % candidate abdicates for higher term
     {follower, #{current_term := 6}, _}
         = ra_server:handle_candidate(PreVoteRpc#pre_vote_rpc{term = 6}, State),
-
-    % candidate replies `#pre_vote_result{vote_granted=true}` for higher index
-    {candidate, #{},
-     [{reply, #pre_vote_result{token = Token, vote_granted = true}}]}
-        = ra_server:handle_candidate(PreVoteRpc#pre_vote_rpc{last_log_index = 4}, State),
 
     ok.
 

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1943,8 +1943,9 @@ candidate_receives_pre_vote(_Config) ->
     {follower, #{current_term := 6}, _}
         = ra_server:handle_candidate(PreVoteRpc#pre_vote_rpc{term = 6}, State),
 
-    % candidate abdicates for higher index
-    {follower, #{}, _}
+    % candidate replies `#pre_vote_result{vote_granted=true}` for higher index
+    {candidate, #{},
+     [{reply, #pre_vote_result{token = Token, vote_granted = true}}]}
         = ra_server:handle_candidate(PreVoteRpc#pre_vote_rpc{last_log_index = 4}, State),
 
     ok.

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -33,6 +33,7 @@ all() ->
      higher_term_detected,
      pre_vote_election,
      pre_vote_election_reverts,
+     candidate_receives_pre_vote,
      leader_receives_pre_vote,
      candidate_election,
      is_new,
@@ -1925,6 +1926,27 @@ pre_vote_election_reverts(_Config) ->
                                 data = []},
     {follower, #{current_term := 5, votes := 0}, [{next_event, ISR}]}
         = ra_server:handle_pre_vote(ISR, State),
+    ok.
+
+candidate_receives_pre_vote(_Config) ->
+    % candidate ignores an pre_vote_rpc with lower term and lower index
+    Token = make_ref(),
+    State = (base_state(5, ?FUNCTION_NAME))#{votes => 1},
+    PreVoteRpc = #pre_vote_rpc{term = 5, candidate_id = ?N1,
+                               token = Token,
+                               machine_version = 0,
+                               last_log_index = 3, last_log_term = 5},
+    {candidate, #{}, []}
+        = ra_server:handle_candidate(PreVoteRpc, State),
+
+    % candidate abdicates for higher term
+    {follower, #{current_term := 6}, _}
+        = ra_server:handle_candidate(PreVoteRpc#pre_vote_rpc{term = 6}, State),
+
+    % candidate abdicates for higher index
+    {follower, #{}, _}
+        = ra_server:handle_candidate(PreVoteRpc#pre_vote_rpc{last_log_index = 4}, State),
+
     ok.
 
 leader_receives_pre_vote(_Config) ->


### PR DESCRIPTION
## Proposed Changes

This PR addresses the issue reported in #439.

To summarize #439, if there is a candidate member and a pre_vote member where the pre_vote member has a higher log index than the candidate member, neither of them can ever be elected as the leader.
(This holds true even if there are additional `N / 2 - 1` or fewer followers without election timers, where `N` is the cluster size.)

This PR adds a branch to  `ra_server:handle_candidate(#pre_vote_rpc{}, ...)` to handle cases where the pre_vote member has a higher log index. By the new branch, when such a message is received, the candidate transitions to the follower state.

I think this is somewhat ad-hoc. However, since I don't know much about the `ra` code base (especially regarding the role of the `pre_vote` state), I made a patch to minimize the impact range. 
Feel free to suggest any better alternative approaches.

Closes #439.

### FYI

By applying the patch for reproduction from issue #439 to this PR branch, the execution result became as follows:

```
(foo@localhost)1> repro:run().
# create cluster
* [repro_a] init
* [repro_c] init
* [repro_b] init
* [repro_a] state_enter: recover
* [repro_c] state_enter: recover
* [repro_b] state_enter: recover
* [repro_a] state_enter: recovered
* [repro_c] state_enter: recovered
* [repro_b] state_enter: recovered
* [repro_a] state_enter: follower
* [repro_c] state_enter: follower
* [repro_b] state_enter: follower
* [repro_c] state_enter: pre_vote
* [repro_c] state_enter: candidate
* [repro_c] state_enter: leader
# Please wait 5 seconds...
# trigger election
ok
* [repro_a] state_enter: pre_vote
* [repro_a] state_enter: candidate
* [repro_c] state_enter: follower
* [repro_c] state_enter: pre_vote
* [repro_a] state_enter: follower
* [repro_c] state_enter: candidate
* [repro_c] state_enter: leader  # new leader is elected
* [repro_a] state_enter: await_condition
* [repro_a] state_enter: follower
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #439)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
