### PR TITLE
Add functions to pipeline membership changes

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -3518,6 +3518,8 @@ append_error_reply(Cmd, Reason, Effects0) ->
     case Cmd of
         {_, #{from := From}, _, _} ->
             [{reply, From, {error, Reason}} | Effects0];
+        {_, _, _, {notify, Corr, Pid}} ->
+            [{notify, #{Pid => [{Corr, {error, Reason}}]}} | Effects0];
         _ ->
             Effects0
     end.


### PR DESCRIPTION
This change adds pipelined versions of ra:add_member/2 and ra:remove_member/2. Pipeline versions can be useful for using the WAL more efficiently when making multiple membership changes to different clusters simultaneously. In RabbitMQ this could be used for "shrinking" operations like forget_cluster_node which remove a member from all Ra clusters.

Originally discussed in https://github.com/rabbitmq/rabbitmq-server/pull/15081