### PR TITLE
 Trigger tick_timeout immedately after entering leader state.

### DIFF
--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -654,8 +654,8 @@ candidate(EventType, Msg, State0) ->
             {State, Actions0} = ?HANDLE_EFFECTS(Effects, EventType, State1),
             %% reset the tick timer to avoid it triggering early after a leader
             %% change
-            Actions = set_tick_timer(State, Actions0),
-            next_state(leader, State, Actions)
+            next_state(leader, State,
+                       [{next_event, cast, tick_timeout} | Actions0])
     end.
 
 pre_vote(enter, OldState, #state{leader_monitor = MRef} = State0) ->

--- a/test/ra_machine_int_SUITE.erl
+++ b/test/ra_machine_int_SUITE.erl
@@ -785,6 +785,9 @@ aux_command_v1_and_v2(Config) ->
                     (_RaftState, cast, eval, AuxState, Opaque) ->
                         %% replaces aux state
                         {no_reply, AuxState, Opaque};
+                    (_RaftState, cast, tick, AuxState, Opaque) ->
+                        %% replaces aux state
+                        {no_reply, AuxState, Opaque};
                     (_RaftState, cast, NewState, _AuxState, Opaque0) ->
                         {Idx, _} = ra_aux:log_last_index_term(Opaque0),
                         {{_Term, _Meta, apple}, Opaque} = ra_aux:log_fetch(Idx, Opaque0),
@@ -831,6 +834,8 @@ aux_eval(Config) ->
                     (_RaftState, _, eval, AuxState, Log, _MacState) ->
                         %% monitors a process
                         Self ! got_eval,
+                        {no_reply, AuxState, Log, []};
+                    (_RaftState, _, _, AuxState, Log, _MacState) ->
                         {no_reply, AuxState, Log, []}
                 end),
     ok = start_cluster(ClusterName, {module, Mod, #{}}, Cluster),


### PR DESCRIPTION
 Instead of waiting a full tick interval after a process enters
 leader state instead immediately trigger a tick_timeout.
