### PR TITLE
Don't allow a non-voter to start elections

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1483,19 +1483,13 @@ handle_follower(#append_entries_reply{}, State) ->
 handle_follower(election_timeout,
                 #{cfg := #cfg{log_id = LogId},
                   membership := Membership} = State) when Membership =/= voter ->
-    ?DEBUG("~ts: follower ignored election_timeout, non-voter: ~0p",
+    ?INFO("~ts: follower ignored election_timeout, non-voter: ~0p",
            [LogId, Membership]),
     {follower, State, []};
 handle_follower(election_timeout, State) ->
     call_for_election(pre_vote, State);
-handle_follower(try_become_leader,
-                #{cfg := #cfg{log_id = LogId},
-                  membership := Membership} = State) when Membership =/= voter ->
-    ?INFO("~ts: follower ignored try_become_leader, non-voter: ~0p",
-           [LogId, Membership]),
-    {follower, State, []};
 handle_follower(try_become_leader, State) ->
-    call_for_election(pre_vote, State);
+    handle_follower(election_timeout, State);
 handle_follower({register_external_log_reader, Pid}, #{log := Log0} = State) ->
     {Log, Effs} = ra_log:register_reader(Pid, Log0),
     {follower, State#{log => Log}, Effs};

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -920,12 +920,12 @@ handle_leader({transfer_leadership, ServerId},
             ?DEBUG("~ts: transfer leadership to ~w requested",
                    [LogId, ServerId]),
             %% TODO find a timeout
-            gen_statem:cast(ServerId, try_become_leader),
             {await_condition,
              State#{condition =>
                         #{predicate_fun => fun transfer_leadership_condition/2,
-                          timeout => #{effects => [], transition_to => leader}}},
-             [{reply, ok}]}
+                          timeout => #{effects => [],
+                                       transition_to => leader}}},
+             [{reply, ok}, {send_msg, ServerId, election_timeout, cast}]}
     end;
 handle_leader({register_external_log_reader, Pid}, #{log := Log0} = State) ->
     {Log, Effs} = ra_log:register_reader(Pid, Log0),

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1113,7 +1113,8 @@ handle_pre_vote(#pre_vote_result{term = Term, vote_granted = true,
                   votes := Votes,
                   cfg := #cfg{log_id = LogId},
                   pre_vote_token := Token,
-                  cluster := Nodes} = State0) ->
+                  cluster := Nodes,
+                  membership := voter} = State0) ->
     ?DEBUG("~ts: pre_vote granted ~w for term ~b votes ~b",
           [LogId, Token, Term, Votes + 1]),
     NewVotes = Votes + 1,
@@ -1124,15 +1125,12 @@ handle_pre_vote(#pre_vote_result{term = Term, vote_granted = true,
         _ ->
             {pre_vote, State#{votes => NewVotes}, []}
     end;
-handle_pre_vote(#pre_vote_result{vote_granted = false}, State) ->
+handle_pre_vote(#pre_vote_result{}, State) ->
     %% just handle negative results to avoid printing an unhandled message log
     {pre_vote, State, []};
 handle_pre_vote(#pre_vote_rpc{} = PreVote, State) ->
     process_pre_vote(pre_vote, PreVote, State);
 handle_pre_vote(#request_vote_result{}, State) ->
-    %% handle to avoid logging as unhandled
-    {pre_vote, State, []};
-handle_pre_vote(#pre_vote_result{}, State) ->
     %% handle to avoid logging as unhandled
     {pre_vote, State, []};
 handle_pre_vote(election_timeout, State) ->
@@ -1360,7 +1358,7 @@ handle_follower({ra_log_event, Evt}, #{log := Log0,
 handle_follower(#pre_vote_rpc{},
                 #{cfg := #cfg{log_id = LogId},
                   membership := Membership} = State) when Membership =/= voter ->
-    ?DEBUG("~ts: follower ignored pre_vote_rpc, non-voter: ~p0",
+    ?DEBUG("~ts: follower ignored pre_vote_rpc, non-voter: ~0p",
            [LogId, Membership]),
     {follower, State, []};
 handle_follower(#pre_vote_rpc{} = PreVote, State) ->
@@ -1368,7 +1366,7 @@ handle_follower(#pre_vote_rpc{} = PreVote, State) ->
 handle_follower(#request_vote_rpc{},
                 #{cfg := #cfg{log_id = LogId},
                   membership := Membership} = State) when Membership =/= voter ->
-    ?DEBUG("~ts: follower ignored request_vote_rpc, non-voter: ~p0",
+    ?DEBUG("~ts: follower ignored request_vote_rpc, non-voter: ~0p",
            [LogId, Membership]),
     {follower, State, []};
 handle_follower(#request_vote_rpc{candidate_id = Cand, term = Term},
@@ -1485,11 +1483,17 @@ handle_follower(#append_entries_reply{}, State) ->
 handle_follower(election_timeout,
                 #{cfg := #cfg{log_id = LogId},
                   membership := Membership} = State) when Membership =/= voter ->
-    ?DEBUG("~ts: follower ignored election_timeout, non-voter: ~p0",
+    ?DEBUG("~ts: follower ignored election_timeout, non-voter: ~0p",
            [LogId, Membership]),
     {follower, State, []};
 handle_follower(election_timeout, State) ->
     call_for_election(pre_vote, State);
+handle_follower(try_become_leader,
+                #{cfg := #cfg{log_id = LogId},
+                  membership := Membership} = State) when Membership =/= voter ->
+    ?INFO("~ts: follower ignored try_become_leader, non-voter: ~0p",
+           [LogId, Membership]),
+    {follower, State, []};
 handle_follower(try_become_leader, State) ->
     call_for_election(pre_vote, State);
 handle_follower({register_external_log_reader, Pid}, #{log := Log0} = State) ->

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -35,6 +35,7 @@ all() ->
      leader_does_not_abdicate_to_unknown_peer,
      higher_term_detected,
      pre_vote_election,
+     pre_vote_election_non_voter,
      pre_vote_election_reverts,
      candidate_receives_pre_vote,
      leader_receives_pre_vote,
@@ -2129,6 +2130,15 @@ pre_vote_election(_Config) ->
     % quorum has been achieved - pre_vote becomes candidate
     {candidate,
      #{current_term := 6}, _} = ra_server:handle_pre_vote(Reply, State1).
+
+pre_vote_election_non_voter(_Config) ->
+    Token = make_ref(),
+    State = (base_state(5, ?FUNCTION_NAME))#{votes => 1,
+                             membership => promotable,
+                             pre_vote_token => Token},
+    Reply = #pre_vote_result{term = 5, token = Token, vote_granted = true},
+    % non-voter should ignore pre-vote
+    {pre_vote, #{votes := 1}, []} = ra_server:handle_pre_vote(Reply, State).
 
 pre_vote_election_reverts(_Config) ->
     N2 = ?N2,

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -2104,6 +2104,7 @@ candidate_election(_Config) ->
 pre_vote_election(_Config) ->
     Token = make_ref(),
     State = (base_state(5, ?FUNCTION_NAME))#{votes => 1,
+                             membership => voter,
                              pre_vote_token => Token},
     Reply = #pre_vote_result{term = 5, token = Token, vote_granted = true},
     {pre_vote, #{votes := 2} = State1, []}


### PR DESCRIPTION
When transfer_leadership is requested, the leader checks whether the desired new leader is a voter and refuses to proceed if it is not. However, the desired new leader should also refuse to proceed, if it doesn't consider itself a voter (the view of the membership may be different on different nodes or might have changed since the old/current leader checked it).

This fixes a behaviour we observed in testing where a newly added member, which was still catching up, was picked to be a new leader and actually became a leader, even though it was still in the `promotable` state.