### PR TITLE
Add `ra_machine:snapshot_installed/4` callback to pass old state

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1342,7 +1342,8 @@ handle_receive_snapshot(#install_snapshot_rpc{term = Term,
                                       machine_versions = MachineVersions,
                                       machine = Machine} = Cfg0,
                           log := Log0,
-                          current_term := CurTerm} = State0)
+                          current_term := CurTerm,
+                          machine_state := OldMacState} = State0)
   when Term >= CurTerm ->
     ?DEBUG("~ts: receiving snapshot chunk: ~b / ~w, index ~b, term ~b",
            [LogId, Num, ChunkFlag, SnapIndex, SnapTerm]),
@@ -1377,6 +1378,8 @@ handle_receive_snapshot(#install_snapshot_rpc{term = Term,
 
             SnapInstalledEffs = ra_machine:snapshot_installed(EffMacMod,
                                                               SnapMeta,
+                                                              CurEffMacVer,
+                                                              OldMacState,
                                                               MacState),
 
             State = update_term(Term,

--- a/test/coordination_SUITE.erl
+++ b/test/coordination_SUITE.erl
@@ -1329,7 +1329,7 @@ apply(#{index := _Idx}, {segment_writer_or_wal_crash_follower, _}, State) ->
 apply(#{index := Idx}, _Cmd, State) ->
     {State, ok, [{release_cursor, Idx, State}]}.
 
-snapshot_installed(Meta, _State) ->
+snapshot_installed(Meta, _OldMacVer, _OldState, _NewState) ->
     case whereis(snapshot_installed_proc) of
         undefined ->
             [];


### PR DESCRIPTION
This adds an extended version of the existing `Machine:snapshot_installed(SnapMeta, NewState)` callback which adds parameters for the old state: the state of the machine before the snapshot was installed and also its version since the snapshot installation might cause a version bump.

```erl
Module:snapshot_installed(SnapMeta, OldMacVer, OldState, NewState)
```

This is meant for any machine that needs to diff the old and new states. For example Khepri needs this (see rabbitmq/khepri#290) to update its projections when either the projections change or any part of the tree which is covered by a projection's pattern.