### PR TITLE
Enable async_dist by default for Ra server processes.

### DIFF
--- a/src/ra_system.erl
+++ b/src/ra_system.erl
@@ -58,8 +58,8 @@
                     low_priority_commands_flush_size => non_neg_integer(),
                     low_priority_commands_in_memory_size => non_neg_integer(),
                     server_recovery_strategy => undefined |
-                                               registered |
-                                               {module(), atom(), list()}
+                                                registered |
+                                                {module(), atom(), list()}
                    }.
 
 -export_type([

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -117,15 +117,16 @@ end_per_testcase(_TestCase, Config) ->
     Config.
 
 single_server_processes_command(Config) ->
-    % ok = logger:set_primary_config(level, all),
     Name = ?config(test_name, Config),
-    N1 = nth_server_name(Config, 1),
+    {_RaName, _} = N1 = nth_server_name(Config, 1),
     ok = ra:start_server(default, Name, N1, add_machine(), []),
     ok = ra:trigger_election(N1),
     % index is 2 as leaders commit a no-op entry on becoming leaders
+    monitor(process, element(1, N1)),
     {ok, 5, _} = ra:process_command(N1, 5, 2000),
     {ok, 10, _} = ra:process_command(N1, 5, 2000),
-    terminate_cluster([N1]).
+    terminate_cluster([N1]),
+    ok.
 
 pipeline_commands(Config) ->
     Name = ?config(test_name, Config),


### PR DESCRIPTION
Enable async_dist by default for Ra server processes for remote nodes.

This will allow users to simplify their Ra client implementations
not to have to handle lost messages as could occur
when the distribution buffer fills.