### PR TITLE
ra_aux: Expose effective machine version, current term

### DIFF
--- a/src/ra_aux.erl
+++ b/src/ra_aux.erl
@@ -10,6 +10,7 @@
          effective_machine_version/1,
          leader_id/1,
          last_applied/1,
+         current_term/1,
          members_info/1,
          overview/1,
          log_last_index_term/1,
@@ -39,6 +40,10 @@ leader_id(State) ->
 
 -spec last_applied(ra_aux:internal_state()) -> ra_index().
 last_applied(State) ->
+    maps:get(?FUNCTION_NAME, State).
+
+-spec current_term(ra_aux:internal_state()) -> ra_term().
+current_term(State) ->
     maps:get(?FUNCTION_NAME, State).
 
 -spec members_info(ra_aux:internal_state()) -> ra_cluster().

--- a/src/ra_aux.erl
+++ b/src/ra_aux.erl
@@ -7,6 +7,7 @@
 
 -export([
          machine_state/1,
+         effective_machine_version/1,
          leader_id/1,
          last_applied/1,
          members_info/1,
@@ -17,6 +18,7 @@
         ]).
 
 -include("ra.hrl").
+-include("ra_server.hrl").
 
 -opaque internal_state() :: ra_server:state().
 
@@ -25,6 +27,11 @@
 -spec machine_state(ra_aux:internal_state()) -> term().
 machine_state(State) ->
     maps:get(?FUNCTION_NAME, State).
+
+-spec effective_machine_version(ra_aux:internal_state()) ->
+    ra_machine:version().
+effective_machine_version(#{cfg := Cfg}) ->
+    Cfg#cfg.effective_machine_version.
 
 -spec leader_id(ra_aux:internal_state()) -> undefined | ra_server_id().
 leader_id(State) ->


### PR DESCRIPTION
A machine might want to know the effective machine version to determine if it should emit an effect like `{append, NewCmd}` that can only be handled once a cluster reaches an effective machine version.

This change also exposes the `current_term` so that the callers of the ra_aux API have essentially the same metadata as is passed to the `RaMachine:apply/3` callback.