### PR TITLE
Fix type mixups of `ra_index()` and `ra_term()`

### DIFF
--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -135,7 +135,7 @@
         {term :: ra_term(),
          candidate_id :: ra_server_id(),
          last_log_index :: ra_index(),
-         last_log_term :: ra_index()}).
+         last_log_term :: ra_term()}).
 
 %% Section 4.2
 -record(request_vote_result,
@@ -151,7 +151,7 @@
          token :: reference(),
          candidate_id :: ra_server_id(),
          last_log_index :: ra_index(),
-         last_log_term :: ra_index()}).
+         last_log_term :: ra_term()}).
 
 -record(pre_vote_result,
         {term :: ra_term(),

--- a/test/ra_log_memory.erl
+++ b/test/ra_log_memory.erl
@@ -46,7 +46,7 @@
 -record(state, {last_index = 0 :: ra_index(),
                 last_written = {0, 0} :: ra_idxterm(), % only here to fake the async api of the file based one
                 entries = #{0 => {0, undefined}} ::
-                    #{ra_term() => {ra_index(), term()}},
+                    #{ra_index() => {ra_term(), term()}},
                 meta = #{} :: ra_log_memory_meta(),
                 snapshot :: option({ra_snapshot:meta(), term()})}).
 


### PR DESCRIPTION
This is a cosmetic change since the dialyzer isn't smart enough yet to notice the mixup. With the addition of nominal types in OTP 28 though we will eventually be able to get the dialyzer to notice this. I played around with nominal types on OTP 28 in [this branch](https://github.com/rabbitmq/ra/tree/nominal-types) and the dialyzer found these mixups.

Note that in practice `#request_vote_rpc{}` and `#pre_vote_rpc{}` are being constructed correctly with `ra_term()`s in these fields, so this isn't a bug fix.