### PR TITLE
Allow force shrink to non-voter member

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1495,13 +1495,15 @@ handle_follower({register_external_log_reader, Pid}, #{log := Log0} = State) ->
     {follower, State#{log => Log}, Effs};
 handle_follower(force_member_change,
                 #{cfg := #cfg{id = Id,
+                              uid = Uid,
                               log_id = LogId}} = State0) ->
-    Cluster = #{Id => new_peer()},
+    Cluster = #{Id => new_peer_with(#{voter_status => #{uid => Uid, 
+                                                        membership => voter}})},
     ?WARN("~ts: Forcing cluster change. New cluster ~w",
           [LogId, Cluster]),
     {ok, _, _, State, Effects} =
         append_cluster_change(Cluster, undefined, no_reply, State0, []),
-    call_for_election(pre_vote, State, [{reply, ok} | Effects]);
+    call_for_election(pre_vote, State#{membership => voter}, [{reply, ok} | Effects]);
 handle_follower(#info_rpc{term = Term} = Msg,
                 #{current_term := CurTerm} = State)
   when CurTerm < Term ->


### PR DESCRIPTION
Hi,

We recently tested the force shrink operation to a single member and found that it is currently not possible to shrink to a non-voter member. However, we think that in disaster recovery scenarios, it should be reasonable to recover from any member, whether a voter or non-voter.

## Proposed Changes

Allow force shrink to a non-voter member, as it can be the only surviving member in a disaster recovery scenario.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
