### PR TITLE
Use infinity timeout for ra_log_ets:mem_table_please

### DIFF
--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -686,7 +686,8 @@ handle_event({segments, TidRanges, NewSegs},
                       readers = Readers
                      } = State0) ->
     Reader = ra_log_reader:update_segments(NewSegs, Reader0),
-    put_counter(Cfg, ?C_RA_SVR_METRIC_NUM_SEGMENTS, ra_log_reader:segment_ref_count(Reader)),
+    put_counter(Cfg, ?C_RA_SVR_METRIC_NUM_SEGMENTS,
+                ra_log_reader:segment_ref_count(Reader)),
     %% the tid ranges arrive in the reverse order they were written
     %% (new -> old) so we need to foldr here to process the oldest first
     Mt = lists:foldr(

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -669,9 +669,9 @@ handle_event({written, _Term, {FromIdx, _}} = Evt,
                   [LogId, FromIdx, Expected]),
             {resend_from(Expected, State0), []};
         false ->
-            ?INFO("~ts: ra_log: written gap detected at ~b but is outside
-                  of mem table range. Updating last written index to ~b!",
-                  [LogId, FromIdx, Expected]),
+            ?DEBUG("~ts: ra_log: written gap detected at ~b but is outside
+                  of mem table range ~w. Updating last written index to ~b!",
+                   [LogId, FromIdx, MtRange, Expected]),
             %% if the entry is not in the mem table we may have missed a
             %% written event due to wal crash. Accept written event by updating
             %% last written index term and recursing

--- a/src/ra_log_ets.erl
+++ b/src/ra_log_ets.erl
@@ -137,6 +137,8 @@ handle_call(Request, _From, State) ->
 
 handle_cast({exec_delete, UId, Spec},
             #state{names = #{open_mem_tbls := MemTables}} = State) ->
+
+    %% delete from open mem tables if {delete, tid()}
     case Spec of
         {delete, Tid} ->
             ets:delete_object(MemTables, {UId, Tid});
@@ -144,11 +146,11 @@ handle_cast({exec_delete, UId, Spec},
             ok
     end,
 
-    %% TODO: delete from ra_log_open_mem_tables if {delete, tid()}
     try timer:tc(fun () -> ra_mt:delete(Spec) end) of
         {Time, Num} ->
-            ?DEBUG_IF(Time > 25_000, "ra_log_ets: ra_mt:delete/1 took ~bms to delete ~w ~b entries",
-                   [Time div 1000, Spec, Num]),
+            ?DEBUG_IF(Time > 25_000,
+                      "ra_log_ets: ra_mt:delete/1 took ~bms to delete ~w ~b entries",
+                      [Time div 1000, Spec, Num]),
             ok
     catch
         _:Err ->
@@ -166,8 +168,9 @@ handle_cast({delete_mem_tables, UId},
     [begin
          try timer:tc(fun () -> ets_delete(Tid) end) of
              {Time, true} ->
-                 ?DEBUG_IF(Time > 25_000, "ra_log_ets: ets:delete/1 took ~bms to delete ~w",
-                        [Time div 1000, Tid]),
+                 ?DEBUG_IF(Time > 25_000,
+                           "ra_log_ets: ets:delete/1 took ~bms to delete ~w",
+                           [Time div 1000, Tid]),
                  ok
          catch
              _:Err ->

--- a/src/ra_log_ets.erl
+++ b/src/ra_log_ets.erl
@@ -54,7 +54,7 @@ mem_table_please(#{log_ets := Name,
                    open_mem_tbls := OpnMemTbls}, UId, Mode) ->
     case ets:lookup(OpnMemTbls, UId) of
         [] ->
-            case gen_server:call(Name, {mem_table_please, UId, #{}}) of
+            case gen_server:call(Name, {mem_table_please, UId, #{}}, infinity) of
                 {ok, [Tid | Rem]} ->
                     Mt = lists:foldl(
                            fun (T, Acc) ->

--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -150,8 +150,8 @@ handle_cast({mem_tables, Ranges, WalFile}, #state{data_dir = Dir,
                                false ->
                                    %% delete all tids as the uid is not
                                    %% registered
-                                   ?DEBUG("segment_writer in '~w': deleting memtable "
-                                          "for ~w as not a registered uid",
+                                   ?DEBUG("segment_writer in '~ts': deleting memtable "
+                                          "for ~ts as not a registered uid",
                                           [System, UId]),
                                    ok = ra_log_ets:delete_mem_tables(Names, UId),
                                    Acc


### PR DESCRIPTION
As else it may readily timeout and retry when mem table delete backlog is long.

Plus a few other log tweaks and adding some more detail to ra_lib:partition_parallel/3 failures.
