### PR TITLE
Avoid interrupting Ra system start when pre init fails

### DIFF
--- a/src/ra_lib.erl
+++ b/src/ra_lib.erl
@@ -529,7 +529,7 @@ merge_with_1(none, Result, _, _) ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
-lists_chink_test() ->
+lists_chunk_test() ->
     ?assertError(invalid_size, lists_chunk(0, [a])),
     ?assertMatch([], lists_chunk(2, [])),
     ?assertMatch([[a]], lists_chunk(2, [a])),

--- a/src/ra_log_pre_init.erl
+++ b/src/ra_log_pre_init.erl
@@ -46,9 +46,9 @@ init([System]) ->
                  ok -> ok
              catch _:Err ->
                        ?ERROR("pre_init failed in system ~s for UId ~ts with name ~ts"
-                              " This error may need manual intervention",
-                              [System, UId, Name]),
-                       throw({stop, {error, Err}})
+                              " This error may need manual intervention, Error ~p",
+                              [System, UId, Name, Err]),
+                       ok
              end
          end|| {Name, UId} <- Regd],
     {ok, #state{} , hibernate}.
@@ -95,11 +95,13 @@ pre_init(System, UId) ->
                                 {error, Err} ->
                                     ?ERROR("pre_init failed to read config file for UId '~ts', Err ~p",
                                            [UId, Err]),
-                                    exit({pre_init_failed, Err})
+                                    ok
                             end;
                         false ->
-                            ?INFO("pre_init UId '~ts' is registered but no data directory was found",
+                            ?INFO("pre_init UId '~ts' is registered but no data
+                                  directory was found, removing from ra directory",
                                   [UId]),
+                            _ = catch ra_directory:unregister_name(System, UId),
                             ok
                     end
             end

--- a/test/coordination_SUITE.erl
+++ b/test/coordination_SUITE.erl
@@ -902,7 +902,8 @@ segment_writer_or_wal_crash_follower(Config) ->
                               LastIdxs =
                               [begin
                                    {ok, #{current_term := T,
-                                          log := #{last_index := L}}, _} =
+                                          log := #{last_index := L,
+                                                   cache_size := 0}}, _} =
                                    ra:member_overview(S),
                                    {T, L}
                                end || {_, _N} = S <- ServerIds],
@@ -934,8 +935,6 @@ segment_writer_or_wal_crash_follower(Config) ->
 
          %% assert stuff
          await_condition(AwaitReplicated, 100),
-         ?assertMatch({ok, #{log := #{cache_size := 0}}, _},
-                      ra:member_overview(Follower)),
          %% follower hasn't crashed
          ?assertEqual(FollowerPid, ct_rpc:call(FollowerNode, erlang, whereis,
                                                [FollowerName]))


### PR DESCRIPTION
In practice this has proven too strict so now we will only log
errors as they occur, not stop the pre-init process from completing.

Also avoid asserting on a missing checkpoints directory as it isn't necessary
and the next server start will take care of that.