### PR TITLE
Fix segment read bug when segment has been appended to

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1728,7 +1728,7 @@ machine_query(QueryFun, #{cfg := #cfg{effective_machine_module = MacMod},
 become(leader, OldRaftState, #{cluster := Cluster,
                                cluster_change_permitted := CCP0,
                                log := Log0} = State) ->
-    Log = ra_log:release_resources(maps:size(Cluster) + 2, random, Log0),
+    Log = ra_log:release_resources(maps:size(Cluster), sequential, Log0),
     CCP = case OldRaftState of
               await_condition ->
                   CCP0;

--- a/test/ra_log_segment_writer_SUITE.erl
+++ b/test/ra_log_segment_writer_SUITE.erl
@@ -800,10 +800,10 @@ segments_for(UId, DataDir) ->
     SegFiles.
 
 read_sparse(R, Idxs) ->
-    {_, Entries} = ra_log_segment:read_sparse(R, Idxs,
-                                              fun(I, T, B, Acc) ->
-                                                      [{I, T, B} | Acc]
-                                              end, []),
+    {ok, _, Entries} = ra_log_segment:read_sparse(R, Idxs,
+                                                  fun(I, T, B, Acc) ->
+                                                          [{I, T, B} | Acc]
+                                                  end, []),
     lists:reverse(Entries).
 
 get_names(System) when is_atom(System) ->


### PR DESCRIPTION
Detect when a segment has been modified.

When executing a read plan it is possible that the read plan
refers to indexes not in the index of an segment that is still
being written to. This commit handles that change.