### PR TITLE
Optimise ra_directory:is_registered_uid/2

### DIFF
--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -137,6 +137,7 @@ segments_for(UId, #state{data_dir = DataDir}) ->
 
 handle_cast({mem_tables, Ranges, WalFile}, #state{data_dir = Dir,
                                                   system = System} = State) ->
+    T1 = erlang:monotonic_time(),
     ok = counters:add(State#state.counter, ?C_MEM_TABLES, map_size(Ranges)),
     #{names := Names} = ra_system:fetch(System),
     Degree = erlang:system_info(schedulers),
@@ -158,7 +159,6 @@ handle_cast({mem_tables, Ranges, WalFile}, #state{data_dir = Dir,
                            end
                    end, [], Ranges),
 
-    T1 = erlang:monotonic_time(),
     _ = [begin
              {_, Failures} = ra_lib:partition_parallel(
                                fun (TidRange) ->

--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -365,9 +365,9 @@ snap_idx(ServerUId) ->
 send_segments(System, ServerUId, TidRanges, SegRefs) ->
     case ra_directory:pid_of(System, ServerUId) of
         undefined ->
-            ?DEBUG("ra_log_segment_writer: error sending "
+            ?DEBUG("ra_log_segment_writer: unable to send "
                    "ra_log_event to: "
-                   "~ts. Error: ~s",
+                   "~ts. Reason: ~s",
                    [ServerUId, "No Pid"]),
             %% delete from the memtable on the non-running server's behalf
             [begin

--- a/test/ra_log_segment_writer_SUITE.erl
+++ b/test/ra_log_segment_writer_SUITE.erl
@@ -347,6 +347,8 @@ accept_mem_tables_for_down_server(Config) ->
     %% but not running
     ok = dets:insert(maps:get(directory_rev, get_names(default)),
                      {down_uid, DownUId}),
+    true = ets:insert(maps:get(directory, get_names(default)),
+                      {DownUId, undefined, undefined, down_uid, undefined}),
     ok = ra_lib:make_dir(filename:join(Dir, DownUId)),
     application:start(sasl),
     {ok, TblWriterPid} = ra_log_segment_writer:start_link(#{system => default,


### PR DESCRIPTION
By recovering the ETS table on init with default values instead of leaving empty until a Ra process registers.

