### PR TITLE
Fix last_index counter lag

### DIFF
--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -398,7 +398,7 @@ append({Idx, Term, _Cmd} = Entry,
       when Idx =:= LastIdx + 1 ->
     case ra_mt:stage(Entry, Mt0) of
         {ok, Mt} ->
-            put_counter(Cfg, ?C_RA_SVR_METRIC_LAST_INDEX, LastIdx),
+            put_counter(Cfg, ?C_RA_SVR_METRIC_LAST_INDEX, Idx),
             State#?MODULE{last_index = Idx,
                           last_term = Term,
                           mem_table = Mt};

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -160,6 +160,10 @@ pipeline_commands(Config) ->
     %% here we are asserting on the order of received
     %% correlations
     [{C1, 15}, {C2, 20}] = gather_applied([], 125),
+    ?assertMatch(#{last_index := I,
+                   last_applied := I,
+                   last_written_index := I,
+                   commit_index := I}, ra:key_metrics(N1)),
     terminate_cluster([N1]).
 
 stop_server_idemp(Config) ->


### PR DESCRIPTION
When the leader is writing a low priority command it updated the last_index counter to the last index not the index it just wrote.
