### PR TITLE
Introduce initial_machine_version server config.

### DIFF
--- a/test/ra_dbg_SUITE.erl
+++ b/test/ra_dbg_SUITE.erl
@@ -77,7 +77,8 @@ execute_state_machine() ->
   %% creating a new WAL file with ra_fifo
   [Srv] = Nodes = [{ra_dbg, node()}],
   ClusterId = ra_dbg,
-  Config = #{name => ClusterId},
+  Config = #{name => ClusterId,
+             machine_version => 0},
   Machine = {module, ra_fifo, Config},
   ra:start(),
   {ok, _, _} = ra:start_cluster(default, ClusterId, Machine, Nodes),


### PR DESCRIPTION
This new key can be used to specify the initial machine version
a new Ra server should be initialised against.

This allows machines to skip old versions when creating a new
Ra cluster.  This is particularly useful when machine_version_strategy=all
as the initial machine upgrade upgrade after cluster creation is delayed until
all members reply to the info requests.

If the machine_version_strategy=all, starting a server with
an initial machine version that is higher than the locally available
machine version will result in an error: {error, invalid_initial_machine_version}.

When machine_version_strategy=quorum the initial machine version
will be clamped to the locally available machine version.

Fixes #497 
