### PR TITLE
Handle case where mem table is deleted during segment writer flush

### DIFF
--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -683,8 +683,8 @@ handle_event({segments, TidRanges, NewSegs},
                       readers = Readers
                      } = State0) ->
     Reader = ra_log_reader:update_segments(NewSegs, Reader0),
-    %% the tid ranges arrive in the order they were written so we need to
-    %% foldr here to process the oldest first
+    %% the tid ranges arrive in the reverse order they were written
+    %% (new -> old) so we need to foldr here to process the oldest first
     Mt = lists:foldr(
            fun ({Tid, Range}, Acc0) ->
                    {Spec, Acc} = ra_mt:record_flushed(Tid, Range, Acc0),

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1761,7 +1761,9 @@ gen_statem_safe_call(ServerId, Msg, Timeout) ->
          exit:{{nodedown, _}, _} ->
             {error, nodedown};
          exit:{shutdown, _} ->
-            {error, shutdown}
+            {error, shutdown};
+         exit:{Reason, _} ->
+            {error, Reason}
     end.
 
 do_state_query(QueryName, #state{server_state = State}) ->


### PR DESCRIPTION
Handle all gen_statem:call exit types

Segment writer segref ordering bugfixes.