### PR TITLE
Check membership before transferring leadership

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -1154,8 +1154,9 @@ initial_members(ServerId) ->
 initial_members(ServerId, Timeout) ->
     ra_server_proc:state_query(ServerId, initial_members, Timeout).
 
-%% @doc Transfers leadership from the leader to a follower.
+%% @doc Transfers leadership from the leader to a voter follower.
 %% Returns `already_leader' if the transfer target is already the leader.
+%% Leadership cannot be transferred to non-voters.
 %% @end
 -spec transfer_leadership(ra_server_id(), ra_server_id()) ->
     ok | already_leader | {error, term()} | {timeout, ra_server_id()}.

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -830,11 +830,14 @@ handle_leader({transfer_leadership, ServerId},
               #{cfg := #cfg{log_id = LogId},
                 cluster := Cluster} = State) ->
     case Cluster of
-        #{ServerId := #{voter_status := #{membership := Membership}}} when Membership =/= voter ->
-            ?DEBUG("~ts: transfer leadership requested but non-voter member ~w", [LogId, ServerId]),
-            {leader, State, [{reply, {error, non_voter_member}}]};
+        #{ServerId := #{voter_status := #{membership := Membership}}}
+          when Membership =/= voter ->
+            ?INFO("~ts: transfer leadership requested but non-voter member ~w",
+                  [LogId, ServerId]),
+            {leader, State, [{reply, {error, non_voter}}]};
         _ ->
-            ?DEBUG("~ts: transfer leadership to ~w requested", [LogId, ServerId]),
+            ?DEBUG("~ts: transfer leadership to ~w requested",
+                   [LogId, ServerId]),
             %% TODO find a timeout
             gen_statem:cast(ServerId, try_become_leader),
             {await_condition,

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -1233,7 +1233,7 @@ transfer_leadership(Config) ->
     {ok, _, _} = ra:add_member(NewLeader, NonVoterMember),
     ok = ra:start_server(default, Name, NonVoterMember, add_machine(), Members),
     ct:pal("Transferring leadership from ~p to ~p", [NewLeader, NonVoterMemberId]),
-    ?assertEqual({error, non_voter_member}, ra:transfer_leadership(NewLeader, NonVoterMemberId)),
+    ?assertEqual({error, non_voter}, ra:transfer_leadership(NewLeader, NonVoterMemberId)),
     terminate_cluster([NonVoterMemberId | Members]).
 
 transfer_leadership_two_node(Config) ->


### PR DESCRIPTION
Hi,

During the testing with the current `ra` library, we noticed that leadership can be transferred to a non-voter member. We think non-voter members should not hold leadership.

## Proposed Changes

- Added a membership check to ensure the target `ServerId` is a voter member.
- If the target is not a voter, return a `non_voter_member` error.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
