### PR TITLE
WAL: drop entries with indexes lower or equal to the last snapshot

### DIFF
--- a/src/ra_log_cache.erl
+++ b/src/ra_log_cache.erl
@@ -42,8 +42,7 @@ init() ->
 -spec reset(state()) -> state().
 reset(#?MODULE{range = undefined} = State) ->
     State;
-reset(#?MODULE{tbl = Tid,
-               cache = _Cache} = State) ->
+reset(#?MODULE{tbl = Tid} = State) ->
     true = ets:delete_all_objects(Tid),
     State#?MODULE{cache = #{},
                   range = undefined}.
@@ -133,6 +132,9 @@ trim(To, #?MODULE{tbl = Tid,
     NewRange = {To + 1, RangeTo},
     State#?MODULE{range = NewRange,
                   cache = cache_without(From, To, Cache, Tid)};
+trim(To, #?MODULE{range = {From, _RangeTo}} = State)
+  when To < From ->
+    State;
 trim(_To, State) ->
     reset(State).
 


### PR DESCRIPTION
In situations where the WAL lags behind but entries are still
committed the WAL will still write entries with indexes lower
than the last snapshot index for a given server. To avoid this
unnessary work we no check the ra_log_snapshot_state table for
each write and do not write them if they are lower than the
snapshot index. This allows the wal a better chance to catch
up on it's backlog.

Some changes needed to be made to the ra_log also to handle
this new behaviour.