### PR TITLE
Replication bug fixes

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -480,13 +480,13 @@ handle_leader({PeerId, #append_entries_reply{term = Term, success = true,
             State1 = put_peer(PeerId, Peer, State0),
             Effects00 = maybe_promote_peer(PeerId, State1, []),
             {State2, Effects0} = evaluate_quorum(State1, Effects00),
-            {State, Effects1} = process_pending_consistent_queries(State2,
+            {State3, Effects1} = process_pending_consistent_queries(State2,
                                                                    Effects0),
-            Effects = [{next_event, info, pipeline_rpcs} | Effects1],
-            case State of
+            Effects2 = [{next_event, info, pipeline_rpcs} | Effects1],
+            case State3 of
                 #{cluster := #{Id := _}} ->
                     % leader is in the cluster
-                    {leader, State, Effects};
+                    {leader, State3, Effects2};
                 #{commit_index := CI,
                   cluster_index_term := {CITIndex, _}}
                   when CI >= CITIndex ->
@@ -494,9 +494,12 @@ handle_leader({PeerId, #append_entries_reply{term = Term, success = true,
                     % config has been committed
                     % time to say goodbye
                     ?INFO("~ts: leader not in new cluster - goodbye", [LogId]),
+                    %% need to make pipelined rpcs here as cannot use next event
+                    {State, _, Effects} =
+                        make_pipelined_rpc_effects(State3, Effects2),
                     {stop, State, Effects};
                 _ ->
-                    {leader, State, Effects}
+                    {leader, State3, Effects2}
             end
     end;
 handle_leader({PeerId, #append_entries_reply{term = Term}},
@@ -1257,15 +1260,9 @@ handle_follower(#append_entries_rpc{term = Term,
                             evaluate_commit_index_follower(State#{log => Log2},
                                                            Effects0);
                         {error, wal_down} ->
-                            %% at this point we know the wal process exited
+                            %% At this point we know the wal process exited
                             %% but we dont know exactly which in flight messages
                             %% made it to the wal before it crashed.
-                            %% TODO: we cannot discover what the last index
-                            %% the WAL wrote was anymore as the WAL does
-                            %% not write the mem tables. We could implement something
-                            %% alternative where the WAL writes the last index, term
-                            %% it wrote for each UID into an ETS table and query
-                            %% this.
                             {await_condition,
                              State#{log => Log1,
                                     condition =>
@@ -1291,7 +1288,6 @@ handle_follower(#append_entries_rpc{term = Term,
                                    transition_to => follower}}},
              Effects};
         {term_mismatch, OtherTerm, Log0} ->
-            %% NB: this is the commit index before update
             LastApplied = maps:get(last_applied, State00),
             ?INFO("~ts: term mismatch - follower had entry at ~b with term ~b "
                   "but not with term ~b. "
@@ -1305,7 +1301,7 @@ handle_follower(#append_entries_rpc{term = Term,
             % is rewind back and use the last applied as the last index
             % and last applied + 1 as the next expected.
             % This _may_ overwrite some valid entries but is probably the
-            % simplest way to proceed
+            % simplest and most reliable way to proceed
             {Reply, State} = mismatch_append_entries_reply(Term, LastApplied,
                                                            State0),
             Effects = [cast_reply(Id, LeaderId, Reply) | Effects0],
@@ -2086,11 +2082,15 @@ make_pipelined_rpc_effects(#{cfg := #cfg{id = Id,
                                    end,
                       %% ensure we don't pass a batch size that would allow
                       %% the peer to go over the max pipeline count
-                      BatchSize = min(MaxBatchSize,
-                                      MaxPipelineCount - NumInFlight),
+                      %% we'd only really get here if Force=true so setting
+                      %% a single entry batch size should be fine
+                      BatchSize = max(1,
+                                      min(MaxBatchSize,
+                                          MaxPipelineCount - NumInFlight)),
                       {NewNextIdx, Eff, S} =
                           make_rpc_effect(PeerId, Peer0, BatchSize, S0,
                                           EntryCache),
+                      ?assert(NewNextIdx >= NextIdx),
                       Peer = Peer0#{next_index => NewNextIdx,
                                     commit_index_sent => CommitIndex},
                       NewNumInFlight = NewNextIdx - MatchIdx - 1,
@@ -2149,12 +2149,17 @@ make_rpc_effect(PeerId, #{next_index := Next}, MaxBatchSize,
                                             PrevTerm, MaxBatchSize,
                                             State#{log => Log},
                                             EntryCache);
-                {LastIdx, _} ->
+                {SnapIdx, _} ->
+                    ?DEBUG("~ts: sending snapshot to ~w as their next index ~b "
+                           "is lower than snapshot index ~b", [log_id(State),
+                                                               PeerId, Next,
+                                                               SnapIdx]),
+                    ?assert(PrevIdx < SnapIdx),
                     SnapState = ra_log:snapshot_state(Log),
                     %% don't increment the next index here as we will do
                     %% that once the snapshot is fully replicated
                     %% and we don't pipeline entries until after snapshot
-                    {LastIdx,
+                    {SnapIdx,
                      {send_snapshot, PeerId, {SnapState, Id, Term}},
                      State#{log => Log}}
             end
@@ -2861,16 +2866,16 @@ apply_with({Idx, Term, {'$ra_cluster_change', CmdMeta, NewCluster, ReplyMode}},
     State = case State0 of
                 #{cluster_index_term := {CI, CT}}
                   when Idx > CI andalso Term >= CT ->
-                    ?DEBUG("~ts: applying ra cluster change to ~w",
-                           [log_id(State0), maps:keys(NewCluster)]),
+                    ?DEBUG("~ts: applying ra cluster change at index ~b to ~w",
+                           [log_id(State0), Idx, maps:keys(NewCluster)]),
                     %% we are recovering and should apply the cluster change
                     State0#{cluster => NewCluster,
                             membership => get_membership(NewCluster, State0),
                             cluster_change_permitted => true,
                             cluster_index_term => {Idx, Term}};
                 _  ->
-                    ?DEBUG("~ts: committing ra cluster change to ~w",
-                           [log_id(State0), maps:keys(NewCluster)]),
+                    ?DEBUG("~ts: committing ra cluster change at index ~b to ~w",
+                           [log_id(State0), Idx, maps:keys(NewCluster)]),
                     %% else just enable further cluster changes again
                     State0#{cluster_change_permitted => true}
             end,
@@ -3078,17 +3083,23 @@ pre_append_log_follower({Idx, Term, Cmd} = Entry,
     % cluster
     case Cmd of
         {'$ra_cluster_change', _, Cluster, _} ->
+            ?DEBUG("~ts: ~ts: follower applying ra cluster change to ~w",
+                   [log_id(State), ?FUNCTION_NAME, maps:keys(Cluster)]),
             State#{cluster => Cluster,
                    cluster_index_term => {Idx, Term}};
         _ ->
             % revert back to previous cluster
             {PrevIdx, PrevTerm, PrevCluster} = maps:get(previous_cluster, State),
+            ?DEBUG("~ts: ~ts: follower reverting cluster change to ~w",
+                   [log_id(State), ?FUNCTION_NAME, maps:keys(PrevCluster)]),
             State1 = State#{cluster => PrevCluster,
                             cluster_index_term => {PrevIdx, PrevTerm}},
             pre_append_log_follower(Entry, State1)
     end;
 pre_append_log_follower({Idx, Term, {'$ra_cluster_change', _, Cluster, _}},
                         State) ->
+    ?DEBUG("~ts: ~ts: follower applying ra cluster change to ~w",
+           [log_id(State), ?FUNCTION_NAME, maps:keys(Cluster)]),
     State#{cluster => Cluster,
            membership => get_membership(Cluster, State),
            cluster_index_term => {Idx, Term}};
@@ -3132,11 +3143,6 @@ mismatch_append_entries_reply(Term, LastAppliedIdx, State0) ->
      State}.
 
 append_entries_reply(Term, Success, #{log := Log} = State) ->
-    % we can't use the the last received idx
-    % as it may not have been persisted yet
-    % also we can't use the last writted Idx as then
-    % the follower may resent items that are currently waiting to
-    % be written.
     {LWIdx, LWTerm} = ra_log:last_written(Log),
     {LastIdx, _} = last_idx_term(State),
     #append_entries_reply{term = Term,

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1225,18 +1225,22 @@ handle_follower(#append_entries_rpc{term = Term,
                             {NextState, State,
                              [cast_reply(Id, LeaderId, Reply) | Effects]};
                         false ->
-                            %% We need to ensure we make progress in case
-                            %% the last applied index is lower than the last
-                            %% valid index
+                            %% We need to ensure we make progress in case the
+                            %% leader is having to resend already received
+                            %% entries in order to validate, e.g. after a
+                            %% term_mismatch, hence we reply with success but
+                            %% only up to the last index we already had
                             LastValidatedIdx = max(LastApplied, LastValidIdx),
                             ?DEBUG("~ts: append_entries_rpc with last index ~b "
                                    " including ~b entries did not validate local log. "
-                                   "Requesting resend from index ~b",
-                                   [LogId, PLIdx, length(Entries0),
-                                    LastValidatedIdx + 1]),
-                            {Reply, State} =
-                                mismatch_append_entries_reply(Term, LastValidatedIdx,
-                                                              State0#{log => Log2}),
+                                   "Local last index ~b",
+                                   [LogId, PLIdx, length(Entries0), LocalLastIdx]),
+                            {LVTerm, State} = fetch_term(LastValidatedIdx, State0),
+                            Reply = #append_entries_reply{term = CurTerm,
+                                                          success = true,
+                                                          next_index = LastValidatedIdx + 1,
+                                                          last_index = LastValidatedIdx,
+                                                          last_term = LVTerm},
                             {follower, State,
                              [cast_reply(Id, LeaderId, Reply)]}
                     end;
@@ -1246,14 +1250,12 @@ handle_follower(#append_entries_rpc{term = Term,
                                      LeaderCommit),
                     %% assert we're not writing below the last applied index
                     ?assertNot(FstIdx < LastApplied),
-                    State2 = lists:foldl(fun pre_append_log_follower/2,
-                                         State1, Entries),
+                    State = lists:foldl(fun pre_append_log_follower/2,
+                                        State1, Entries),
                     case ra_log:write(Entries, Log1) of
                         {ok, Log2} ->
-                            {NextState, State, Effects} =
-                                evaluate_commit_index_follower(State2#{log => Log2},
-                                                               Effects0),
-                                {NextState, State, Effects};
+                            evaluate_commit_index_follower(State#{log => Log2},
+                                                           Effects0);
                         {error, wal_down} ->
                             %% at this point we know the wal process exited
                             %% but we dont know exactly which in flight messages
@@ -1265,9 +1267,9 @@ handle_follower(#append_entries_rpc{term = Term,
                             %% it wrote for each UID into an ETS table and query
                             %% this.
                             {await_condition,
-                             State2#{log => Log1,
-                                     condition =>
-                                     #{predicate_fun => fun wal_down_condition/2}},
+                             State#{log => Log1,
+                                    condition =>
+                                        #{predicate_fun => fun wal_down_condition/2}},
                              Effects0};
                         {error, _} = Err ->
                             exit(Err)
@@ -1342,20 +1344,23 @@ handle_follower(#heartbeat_rpc{leader_id = LeaderId,
                   cfg := #cfg{id = Id}} = State) ->
     Reply = heartbeat_reply(CurTerm, QueryIndex),
     {follower, State, [cast_reply(Id, LeaderId, Reply)]};
-handle_follower({ra_log_event, {written, _, _} = Evt},
-                State0 = #{log := Log0,
-                           cfg := #cfg{id = Id},
-                           leader_id := LeaderId,
-                           current_term := Term})
-  when LeaderId =/= undefined ->
+handle_follower({ra_log_event, Evt}, #{log := Log0,
+                                       cfg := #cfg{id = Id},
+                                       leader_id := LeaderId,
+                                       current_term := Term} = State0) ->
+    % forward events to ra_log
+    % if the last written changes then send an append entries reply
+    LW = ra_log:last_written(Log0),
     {Log, Effects} = ra_log:handle_event(Evt, Log0),
     State = State0#{log => Log},
-    Reply = append_entries_reply(Term, true, State),
-    {follower, State, [cast_reply(Id, LeaderId, Reply) | Effects]};
-handle_follower({ra_log_event, Evt}, State = #{log := Log0}) ->
-    % simply forward all other events to ra_log
-    {Log, Effects} = ra_log:handle_event(Evt, Log0),
-    {follower, State#{log => Log}, Effects};
+    case LW =/= ra_log:last_written(Log) of
+        true when LeaderId =/= undefined ->
+            %% last written has changed so we need to send an AER reply
+            Reply = append_entries_reply(Term, true, State),
+            {follower, State, [cast_reply(Id, LeaderId, Reply) | Effects]};
+        _ ->
+            {follower, State, Effects}
+    end;
 handle_follower(#pre_vote_rpc{},
                 #{cfg := #cfg{log_id = LogId},
                   membership := Membership} = State) when Membership =/= voter ->
@@ -2180,7 +2185,10 @@ log_read(From0, To, Cache, Log0) ->
     {From, Entries0} = log_fold_cache(From0, To, Cache, []),
     ra_log:fold(From, To, fun (E, A) -> [E | A] end, Entries0, Log0).
 
-log_fold_cache(From, To, [{From, _, _} = Entry | Rem], Acc) ->
+%% this cache is a bit so and so as it will only really work when each follower
+%% begins with the same from index
+log_fold_cache(From, To, [{From, _, _} = Entry | Rem], Acc)
+  when From =< To ->
     log_fold_cache(From + 1, To, Rem, [Entry | Acc]);
 log_fold_cache(From, _To, _Cache, Acc) ->
     {From, Acc}.

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1142,17 +1142,20 @@ handle_enter(RaftState, OldRaftState,
     {ServerState, Effects} = ra_server:handle_state_enter(RaftState,
                                                           OldRaftState,
                                                           ServerState0),
+    LastApplied = do_state_query(last_applied, State),
     case RaftState == leader orelse OldRaftState == leader of
         true ->
             %% ensure transitions from and to leader are logged at a higher
             %% level
-            ?NOTICE("~ts: ~s -> ~s in term: ~b machine version: ~b",
+            ?NOTICE("~ts: ~s -> ~s in term: ~b machine version: ~b, last applied ~b",
                     [log_id(State), OldRaftState, RaftState,
-                     current_term(State), machine_version(State)]);
+                     current_term(State), machine_version(State),
+                     LastApplied]);
         false ->
-            ?DEBUG("~ts: ~s -> ~s in term: ~b machine version: ~b",
+            ?DEBUG("~ts: ~s -> ~s in term: ~b machine version: ~b, last applied ~b",
                    [log_id(State), OldRaftState, RaftState,
-                    current_term(State), machine_version(State)])
+                    current_term(State), machine_version(State),
+                    LastApplied])
     end,
     handle_effects(RaftState, Effects, cast,
                    State#state{server_state = ServerState}).

--- a/test/coordination_SUITE.erl
+++ b/test/coordination_SUITE.erl
@@ -43,6 +43,7 @@ all_tests() ->
      start_cluster_majority,
      start_cluster_minority,
      grow_cluster,
+     shrink_cluster_with_snapshot,
      send_local_msg,
      local_log_effect,
      leaderboard,
@@ -380,6 +381,45 @@ grow_cluster(Config) ->
     undefined = rpc:call(BNode, ra_leaderboard, lookup_leader, [ClusterName]),
 
     stop_peers(Peers),
+    ok.
+
+shrink_cluster_with_snapshot(Config) ->
+    %% this test removes leaders to ensure the remaining cluster can
+    %% resume activity ok
+    PrivDir = ?config(data_dir, Config),
+    ClusterName = ?config(cluster_name, Config),
+    Peers = start_peers([s1,s2,s3], PrivDir),
+    ServerIds = server_ids(ClusterName, Peers),
+    [A, B, C] = ServerIds,
+
+    Machine = {module, ?MODULE, #{}},
+    {ok, _, []} = ra:start_cluster(?SYS, ClusterName, Machine, ServerIds),
+    {ok, _, Leader1} = ra:members(ServerIds),
+
+    %% run some activity to create a snapshot
+    [_ = ra:process_command(Leader1, {banana, I})
+      || I <- lists:seq(1, 5000)],
+
+    Fun = fun F(L0) ->
+                  {ok, _, L} = ra:process_command(L0, banana),
+                  F(L)
+          end,
+    Pid = spawn(fun () -> Fun(Leader1) end),
+    timer:sleep(100),
+
+    exit(Pid, kill),
+    {ok, _, _} = ra:remove_member(Leader1, Leader1),
+
+
+    timer:sleep(500),
+
+    {ok, _, Leader2} = ra:members(ServerIds),
+
+    ct:pal("old leader ~p, new leader ~p", [Leader1, Leader2]),
+    {ok, O, _} = ra:member_overview(Leader2),
+    ct:pal("overview2 ~p", [O]),
+    stop_peers(Peers),
+    ?assertMatch(#{cluster_change_permitted := true}, O),
     ok.
 
 send_local_msg(Config) ->

--- a/test/ra_2_SUITE.erl
+++ b/test/ra_2_SUITE.erl
@@ -361,8 +361,9 @@ diverged_follower(Config) ->
     ra:stop_server(?SYS, F2),
 
     %% use pipeline as wont be able to commit
-    ra:pipeline_command(LeaderId1, {enq, d3}, make_ref()),
-    ra:pipeline_command(LeaderId1, {enq, d4}, make_ref()),
+    [
+    ra:pipeline_command(LeaderId1, {enq, I}, make_ref())
+    || I <- lists:seq(3, 100)],
 
     %% stop leader
     ra:stop_server(?SYS, LeaderId1),
@@ -393,6 +394,7 @@ diverged_follower(Config) ->
 
               [[m1, m2, m3, m4, m5]] == lists:usort(States)
       end, 50),
+    flush(),
 
     ra:delete_cluster(Peers),
     ok.
@@ -898,8 +900,8 @@ init(_) ->
 state_enter(eol = S, State) ->
     ct:pal("state_enter ~w ~w", [self(), S]),
     [{send_msg, P, eol, ra_event} || {P, _} <- queue:to_list(State), is_pid(P)];
-state_enter(S, _) ->
-    ct:pal("state_enter ~w ~w", [self(), S]),
+state_enter(_S, _) ->
+    % ct:pal("state_enter ~w ~w", [self(), S]),
     [].
 
 flush() ->

--- a/test/ra_log_memory.erl
+++ b/test/ra_log_memory.erl
@@ -20,6 +20,8 @@
          fetch_term/2,
          flush/2,
          next_index/1,
+         snapshot_state/1,
+         set_snapshot_state/2,
          install_snapshot/3,
          read_snapshot/1,
          recover_snapshot/1,
@@ -40,13 +42,13 @@
 -include("src/ra.hrl").
 
 -type ra_log_memory_meta() :: #{atom() => term()}.
--type snapshot() :: {snapshot_meta(), term()}.
 
 -record(state, {last_index = 0 :: ra_index(),
                 last_written = {0, 0} :: ra_idxterm(), % only here to fake the async api of the file based one
-                entries = #{0 => {0, undefined}} :: #{ra_term() => {ra_index(), term()}},
+                entries = #{0 => {0, undefined}} ::
+                    #{ra_term() => {ra_index(), term()}},
                 meta = #{} :: ra_log_memory_meta(),
-                snapshot :: option(snapshot())}).
+                snapshot :: option({ra_snapshot:meta(), term()})}).
 
 -type ra_log_memory_state() :: #state{} | ra_log:state().
 
@@ -168,13 +170,18 @@ last_written(#state{last_written = LastWritten}) ->
 
 -spec handle_event(ra_log:event_body(), ra_log_memory_state()) ->
     {ra_log_memory_state(), list()}.
-handle_event({written, Term, {_From, Idx}}, State0) ->
+handle_event({written, Term, {_From, Idx} = Range0}, State0) ->
     case fetch_term(Idx, State0) of
         {Term, State} ->
             {State#state{last_written = {Idx, Term}}, []};
         _ ->
-            % if the term doesn't match we just ignore it
-            {State0, []}
+            case ra_range:limit(Idx, Range0) of
+                undefined ->
+                    % if the term doesn't match we just ignore it
+                    {State0, []};
+                Range ->
+                    handle_event({written, Term, Range}, State0)
+            end
     end;
 handle_event(_Evt, State0) ->
             {State0, []}.
@@ -203,17 +210,17 @@ fetch_term(Idx, #state{entries = Log} = State) ->
 
 flush(_Idx, Log) -> Log.
 
--spec install_snapshot(SnapshotMeta :: ra_snapshot:meta(),
-                       SnapshotData :: term(),
-                       State :: ra_log_memory_state()) ->
-    {ra_log_memory_state(), term(), list()}.
-install_snapshot(Meta, Data, #state{entries = Log0} = State) ->
-    Index  = maps:get(index, Meta),
+install_snapshot({Index, Term}, Data, #state{entries = Log0} = State) ->
+    % Index  = maps:get(index, Meta),
+    % Term  = maps:get(term, Meta),
     % discard log
     Log = maps:filter(fun (K, _) -> K > Index end, Log0),
-    {State#state{entries = Log, snapshot = {Meta, Data}}, Data, []};
-install_snapshot(_Meta, Data, State) ->
-    {State, Data, []}.
+    {State#state{entries = Log,
+                 last_index = Index,
+                 last_written = {Index, Term},
+                 snapshot = Data}, []};
+install_snapshot(_Meta, _Data, State) ->
+    {State, []}.
 
 -spec read_snapshot(State :: ra_log_memory_state()) ->
     {ok, ra_snapshot:meta(), term()}.
@@ -224,9 +231,14 @@ read_snapshot(#state{snapshot = {Meta, Data}}) ->
     undefined | {ok, ra_snapshot:meta(), term()}.
 recover_snapshot(#state{snapshot = undefined}) ->
     undefined;
-recover_snapshot(#state{snapshot = {Meta, Data}}) ->
-    {Meta, Data}.
+recover_snapshot(#state{snapshot = {Meta, MacState}}) ->
+    {Meta, MacState}.
 
+set_snapshot_state(SnapState, State) ->
+    State#state{snapshot = SnapState}.
+
+snapshot_state(State) ->
+    State#state.snapshot.
 
 -spec read_meta(Key :: ra_log:ra_meta_key(), State :: ra_log_memory_state()) ->
     option(term()).
@@ -235,10 +247,11 @@ read_meta(Key, #state{meta = Meta}) ->
 
 -spec snapshot_index_term(State :: ra_log_memory_state()) ->
     ra_idxterm().
-snapshot_index_term(#state{snapshot = {#{index := Idx, term := Term}, _}}) ->
-    {Idx, Term};
 snapshot_index_term(#state{snapshot = undefined}) ->
-    undefined.
+    undefined;
+snapshot_index_term(#state{snapshot = {#{index := Idx,
+                                         term := Term}, _}}) ->
+    {Idx, Term}.
 
 -spec update_release_cursor(ra_index(), ra_cluster(),
                             ra_machine:version(), term(),

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -22,6 +22,8 @@ all() ->
      follower_handles_append_entries_rpc,
      candidate_handles_append_entries_rpc,
      append_entries_reply_success_promotes_nonvoter,
+     follower_aer_dupe,
+     follower_leader_change_before_written,
      append_entries_reply_success,
      append_entries_reply_no_success,
      append_entries_reply_no_success_from_unknown_peer,
@@ -158,9 +160,9 @@ setup_log() ->
                 end),
     meck:expect(ra_snapshot, abort_accept, fun(SS) -> SS end),
     meck:expect(ra_snapshot, accepting, fun(_SS) -> undefined end),
-    meck:expect(ra_log, snapshot_state, fun (_) -> snap_state end),
-    meck:expect(ra_log, set_snapshot_state, fun (_, Log) -> Log end),
-    meck:expect(ra_log, install_snapshot, fun (_, _, Log) -> {Log, []} end),
+    meck:expect(ra_log, snapshot_state, fun ra_log_memory:snapshot_state/1),
+    meck:expect(ra_log, set_snapshot_state, fun ra_log_memory:set_snapshot_state/2),
+    meck:expect(ra_log, install_snapshot, fun ra_log_memory:install_snapshot/3),
     meck:expect(ra_log, recover_snapshot, fun ra_log_memory:recover_snapshot/1),
     meck:expect(ra_log, snapshot_index_term, fun ra_log_memory:snapshot_index_term/1),
     meck:expect(ra_log, fold, fun ra_log_memory:fold/5),
@@ -219,7 +221,8 @@ init_test(_Config) ->
                      cluster => dehydrate_cluster(Cluster),
                      machine_version => 1},
     SnapshotData = "hi1+2+3",
-    {LogS, _, _} = ra_log_memory:install_snapshot(SnapshotMeta, SnapshotData, Log0),
+    {LogS, _} = ra_log_memory:install_snapshot({3, 5}, {SnapshotMeta,
+                                                        SnapshotData}, Log0),
     meck:expect(ra_log, init, fun (_) -> LogS end),
     #{current_term := 5,
       commit_index := 3,
@@ -641,7 +644,7 @@ follower_aer_7(_Config) ->
 follower_aer_diverged(_Config) ->
     State0 = (base_state(3, ?FUNCTION_NAME))#{last_applied => 2,
                                               commit_index => 2},
-    %% the leaders sends an rpc with old entries the diverged follower already
+    %% the leader sends an rpc with old entries the diverged follower already
     %% has
     AER = #append_entries_rpc{term = 6,
                               leader_id = ?N1,
@@ -653,7 +656,7 @@ follower_aer_diverged(_Config) ->
                                         ]},
     {follower, State1, Effects} = ra_server:handle_follower(AER, State0),
     ?assertMatch([{cast,_,
-                   {_, #append_entries_reply{success = false,
+                   {_, #append_entries_reply{success = true,
                                              next_index = 3}}} | _],
                  Effects),
     %% ensure the follower does not incorrectly apply the diverged entry at 3
@@ -718,7 +721,7 @@ follower_aer_term_mismatch_snapshot(_Config) ->
              cluster => #{},
              machine_version => 1},
     Data = <<"hi3">>,
-    {Log, _, _} = ra_log_memory:install_snapshot(Meta, Data, Log0),
+    {Log,_} = ra_log_memory:install_snapshot({3, 5}, {Meta, Data}, Log0),
     State = maps:put(log, Log, State0),
 
     AE = #append_entries_rpc{term = 6,
@@ -1081,8 +1084,8 @@ append_entries_reply_success_promotes_nonvoter(_Config) ->
       _]} = ra_server:handle_leader(RaJoin, State2),
 
     Ack2 = #append_entries_reply{term = 5, success = true,
-                                     next_index = 5,
-                                     last_index = 4, last_term = 5},
+                                 next_index = 5,
+                                 last_index = 4, last_term = 5},
 
     % voter ack, raises commit_index
     {leader, #{cluster := #{N2 := #{next_index := 5,
@@ -1094,6 +1097,100 @@ append_entries_reply_success_promotes_nonvoter(_Config) ->
       {aux, eval}]} = ra_server:handle_leader({N2, Ack2}, State3),
     ok.
 
+% leader_make_rpcs(_Config) ->
+%     N1 = ?N1, N2 = ?N2, N3 = ?N3,
+%     Cluster = #{N1 => new_peer_with(#{next_index => 1, match_index => 0}),
+%                 N2 => new_peer_with(#{next_index => 4, match_index => 3,
+%                                       commit_index_sent => 3}),
+%                 N3 => new_peer_with(#{next_index => 2, match_index => 1})},
+%     State0 = (base_state(3, ?FUNCTION_NAME))#{commit_index => 3,
+%                                               last_applied => 3,
+%                                               cluster => Cluster,
+%                                               machine_state => <<"hi3">>},
+%     {leader, State1, Effs1} = ra_server:handle_leader(pipeline_rpcs, State0),
+%     % Res = ra_server:make_rpcs(State0),
+%     ct:pal("reas ~p", [ra_server:make_rpcs(State1)]),
+
+%     ok.
+
+follower_aer_dupe(_Config) ->
+    N1 = ?N1,
+    N2 = ?N2,
+
+    % AER with index [1], commit = 0, commit_index = 0
+    Init = empty_state(3, n1),
+    AER1 = #append_entries_rpc{term = 1, leader_id = N2, prev_log_index = 0,
+                               prev_log_term = 0, leader_commit = 1,
+                               entries = [entry(1, 1, one),
+                                          entry(2, 1, two),
+                                          entry(3, 1, three)]},
+    {follower, #{leader_id := N2, current_term := 1,
+                 commit_index := 1, last_applied := 1} = State1, _} =
+        ra_server:handle_follower(AER1, Init),
+
+    %% a resend that doesn to fully cover the previous is issued (incorrectly)
+    %% but it could happen
+    AER2 = #append_entries_rpc{term = 1, leader_id = N2, prev_log_index = 1,
+                               prev_log_term = 1, leader_commit = 1,
+                               entries = [entry(2, 1, two)]},
+    {follower, #{leader_id := N2, current_term := 1,
+                 commit_index := 1, last_applied := 1} = _State2,
+     [{cast, N2, {N1, AEReply}}]} =
+        ra_server:handle_follower(AER2, State1),
+
+    ?assertMatch(
+       #append_entries_reply{success = true,
+                             next_index = 3,
+                             last_term = 1,
+                             last_index = 2}, AEReply),
+
+    ok.
+
+follower_leader_change_before_written(_Config) ->
+    N1 = ?N1,
+    N2 = ?N2,
+    N3 = ?N3,
+
+    Init = empty_state(3, n3),
+    AER1 = #append_entries_rpc{term = 1, leader_id = N1, prev_log_index = 0,
+                               prev_log_term = 0, leader_commit = 1,
+                               entries = [entry(1, 1, one),
+                                          entry(2, 1, two)]},
+    {follower, #{leader_id := N1, current_term := 1,
+                 commit_index := 1, last_applied := 1} = State1, _} =
+        ra_server:handle_follower(AER1, Init),
+
+    %% leader change comes in before written notification, this overwrites
+    %% index 2 in term 1
+    AER2 = #append_entries_rpc{term = 2, leader_id = N2, prev_log_index = 0,
+                               prev_log_term = 0, leader_commit = 1,
+                               entries = [entry(2, 2, twos),
+                                          entry(3, 2, three)]},
+    {follower, #{leader_id := N2, current_term := 2,
+                 commit_index := 1, last_applied := 1} = State2, _} =
+        ra_server:handle_follower(AER2, State1),
+
+    %% a written event for indexes 1 and 2 in term 1 should not result in a
+    %% append entries reply confirming index 2 as we have not yet had a notification
+    %% for that, it can however confirm index 1
+    {follower, #{leader_id := N2, last_applied := 1} = State3,
+     [{cast,
+       N2,
+       {N3, #append_entries_reply{success = true,
+                                  term = 2,
+                                  last_index = 1,
+                                  last_term = 1}}}]} =
+        ra_server:handle_follower(written_evt(1, {1, 2}), State2),
+    {follower, #{leader_id := N2, last_applied := 1} = _State4,
+     [{cast,
+       N2,
+       {N3, #append_entries_reply{success = true,
+                                  term = 2,
+                                  last_index = 3,
+                                  last_term = 2}}}]} =
+        ra_server:handle_follower(written_evt(2, {2, 3}), State3),
+    ok.
+
 append_entries_reply_success(_Config) ->
 
     N1 = ?N1, N2 = ?N2, N3 = ?N3,
@@ -1102,9 +1199,9 @@ append_entries_reply_success(_Config) ->
                                       commit_index_sent => 3}),
                 N3 => new_peer_with(#{next_index => 2, match_index => 1})},
     State0 = (base_state(3, ?FUNCTION_NAME))#{commit_index => 1,
-                             last_applied => 1,
-                             cluster => Cluster,
-                             machine_state => <<"hi1">>},
+                                              last_applied => 1,
+                                              cluster => Cluster,
+                                              machine_state => <<"hi1">>},
     Msg = {N2, #append_entries_reply{term = 5, success = true,
                                      next_index = 4,
                                      last_index = 3, last_term = 5}},
@@ -1780,7 +1877,7 @@ follower_cluster_change(_Config) ->
      [{cast, N1, {N2, #append_entries_reply{}}}]} =
         begin
             {follower, Int, _} = ra_server:handle_follower(AE, State),
-            ra_server:handle_follower(written_evt(4, {4, 5}), Int)
+            ra_server:handle_follower(written_evt(5, {4, 4}), Int)
         end,
 
     ok.
@@ -2293,9 +2390,8 @@ receive_snapshot_new_leader_aer(_Config) ->
 
 snapshotted_follower_received_append_entries(_Config) ->
     N1 = ?N1, N2 = ?N2, N3 = ?N3,
-    #{N3 := {_, FState0 = #{cluster := Config}, _}} =
+    #{N3 := {_, FState00 = #{cluster := Config}, _}} =
         init_servers([N1, N2, N3], {module, ra_queue, #{}}),
-    LastTerm = 1, % snapshot term
     Term = 2, % leader term
     Idx = 3,
     meck:expect(ra_log, recover_snapshot,
@@ -2307,28 +2403,38 @@ snapshotted_follower_received_append_entries(_Config) ->
                          []}
                 end),
     ISRpc = #install_snapshot_rpc{term = Term, leader_id = N1,
-                                  meta = snap_meta(Idx, LastTerm, Config),
+                                  meta = snap_meta(Idx, Term, Config),
                                   chunk_state = {1, last},
                                   data = []},
+    % debugger:start(),
+    % int:i(ra_server),
+    % int:break(ra_server, 1563),
+    % int:break(ra_server, 1181),
+    % int:break(ra_server, 1368),
+    meck:expect(ra_log, last_index_term,
+                fun (_) -> {Idx, Term} end),
+    {receive_snapshot, FState0, _} = ra_server:handle_follower(ISRpc, FState00),
     {follower, FState1, _} = ra_server:handle_receive_snapshot(ISRpc, FState0),
 
     meck:expect(ra_log, snapshot_index_term,
-                fun (_) -> {Idx, LastTerm} end),
+                fun (_) -> {Idx, Term} end),
     %% mock the ra_log write to return ok for index 4 as this is the next
     %% expected index after the snapshot
-    meck:expect(ra_log, write,
-                fun ([{4, _, _}], Log) -> {ok, Log} end),
+    % meck:expect(ra_log, write,
+    %             fun ([{4, _, _}], Log) -> {ok, Log} end),
     Cmd = usr({enc, banana}),
     AER = #append_entries_rpc{entries = [{4, 2, Cmd}],
                               leader_id = N1,
                               term = Term,
                               prev_log_index = 3, % snapshot index
-                              prev_log_term = 1,
+                              prev_log_term = Term,
                               leader_commit = 4 % entry is already committed
                              },
+
     {follower, _FState, [{cast, N1, {N3, #append_entries_reply{success = true}}}]} =
         begin
-            {follower, Int, _} = ra_server:handle_follower(AER, FState1),
+            {follower, Int, _} =
+                ra_server:handle_follower(AER, FState1),
             ra_server:handle_follower(written_evt(2, {4, 4}), Int)
         end,
     ok.

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1097,22 +1097,6 @@ append_entries_reply_success_promotes_nonvoter(_Config) ->
       {aux, eval}]} = ra_server:handle_leader({N2, Ack2}, State3),
     ok.
 
-% leader_make_rpcs(_Config) ->
-%     N1 = ?N1, N2 = ?N2, N3 = ?N3,
-%     Cluster = #{N1 => new_peer_with(#{next_index => 1, match_index => 0}),
-%                 N2 => new_peer_with(#{next_index => 4, match_index => 3,
-%                                       commit_index_sent => 3}),
-%                 N3 => new_peer_with(#{next_index => 2, match_index => 1})},
-%     State0 = (base_state(3, ?FUNCTION_NAME))#{commit_index => 3,
-%                                               last_applied => 3,
-%                                               cluster => Cluster,
-%                                               machine_state => <<"hi3">>},
-%     {leader, State1, Effs1} = ra_server:handle_leader(pipeline_rpcs, State0),
-%     % Res = ra_server:make_rpcs(State0),
-%     ct:pal("reas ~p", [ra_server:make_rpcs(State1)]),
-
-%     ok.
-
 follower_aer_dupe(_Config) ->
     N1 = ?N1,
     N2 = ?N2,
@@ -2406,11 +2390,7 @@ snapshotted_follower_received_append_entries(_Config) ->
                                   meta = snap_meta(Idx, Term, Config),
                                   chunk_state = {1, last},
                                   data = []},
-    % debugger:start(),
-    % int:i(ra_server),
-    % int:break(ra_server, 1563),
-    % int:break(ra_server, 1181),
-    % int:break(ra_server, 1368),
+
     meck:expect(ra_log, last_index_term,
                 fun (_) -> {Idx, Term} end),
     {receive_snapshot, FState0, _} = ra_server:handle_follower(ISRpc, FState00),
@@ -2418,10 +2398,7 @@ snapshotted_follower_received_append_entries(_Config) ->
 
     meck:expect(ra_log, snapshot_index_term,
                 fun (_) -> {Idx, Term} end),
-    %% mock the ra_log write to return ok for index 4 as this is the next
-    %% expected index after the snapshot
-    % meck:expect(ra_log, write,
-    %             fun ([{4, _, _}], Log) -> {ok, Log} end),
+
     Cmd = usr({enc, banana}),
     AER = #append_entries_rpc{entries = [{4, 2, Cmd}],
                               leader_id = N1,


### PR DESCRIPTION
1. Fix bug where occasionally one follower would receive
more entries then expected resulting in triggering 2.

2. Fix bug when follower received an append_entries_rpc with
no new entries in it would trigger an incorrect resend
scenario when throughput is high.

3. Fix bug where a late written event could accidentally confirm
unwritten entries in a higher term.

4.  A replication liveness bug that could cause clusters to get stuck 
after a member removal.