### PR TITLE
Handle specific `exit` in `gen_statem_safe_call/3`

### DIFF
--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1798,6 +1798,8 @@ gen_statem_safe_call(ServerId, Msg, Timeout) ->
             {error, nodedown};
          exit:{shutdown, _} ->
             {error, shutdown};
+         exit:{{shutdown, delete}, _} ->
+            {error, shutdown};
          exit:{Reason, _} ->
             {error, Reason}
     end.


### PR DESCRIPTION
While developing a plugin that creates and deletes quorum queues, I got the following `exit` during a large-scale test:

```
queue 'tmp_test.queue.14' in vhost '/': terminating with reason 'delete'
exception in queue 'test.queue.14' in vhost '/' (migration 1751914526984): exit:{{shutdown,
                                                                                  delete},
                                                                                 {gen_statem,
                                                                                  call,
                                                                                  [{'%2F_tmp_test.queue.14',
                                                                                    'rabbit-3@SEA-3LG5HVJUWJK'},
                                                                                   {leader_call,
                                                                                    {command,
                                                                                     normal,
                                                                                     {'$ra_cluster',
                                                                                      delete,
                                                                                      await_consensus}}},
                                                                                                    5000]}}
[{gen,do_call,4,[{file,"gen.erl"},{line,269}]},
 {gen_statem,call,3,[{file,"gen_statem.erl"},{line,923}]},
 {ra_server_proc,gen_statem_safe_call,3,
                 [{file,"src/ra_server_proc.erl"},{line,1697}]},
 {ra_server_proc,statem_call,3,[{file,"src/ra_server_proc.erl"},{line,252}]},
 {ra_server_proc,multi_statem_call,4,
                 [{file,"src/ra_server_proc.erl"},{line,266}]},
 {ra,delete_cluster,2,[{file,"src/ra.erl"},{line,559}]},
 {rabbit_quorum_queue,delete,4,[{file,"rabbit_quorum_queue.erl"},{line,745}]},
 {rabbit_plugin,my_function,4,
                         [{file,"rabbit_plugin.erl"},{line,522}]}]
```

It seems like a specific case is not being handled in `gen_statem_safe_call/3`. I noticed that this `exit` is specifically handled in RabbitMQ's `mqtt_node` module, function `delete/1`.