### PR TITLE
ra_server: handle higher-term AERs in `receive_snapshot` state

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1411,6 +1411,16 @@ handle_receive_snapshot(#install_snapshot_rpc{term = Term,
             State = update_term(Term, State0#{log => Log}),
             {receive_snapshot, State, [{reply, Reply}]}
     end;
+handle_receive_snapshot(#append_entries_rpc{term = Term} = Msg,
+                        #{current_term := CurTerm,
+                          cfg := #cfg{log_id = LogId}} = State)
+  when Term > CurTerm ->
+    ?INFO("~ts: follower receiving snapshot saw append_entries_rpc from ~w for term ~b "
+          "abdicates term: ~b!",
+          [LogId, Msg#append_entries_rpc.leader_id,
+           Term, CurTerm]),
+    {follower, update_term(Term, clear_leader_id(State)),
+     [{next_event, Msg}]};
 handle_receive_snapshot({ra_log_event, Evt},
                         State = #{cfg := #cfg{id = _Id, log_id = LogId},
                                   log := Log0}) ->

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1413,13 +1413,17 @@ handle_receive_snapshot(#install_snapshot_rpc{term = Term,
     end;
 handle_receive_snapshot(#append_entries_rpc{term = Term} = Msg,
                         #{current_term := CurTerm,
-                          cfg := #cfg{log_id = LogId}} = State)
+                          cfg := #cfg{log_id = LogId},
+                          log := Log0} = State)
   when Term > CurTerm ->
     ?INFO("~ts: follower receiving snapshot saw append_entries_rpc from ~w for term ~b "
           "abdicates term: ~b!",
           [LogId, Msg#append_entries_rpc.leader_id,
            Term, CurTerm]),
-    {follower, update_term(Term, clear_leader_id(State)),
+    SnapState0 = ra_log:snapshot_state(Log0),
+    SnapState = ra_snapshot:abort_accept(SnapState0),
+    Log = ra_log:set_snapshot_state(SnapState, Log0),
+    {follower, update_term(Term, clear_leader_id(State#{log => Log})),
      [{next_event, Msg}]};
 handle_receive_snapshot({ra_log_event, Evt},
                         State = #{cfg := #cfg{id = _Id, log_id = LogId},


### PR DESCRIPTION
## Proposed Changes

When in `receive_snapshot` state, server should handle at least higher-term AERs gracefully. Otherwise, server could become stuck in the `receive_snapshot` state if the current snapshot sender goes away and the new leader gets elected, before snapshot transfer is complete. In this case the new leader will keep sending AERs to this stuck server, which it will ignore but (unfortunately) keep resetting `receive_snapshot_timeout` each time. This constant timer reset prevents `receive_snapshot_timeout` timer to fire, unless `receive_snapshot` timeout option is impractically small.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change, no corresponding GH issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] ~~Any dependent changes have been merged and published in related repositories~~
