### PR TITLE
Avoid modification checks when reading sparse entries inside the Ra …

### DIFF
--- a/src/ra_log_reader.erl
+++ b/src/ra_log_reader.erl
@@ -359,10 +359,10 @@ segment_sparse_read(#?STATE{segment_refs = SegRefs,
       fun ({Idxs, Fn}, {Open0, C, En0}) ->
               {Seg, Open} = get_segment(Cfg, Open0, Fn),
               {ok, ReadSparseCount, Entries} =
-                  ra_log_segment:read_sparse(Seg, Idxs,
-                                             fun (I, T, B, Acc) ->
-                                                     [{I, T, binary_to_term(B)} | Acc]
-                                             end, []),
+                  ra_log_segment:read_sparse_no_checks(
+                    Seg, Idxs, fun (I, T, B, Acc) ->
+                                       [{I, T, binary_to_term(B)} | Acc]
+                               end, []),
               {Open, C +  ReadSparseCount, lists:reverse(Entries, En0)}
       end, {OpenSegs, 0, Entries0}, Plan).
 


### PR DESCRIPTION
…process.

As the Ra process will never try to read entries it does not already know about. This modification check is for processes that read the log outside of the Ra process and may have opened a segment that was later appended to.

Fixes #532 
