### PR TITLE
Do not update ra_log_snapshot_state from snapshot writer process.

### DIFF
--- a/src/ra_snapshot.erl
+++ b/src/ra_snapshot.erl
@@ -349,8 +349,7 @@ begin_snapshot(#{index := Idx, term := Term} = Meta, MacRef, SnapKind,
 -spec promote_checkpoint(Idx :: ra_index(), State0 :: state()) ->
     {boolean(), State :: state(), Effects :: [effect()]}.
 promote_checkpoint(PromotionIdx,
-                   #?MODULE{uid = UId,
-                            module = Mod,
+                   #?MODULE{module = Mod,
                             snapshot_directory = SnapDir,
                             checkpoint_directory = CheckpointDir,
                             checkpoints = Checkpoints0} = State0) ->
@@ -369,7 +368,6 @@ promote_checkpoint(PromotionIdx,
                                 %% into a snapshot.
                                 ok = Mod:sync(Checkpoint),
                                 ok = prim_file:rename(Checkpoint, Snapshot),
-                                true = ets:insert(?ETSTBL, {UId, Idx}),
                                 Self ! {ra_log_event,
                                         {snapshot_written,
                                          {Idx, Term}, snapshot}}


### PR DESCRIPTION
As this could cause entries not to be written to the WAL (as it thinks they will never be read) but the main ra process is not yet aware of the snapshot and thus may try to read these entries.

This line was never necessary, it was an attempt at an optimisation for the checkpoints feature.

also:

Clear out older checkpoint when a snapshot is installed else this could cause old checkpoints to be promoted.
