### PR TITLE
ra_server: Add a new `last_applied` state query

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -2445,6 +2445,8 @@ state_query(initial_members, #{log := Log}) ->
         _ ->
             error
     end;
+state_query(last_applied, State) ->
+    maps:get(last_applied, State, undefined);
 state_query(Query, _State) ->
     {error, {unknown_query, Query}}.
 

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1207,7 +1207,7 @@ perform_or_delay_local_query(
 perform_pending_queries(_RaftState, #state{pending_queries = []} = State) ->
     {State, []};
 perform_pending_queries(RaftState, State) ->
-    #{last_applied := LastApplied} = do_state_query(overview, State),
+    LastApplied = do_state_query(last_applied, State),
     perform_pending_queries(RaftState, LastApplied, State, []).
 
 perform_pending_queries(RaftState, LastApplied,

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1188,9 +1188,9 @@ perform_or_delay_local_query(
     %% If the condition is set to `{applied, {Index, Term}}', the query is
     %% added to a list of pending queries. It will be evaluated once that
     %% index is applied locally.
-    Leader = determine_leader(RaftState, State),
     case maps:get(condition, Options, undefined) of
         undefined ->
+            Leader = determine_leader(RaftState, State),
             Reply = perform_local_query(QueryFun, Leader, ServerState, Conf),
             {keep_state, State, [{reply, From, Reply}]};
         Condition ->


### PR DESCRIPTION
## Why

`ra_server_proc` was querying `overview` up until now to get the last applied index as part of the handling of conditions for queries.

This call was very expensive, leading to really poor performance of conditional queries (like a whopping 3000 times slower).

## How

We add a dedicated state query to get the `last_applied` value only.