### PR TITLE
Fixes #560 - fix crash in wal_log_segment_writer when wal_data_dir /= data_dir

### DIFF
--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -135,8 +135,7 @@ segments_for(UId, #state{data_dir = DataDir}) ->
     Dir = filename:join(DataDir, ra_lib:to_list(UId)),
     segment_files(Dir).
 
-handle_cast({mem_tables, Ranges, WalFile}, #state{data_dir = Dir,
-                                                  system = System} = State) ->
+handle_cast({mem_tables, Ranges, WalFile}, #state{system = System} = State) ->
     T1 = erlang:monotonic_time(),
     ok = counters:add(State#state.counter, ?C_MEM_TABLES, map_size(Ranges)),
     #{names := Names} = ra_system:fetch(System),
@@ -177,7 +176,7 @@ handle_cast({mem_tables, Ranges, WalFile}, #state{data_dir = Dir,
              end
          end || Tabs <- ra_lib:lists_chunk(Degree, RangesList)],
     %% delete wal file once done
-    ok = prim_file:delete(filename:join(Dir, WalFile)),
+    ok = prim_file:delete(WalFile),
     T2 = erlang:monotonic_time(),
     Diff = erlang:convert_time_unit(T2 - T1, native, millisecond),
     ?DEBUG("segment_writer in '~w': completed flush of ~b writers from wal file "

--- a/test/ra_log_segment_writer_SUITE.erl
+++ b/test/ra_log_segment_writer_SUITE.erl
@@ -887,7 +887,7 @@ make_wal(Config, Name) ->
     Dir = ?config(wal_dir, Config),
     FullWalFile = filename:join(Dir, Name),
     ok = file:write_file(FullWalFile, <<"waldata">>),
-    Name.
+    FullWalFile.
 
 is_wal_file(Config, Name) ->
     Dir = ?config(wal_dir, Config),

--- a/test/ra_log_wal_SUITE.erl
+++ b/test/ra_log_wal_SUITE.erl
@@ -143,9 +143,11 @@ basic_log_writes(Config) ->
     {ok, _} = ra_log_wal:write(Pid, WriterId, Tid, 13, 1, "value2"),
     ok = await_written(WriterId, 1, {13, 13}),
     ra_log_wal:force_roll_over(Pid),
+    #{dir := Dir} = Conf,
+    Fn = filename:join(Dir, "0000000000000001.wal"),
     receive
         {'$gen_cast',
-         {mem_tables, #{UId := [{Tid, {12, 13}}]}, "0000000000000001.wal"}} ->
+         {mem_tables, #{UId := [{Tid, {12, 13}}]}, Fn}} ->
             ok
     after 5000 ->
               flush(),
@@ -178,7 +180,7 @@ wal_filename_upgrade(Config) ->
     {ok, Pid2} = ra_log_wal:start_link(Conf#{segment_writer => self()}),
     receive
         {'$gen_cast',
-         {mem_tables, #{UId := [{_Tid, {12, 13}}]}, "0000000000000001.wal"}} ->
+         {mem_tables, #{UId := [{_Tid, {12, 13}}]}, Fn}} ->
             ok
     after 5000 ->
               flush(),


### PR DESCRIPTION
## Proposed Changes

Fixes #560.  ra_log_segment_writer would crash if wal_data_dir was not the same as data_dir, b/c
it tried to delete a non-existing file.

The fix is to send the full filename of the wal file to ra_log_segment_writer. 

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #560)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq) (link doesn't work)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

