### PR TITLE
coordination_SUITE: Improve wait condition in `segment_writer_or_wal_crash_leader/1`

### DIFF
--- a/test/coordination_SUITE.erl
+++ b/test/coordination_SUITE.erl
@@ -927,6 +927,9 @@ segment_writer_or_wal_crash_leader(Config) ->
                               {timeout, _} ->
                                   timer:sleep(1000),
                                   Leader_;
+                              {error, _} ->
+                                  timer:sleep(1000),
+                                  Leader_;
                               {ok, _, L} ->
                                   L
                           end,
@@ -944,7 +947,9 @@ segment_writer_or_wal_crash_leader(Config) ->
                               LastIdxs =
                               [begin
                                    {ok, #{current_term := T,
-                                          log := #{last_index := L}}, _} =
+                                          log := #{last_index := L,
+                                                   last_written_index_term := {L, _}}},
+                                    _} =
                                    ra:member_overview(S),
                                    {T, L}
                                end || {_, _N} = S <- ServerIds],


### PR DESCRIPTION
## Why

The previous condition was not enough. This led to a failing assertion when the cache size was checked.

Submitted-by: @kjnilsson