### PR TITLE
Force pipelined rpcs for noop command.

### DIFF
--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1331,7 +1331,7 @@ handle_effects(RaftState, Effects0, EvtType, State0, Actions0) ->
                          end, {State0, Actions0}, Effects0),
     {State, lists:reverse(Actions)}.
 
-handle_effect(leader, {send_rpc, To, Rpc}, _,
+handle_effect(_RaftState, {send_rpc, To, Rpc}, _,
               #state{conf = Conf} = State0, Actions) ->
     % fully qualified use only so that we can mock it for testing
     % TODO: review / refactor to remove the mod call here

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1873,19 +1873,24 @@ candidate_election(_Config) ->
     {leader, #{cluster := #{N2 := PeerState,
                             N3 := PeerState,
                             N4 := PeerState,
-                            N5 := PeerState}},
+                            N5 := PeerState}} = State2,
      [
-      {next_event, cast, {command, {noop, _, EffectiveMacVer}}},
+      {next_event, cast, {command, {noop, _, EffectiveMacVer}} = Noop},
       {send_rpc, N2, {info_rpc, _, _, _}},
       {send_rpc, N3, {info_rpc, _, _, _}},
       {send_rpc, N4, {info_rpc, _, _, _}},
-      {send_rpc, N5, {info_rpc, _, _, _}},
+      {send_rpc, N5, {info_rpc, _, _, _}}
 
-      {send_rpc, _, _},
-      {send_rpc, _, _},
-      {send_rpc, _, _},
-      {send_rpc, _, _}
-     ]} = ra_server:handle_candidate(Reply, State1).
+     ]} = ra_server:handle_candidate(Reply, State1),
+
+    {leader, _,
+     [
+      {send_rpc, N5, #append_entries_rpc{}},
+      {send_rpc, N4, _},
+      {send_rpc, N3, _},
+      {send_rpc, N2, _}
+     ]} = ra_server:handle_leader(Noop, State2),
+    ok.
 
 pre_vote_election(_Config) ->
     Token = make_ref(),


### PR DESCRIPTION
Instead of the candidate sending a set of empty rpcs before entering leader state, ensure rpcs are sent for all followers by forcing pipelined rpcs to be generated when the command is a noop command.

This fixes potential issues with leader election timeliness.
