### PR TITLE
Bump cluster formation an default (library-wide) timeouts

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -92,7 +92,7 @@
 -deprecated({overview, 0}).
 -deprecated({register_external_log_reader, 1}).
 
--define(START_TIMEOUT, ?DEFAULT_TIMEOUT).
+-define(START_TIMEOUT, 30_000).
 
 -type ra_cmd_ret() :: ra_server_proc:ra_cmd_ret().
 

--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -239,7 +239,7 @@
                                                         domain => [ra]}),
        ok).
 
--define(DEFAULT_TIMEOUT, 5000).
+-define(DEFAULT_TIMEOUT, 20000).
 
 -define(DEFAULT_SNAPSHOT_MODULE, ra_log_snapshot).
 

--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -239,7 +239,7 @@
                                                         domain => [ra]}),
        ok).
 
--define(DEFAULT_TIMEOUT, 20000).
+-define(DEFAULT_TIMEOUT, 20_000).
 
 -define(DEFAULT_SNAPSHOT_MODULE, ra_log_snapshot).
 


### PR DESCRIPTION
There is no such thing as the "right" timeout in distributed systems but some are too prone to false positives in loaded systems. 5s timeouts is one example, based on well over a decade of RabbitMQ engineering experience (and not just in the Ra/Raft-based features, everywhere, including in memory-only channels in some cases).