### PR TITLE
Add `read` to `file:open/2` options in `ra_lib:sync_file/1`

### DIFF
--- a/src/ra_lib.erl
+++ b/src/ra_lib.erl
@@ -349,7 +349,7 @@ write_file(Name, IOData, Sync) ->
 -spec sync_file(file:name_all()) ->
     ok | file_err().
 sync_file(Name) ->
-    case file:open(Name, [binary, write, raw]) of
+    case file:open(Name, [binary, read, write, raw]) of
         {ok, Fd} ->
             sync_and_close_fd(Fd);
         Err ->

--- a/test/coordination_SUITE.erl
+++ b/test/coordination_SUITE.erl
@@ -814,6 +814,16 @@ recover_from_checkpoint(Config) ->
                 Follower2Idx =:= 8
       end, 20),
 
+    %% Restart the servers: the servers should be able to recover from the
+    %% snapshot which was promoted from a checkpoint.
+    [ok = ra:stop_server(?SYS, ServerId) || ServerId <- ServerIds],
+    [ok = ra:restart_server(?SYS, ServerId) || ServerId <- ServerIds],
+    [{ok, {_CurrentIdx, _CheckpointIdx = 8}, _Leader} =
+       ra:local_query(ServerId, fun(State) ->
+                                        maps:get(checkpoint_index, State,
+                                                 undefined)
+                                end) || ServerId <- ServerIds],
+
     stop_nodes(ServerIds),
     ok.
 


### PR DESCRIPTION
This fixes an issue where checkpoints which were promoted to snapshots would become empty. We need to `file:open/2` the checkpoint file with the `read` option as well as `write` since `write` without `read` truncates the file.

We also add another server restart to the checkpoint promotion case which catches the failure - the servers failed to restart since the promoted snapshot is empty.