### PR TITLE
Sync name.dets to disk

### DIFF
--- a/src/ra_directory.erl
+++ b/src/ra_directory.erl
@@ -97,7 +97,6 @@ unregister_name(#{directory := Directory,
                   directory_rev := DirRev}, UId) ->
     case ets:take(Directory, UId) of
         [{_, _, _, ServerName, _}] ->
-            _ = ets:take(Directory, UId),
             ok = dets:delete(DirRev, ServerName),
             ok = dets:sync(DirRev),
             UId;

--- a/src/ra_directory.erl
+++ b/src/ra_directory.erl
@@ -77,14 +77,12 @@ register_name(#{directory := Directory,
                                   ClusterName}),
     case uid_of(System, ServerName) of
         undefined ->
-            ok = dets:insert(DirRev, {ServerName, UId}),
-            ok = dets:sync(DirRev);
+            ok = dets:insert(DirRev, {ServerName, UId});
         UId ->
             %% no need to insert into dets table if already there
             ok;
         OtherUId ->
             ok = dets:insert(DirRev, {ServerName, UId}),
-            ok = dets:sync(DirRev),
             ?WARN("ra server with name ~ts UId ~s replaces prior UId ~s",
                   [ServerName, UId, OtherUId]),
             ok
@@ -98,7 +96,6 @@ unregister_name(#{directory := Directory,
     case ets:take(Directory, UId) of
         [{_, _, _, ServerName, _}] ->
             ok = dets:delete(DirRev, ServerName),
-            ok = dets:sync(DirRev),
             UId;
         [] ->
             UId


### PR DESCRIPTION
## Proposed Changes

I have seen `names.dets` being left not in sync with the system state (server directory name).

The operations that trigger the problem are:

1. start the app
2. create a raft server X (UID-123)
3. leave_and_delete the server X
4. re create the raft server X (UID-456)
5. immediately stop the app (<<<=== before the DETS auto_sync the new registered name to the disk - 500ms)

So, in other words, we are "resetting" an existing ra server (3+4).

What I've seen is that `names.dets` refer to the ra server identifier created at step 2 - UID-123 (the first instance of the server X).
When I restart the application, ra crashes while strarting with error `enoent` since the ra server directory UID-123 does not exist anymore (deleted by step 3).

Here a view of what I see - `names.dets` refer to  the server "ELIXIRXR9LYKF78Z3R" (it's the one created on step 2) while on disk I see the server "ELIXIRHP06E8L3EYLT" (created on step 4).

<img width="778" alt="image" src="https://github.com/rabbitmq/ra/assets/15736959/b36c37b1-78ea-4cbf-a2b0-2bd79d07c6de">


I've been able to "fix" the problem introducing a `dets:sync` call after each change operation in `ra_directory` module, following what is already in place in the `ra_log_metadata` module.

@kjnilsson I have not jet created an ISSUE to link to this PR, would like to get a feedback from you first.
Even if the change is small, and I think should not break existing stuff and lower down the performance, maybe there is a better architectural approach you can come to - since given the non atomicity of writing to a dets can always lead to a dets that has not been updated (ie erlang app killed after a `dets:insert` but before the `dets:sync`).
Let me know if you need more information.

## Types of Changes

- [X] Bug fix (non-breaking change which fixes issue "NOT JET OPENED")
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
