### PR TITLE
Retry prim_file:rename on eacces error

### DIFF
--- a/src/ra_snapshot.erl
+++ b/src/ra_snapshot.erl
@@ -417,7 +417,7 @@ promote_checkpoint(PromotionIdx,
                                 %% sync the checkpoint before promoting it
                                 %% into a snapshot.
                                 ok = Mod:sync(Checkpoint),
-                                ok = prim_file:rename(Checkpoint, Snapshot),
+                                ok = ra_file:rename(Checkpoint, Snapshot),
                                 Self ! {ra_log_event,
                                         {snapshot_written,
                                          {Idx, Term}, snapshot}}


### PR DESCRIPTION
On Windows, when creating a snapshot (renaming a checkpoint), occasionally `prim_file:rename` failed with `eacces`. It's not clear why this happens, it appears that Windows may not release the file handle immediately after closing the file so a close->rename in a quick succession may sometimes return an error.
With this commit, we just retry after 20ms and so far, in our testing, the error has never occurred on the second attempt (with a 10ms delay, it still failed every now and then)

We could have separate macros for eagain and eaccess, but I went with a shared one. One retry seems reasonable in both cases.