### PR TITLE
ra:start_cluster/3: handle timeouts returned by ra_lib:parallel_partition/3

### DIFF
--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -160,11 +160,12 @@ handle_cast({mem_tables, Ranges, WalFile}, #state{data_dir = Dir,
                    end, [], Ranges),
 
     _ = [begin
-             {_, Failures} = ra_lib:partition_parallel(
-                               fun (TidRange) ->
-                                       ok = flush_mem_table_ranges(TidRange, State),
-                                       true
-                               end, Tabs, infinity),
+             {ok, _, Failures} =
+                ra_lib:partition_parallel(
+                    fun (TidRange) ->
+                            ok = flush_mem_table_ranges(TidRange, State),
+                            true
+                    end, Tabs, infinity),
              case Failures of
                  [] ->
                      %% this is what we expect

--- a/test/coordination_SUITE.erl
+++ b/test/coordination_SUITE.erl
@@ -390,7 +390,7 @@ shrink_cluster_with_snapshot(Config) ->
     ClusterName = ?config(cluster_name, Config),
     Peers = start_peers([s1,s2,s3], PrivDir),
     ServerIds = server_ids(ClusterName, Peers),
-    [A, B, C] = ServerIds,
+    [_A, _B, _C] = ServerIds,
 
     Machine = {module, ?MODULE, #{}},
     {ok, _, []} = ra:start_cluster(?SYS, ClusterName, Machine, ServerIds),


### PR DESCRIPTION
Closes #539.
References rabbitmq/rabbitmq-server#13828.
