### PR TITLE
Log segment write: increase the timeout

### DIFF
--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -31,7 +31,7 @@
 
 -include("ra.hrl").
 
--define(AWAIT_TIMEOUT, 30000).
+-define(AWAIT_TIMEOUT, 60000).
 -define(SEGMENT_WRITER_RECOVERY_TIMEOUT, 30000).
 
 -define(C_MEM_TABLES, 1).


### PR DESCRIPTION
Per discussion with @mkuratczyk in rabbitmq/rabbitmq-server#14401.

For RabbitMQ `4.1.x`, this should be backported for `2.16.13`.