### PR TITLE
CI: Include OTP 28 in the erlang workflow version matrix

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp_version: [26, 27]
+        otp_version: [26, 27, 28]
     steps:
     - name: CHECKOUT
       uses: actions/checkout@v2


### PR DESCRIPTION
Everything passes for me locally on OTP 28 so I suggest that we add it to the version matrix for the Erlang workflow in CI.