### PR TITLE
Fixes for pre-init recovery and handling of gaps in mem tables due to snapshotting

### DIFF
--- a/src/ra_directory.erl
+++ b/src/ra_directory.erl
@@ -19,7 +19,8 @@
          pid_of/2,
          uid_of/2,
          overview/1,
-         list_registered/1
+         list_registered/1,
+         is_registered_uid/2
          ]).
 
 -export_type([
@@ -198,6 +199,13 @@ overview(System) when is_atom(System) ->
 list_registered(System) when is_atom(System) ->
     Tbl = get_reverse(System),
     dets:select(Tbl, [{'_', [], ['$_']}]).
+
+-spec is_registered_uid(atom(), ra_uid()) -> boolean().
+is_registered_uid(System, UId)
+  when is_atom(System) andalso
+       is_binary(UId) ->
+    Tbl = get_reverse(System),
+    [] =/= dets:select(Tbl, [{{'_', UId}, [], ['$_']}]).
 
 get_name(#{directory := Tbl}) ->
     Tbl;

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -977,11 +977,12 @@ snapshot_installation_with_call_crash(Config) ->
     {ok, _, _} = ra:process_command(Leader, deq),
 
     meck:new(ra_server, [passthrough]),
-    meck:expect(ra_server, handle_follower, fun (#install_snapshot_rpc{}, _) ->
-                                          exit(timeout);
-                                      (A, B) ->
-                                          meck:passthrough([A, B])
-                                  end),
+    meck:expect(ra_server, handle_follower,
+                fun (#install_snapshot_rpc{}, _) ->
+                        exit(timeout);
+                    (A, B) ->
+                        meck:passthrough([A, B])
+                end),
     %% start the down node again, catchup should involve sending a snapshot
     ok = ra:restart_server(?SYS, Down),
 
@@ -994,7 +995,7 @@ snapshot_installation_with_call_crash(Config) ->
                       {ok, {N2Idx, _}, _} = ra:local_query(N2, fun ra_lib:id/1),
                       {ok, {N3Idx, _}, _} = ra:local_query(N3, fun ra_lib:id/1),
                       (N1Idx == N2Idx) and (N1Idx == N3Idx)
-              end, 20)),
+              end, 200)),
     ok.
 
 

--- a/test/ra_dbg_SUITE.erl
+++ b/test/ra_dbg_SUITE.erl
@@ -9,7 +9,6 @@
 -compile(nowarn_export_all).
 -compile(export_all).
 
--include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->

--- a/test/ra_directory_SUITE.erl
+++ b/test/ra_directory_SUITE.erl
@@ -72,6 +72,7 @@ basics(_Config) ->
     % registrations should always succeed - no negative test
     Self = ra_directory:where_is(?SYS, UId),
     UId = ra_directory:uid_of(?SYS, test1),
+    ?assert(ra_directory:is_registered_uid(?SYS, UId)),
     % ensure it can be read from another process
     _ = spawn_link(
           fun () ->
@@ -86,6 +87,7 @@ basics(_Config) ->
     undefined = ra_directory:name_of(?SYS, UId),
     undefined = ra_directory:cluster_name_of(?SYS, UId),
     undefined = ra_directory:uid_of(?SYS, test1),
+    ?assertNot(ra_directory:is_registered_uid(?SYS, UId)),
     ok.
 
 persistence(_Config) ->


### PR DESCRIPTION
The first thing a ra system does when it starts is run a pre-init
phase for each registered Ra server, mostly to recover the
ra_log_snapshot_state table. This appears to have been broken
for along time and the ra_log_snapshot_table has not been populated
ahead of WAL / segment writer recovery. This was fine as this bit
was just an optimisation and never affected the workings of
the Ra infrastructure.

However since https://github.com/rabbitmq/ra/commit/5b7a26555b6aeefda143297d92e543e276046d07 it needs
this in order to avoid the segment writer crashing when it detects
a gap (caused by the WAL dropping entries lower than the current
snapshot).

This commit mostly fixes the pre-init process but also addresses
a potential race condition which still could cause the segment
writer to crash for the same reason.


See: https://github.com/rabbitmq/rabbitmq-server/discussions/11712