### PR TITLE
Segment fadvise

### DIFF
--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -21,7 +21,7 @@
          fold/5,
          sparse_read/2,
          partial_read/3,
-         execute_read_plan/3,
+         execute_read_plan/4,
          read_plan_info/1,
          last_index_term/1,
          set_last_index/2,
@@ -210,7 +210,7 @@ init(#{uid := UId,
                               Curr -> Curr
                           end,
 
-    AccessPattern = maps:get(initial_access_pattern, Conf, random),
+    AccessPattern = maps:get(initial_access_pattern, Conf, sequential),
     {ok, Mt0} = ra_log_ets:mem_table_please(Names, UId),
     % recover current range and any references to segments
     % this queries the segment writer and thus blocks until any
@@ -558,12 +558,15 @@ partial_read(Indexes0, #?MODULE{cfg = Cfg,
 
 
 -spec execute_read_plan(read_plan(), undefined | ra_flru:state(),
-                        TransformFun :: transform_fun()) ->
+                        TransformFun :: transform_fun(),
+                        ra_log_reader:read_plan_options()) ->
     {#{ra_index() => Command :: term()}, ra_flru:state()}.
 execute_read_plan(#read_plan{dir = Dir,
                              read = Read,
-                             plan = Plan}, Flru0, TransformFun) ->
-    ra_log_reader:exec_read_plan(Dir, Plan, Flru0, TransformFun, Read).
+                             plan = Plan}, Flru0, TransformFun,
+                  Options) ->
+    ra_log_reader:exec_read_plan(Dir, Plan, Flru0, TransformFun,
+                                 Options, Read).
 
 -spec read_plan_info(read_plan()) -> map().
 read_plan_info(#read_plan{read = Read,

--- a/src/ra_log_read_plan.erl
+++ b/src/ra_log_read_plan.erl
@@ -8,12 +8,22 @@
 
 
 -export([execute/2,
+         execute/3,
          info/1]).
 
 -spec execute(ra_log:read_plan(), undefined | ra_flru:state()) ->
     {#{ra:index() => Command :: term()}, ra_flru:state()}.
 execute(Plan, Flru) ->
-    ra_log:execute_read_plan(Plan, Flru, fun ra_server:transform_for_partial_read/3).
+    execute(Plan, Flru, #{access_pattern => random,
+                          file_advise => normal}).
+
+-spec execute(ra_log:read_plan(), undefined | ra_flru:state(),
+              ra_log_reader:read_plan_options()) ->
+    {#{ra:index() => Command :: term()}, ra_flru:state()}.
+execute(Plan, Flru, Options) ->
+    ra_log:execute_read_plan(Plan, Flru,
+                             fun ra_server:transform_for_partial_read/3,
+                             Options).
 
 -spec info(ra_log:read_plan()) -> map().
 info(Plan) ->

--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -426,6 +426,12 @@ close(#state{cfg = #cfg{fd = Fd, mode = append}} = State) ->
     % close needs to be defensive and idempotent so we ignore the return
     % values here
     _ = sync(State),
+    case is_full(State) of
+        true ->
+            _ = file:advise(Fd, 0, 0, dont_need);
+        false ->
+            ok
+    end,
     _ = file:close(Fd),
     ok;
 close(#state{cfg = #cfg{fd = Fd}}) ->

--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -577,6 +577,7 @@ roll_over(#state{wal = Wal0, file_num = Num0,
                            Half + rand:uniform(Half);
                        #wal{ranges = Ranges,
                             filename = Filename} ->
+                           _ = file:advise(Wal0#wal.fd, 0, 0, dont_need),
                            ok = close_file(Wal0#wal.fd),
                            MemTables = Ranges,
                            %% TODO: only keep base name in state

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -409,12 +409,10 @@ recover(#{cfg := #cfg{log_id = LogId,
     FromScan = CommitIndex + 1,
     {ToScan, _} = ra_log:last_index_term(Log0),
     ?DEBUG("~ts: scanning for cluster changes ~b:~b ", [LogId, FromScan, ToScan]),
-    {State, Log1} = ra_log:fold(FromScan, ToScan,
-                                fun cluster_scan_fun/2,
-                                State1, Log0),
+    {State, Log} = ra_log:fold(FromScan, ToScan,
+                               fun cluster_scan_fun/2,
+                               State1, Log0),
 
-    %% disable segment read cache by setting random access pattern
-    Log = ra_log:release_resources(1, random, Log1),
     put_counter(Cfg, ?C_RA_SVR_METRIC_COMMIT_LATENCY, 0),
     State#{log => Log,
            %% reset commit latency as recovery may calculate a very old value

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -519,6 +519,10 @@ read_plan(Config) ->
     ReadPlan = ra_log:partial_read(Indexes, Log4, fun (_, _, Cmd) -> Cmd end),
     ?assert(is_map(ra_log_read_plan:info(ReadPlan))),
     {EntriesOut, _} = ra_log_read_plan:execute(ReadPlan, undefined),
+    %% try again with different read plan options
+    {EntriesOut, _} = ra_log_read_plan:execute(ReadPlan, undefined,
+                                               #{access_pattern => sequential,
+                                                 file_advise => random}),
     ?assertEqual(length(Indexes), maps:size(EntriesOut)),
     %% assert the indexes requestd were all returned in order
     [] = Indexes -- [I || I <- maps:keys(EntriesOut)],


### PR DESCRIPTION
Make segment fadvise option configurable.

It is not clear if `random` or `normal` is the better option for external read plan segment reads so this is now configurable.

This setting also affects segments opened for append as when the segment is full and is closed we perform an fadvise call. By default this is set to `dont_need` to ensure page cache data is reclaimed after a segment flush.

When closing the WAL we also set `dont_need` advise as this data is unlikely to ever be read again.

