### PR TITLE
Stop checkpoint validation when encountering a valid checkpoint

### DIFF
--- a/src/ra_snapshot.erl
+++ b/src/ra_snapshot.erl
@@ -242,12 +242,11 @@ find_checkpoints(#?MODULE{current = Current,
 find_checkpoints([], State, _CurrentIdx, Checkpoints) ->
     %% Reverse so that the most recent checkpoints come first.
     State#?MODULE{checkpoints = lists:reverse(Checkpoints)};
-find_checkpoints(
-  [File | Files],
-  #?MODULE{uid = UId,
-           module = Module,
-           checkpoint_directory = CheckpointDir} = State,
-  CurrentIdx, []) ->
+find_checkpoints([File | Files],
+                 #?MODULE{uid = UId,
+                          module = Module,
+                          checkpoint_directory = CheckpointDir} = State,
+                 CurrentIdx, []) ->
     %% When we haven't yet found a valid checkpoint (`Checkpoints =:= []`),
     %% fully validate the file with the `ra_snapshot:validate/1` callback to
     %% ensure that we can recover from the latest checkpoint.
@@ -273,15 +272,14 @@ find_checkpoints(
             _ = ra_lib:recursive_delete(CP),
             find_checkpoints(Files, State, CurrentIdx, [])
     end;
-find_checkpoints(
-  [File | Files],
-  #?MODULE{uid = UId,
-           module = Module,
-           checkpoint_directory = CheckpointDir} = State,
-  CurrentIdx, Checkpoints) ->
-    %% If a valid checkpoint has already been found, delay validation for the
-    %% older remaining checkpoints until we attempt to promote them. This
-    %% reduces I/O usage on startup.
+find_checkpoints([File | Files],
+                 #?MODULE{uid = UId,
+                          module = Module,
+                          checkpoint_directory = CheckpointDir} = State,
+                 CurrentIdx, Checkpoints) ->
+    %% If a valid checkpoint has already been found it is assumed all older
+    %% checkpoints are also valid. Scanning all can introduce a lot of
+    %% additional I/O during recovery.
     CP = filename:join(CheckpointDir, File),
     case Module:read_meta(CP) of
         {ok, #{index := Idx, term := Term}} ->


### PR DESCRIPTION
@mkuratczyk noticed that with many QQs on the qq-v4 branch and each QQ having many checkpoints, we spend a fair amount of effort reading the checkpoints during recovery. This is because `ra_snapshot:find_checkpoints/1` uses the `ra_snapshot:validate/1` callback to ensure that each snapshot is valid. `validate/1` is somewhat expensive in `ra_log_snapshot` since it fully reads and decodes the checkpoint, discarding the result.

Not all of this validation is necessary: we can stop validating checkpoints when we find the latest checkpoint which is valid. This is likely to be good enough. I've also updated `find_checkpoints/1` to stop its search when it finds a checkpoint with a lower index than the current snapshot as any checkpoints lower than the snapshot index won't be used for promotion and should be removed. For many QQs with many checkpoints each this should save some I/O usage and memory.
