### PR TITLE
Add snapshot write duration to log messages

### DIFF
--- a/test/ra_checkpoint_SUITE.erl
+++ b/test/ra_checkpoint_SUITE.erl
@@ -92,7 +92,7 @@ take_checkpoint(Config) ->
     {{55, 2}, checkpoint} = ra_snapshot:pending(State1),
     Fun(),
     receive
-        {ra_log_event, {snapshot_written, {55, 2} = IdxTerm, Indexes, checkpoint}} ->
+        {ra_log_event, {snapshot_written, {55, 2} = IdxTerm, Indexes, checkpoint, _}} ->
             State = ra_snapshot:complete_snapshot(IdxTerm, checkpoint,
                                                   Indexes, State1),
             undefined = ra_snapshot:pending(State),
@@ -141,7 +141,7 @@ recover_from_checkpoint_only(Config) ->
                                    checkpoint, State0),
     Fun(),
     receive
-        {ra_log_event, {snapshot_written, IdxTerm, Indexes, checkpoint}} ->
+        {ra_log_event, {snapshot_written, IdxTerm, Indexes, checkpoint, _}} ->
             _ = ra_snapshot:complete_snapshot(IdxTerm, checkpoint,
                                               Indexes, State1),
             ok
@@ -170,7 +170,7 @@ recover_from_checkpoint_and_snapshot(Config) ->
                                     snapshot, State0),
     Fun(),
     State2 = receive
-                 {ra_log_event, {snapshot_written, IdxTerm1, Indexes, snapshot}} ->
+                 {ra_log_event, {snapshot_written, IdxTerm1, Indexes, snapshot, _}} ->
                        ra_snapshot:complete_snapshot(IdxTerm1, snapshot,
                                                      Indexes, State1)
              after 1000 ->
@@ -184,7 +184,7 @@ recover_from_checkpoint_and_snapshot(Config) ->
                                     checkpoint, State2),
     Fun2(),
     receive
-        {ra_log_event, {snapshot_written, IdxTerm2, Indexes2, checkpoint}} ->
+        {ra_log_event, {snapshot_written, IdxTerm2, Indexes2, checkpoint, _}} ->
              _ = ra_snapshot:complete_snapshot(IdxTerm2, checkpoint,
                                                Indexes2, State3),
              ok
@@ -214,7 +214,7 @@ newer_snapshot_deletes_older_checkpoints(Config) ->
                                     checkpoint, State0),
     Fun(),
     State2 = receive
-                 {ra_log_event, {snapshot_written, IdxTerm1, Indexes, checkpoint}} ->
+                 {ra_log_event, {snapshot_written, IdxTerm1, Indexes, checkpoint, _}} ->
                        ra_snapshot:complete_snapshot(IdxTerm1, checkpoint,
                                                      Indexes, State1)
              after 1000 ->
@@ -228,7 +228,7 @@ newer_snapshot_deletes_older_checkpoints(Config) ->
                                     checkpoint, State2),
     Fun2(),
     State4 = receive
-                 {ra_log_event, {snapshot_written, IdxTerm2, Indexes2, checkpoint}} ->
+                 {ra_log_event, {snapshot_written, IdxTerm2, Indexes2, checkpoint, _}} ->
                        ra_snapshot:complete_snapshot(IdxTerm2, checkpoint,
                                                      Indexes2, State3)
              after 1000 ->
@@ -242,7 +242,7 @@ newer_snapshot_deletes_older_checkpoints(Config) ->
                                     checkpoint, State4),
     Fun3(),
     State6 = receive
-                 {ra_log_event, {snapshot_written, IdxTerm3, Indexes3, checkpoint}} ->
+                 {ra_log_event, {snapshot_written, IdxTerm3, Indexes3, checkpoint, _}} ->
                        ra_snapshot:complete_snapshot(IdxTerm3, checkpoint,
                                                      Indexes3, State5)
              after 1000 ->
@@ -256,7 +256,7 @@ newer_snapshot_deletes_older_checkpoints(Config) ->
                                     snapshot, State6),
     Fun4(),
     State8 = receive
-                 {ra_log_event, {snapshot_written, IdxTerm4, Indexes4, snapshot}} ->
+                 {ra_log_event, {snapshot_written, IdxTerm4, Indexes4, snapshot, _}} ->
                       ra_snapshot:complete_snapshot(IdxTerm4, snapshot,
                                                     Indexes4, State7)
              after 1000 ->
@@ -293,7 +293,7 @@ init_recover_corrupt(Config) ->
                                    checkpoint, State0),
     Fun(),
     State2 = receive
-                 {ra_log_event, {snapshot_written, {55, 2} = IdxTerm1, Indexes, checkpoint}} ->
+                 {ra_log_event, {snapshot_written, {55, 2} = IdxTerm1, Indexes, checkpoint, _}} ->
                      ra_snapshot:complete_snapshot(IdxTerm1, checkpoint, Indexes, State1)
              after 1000 ->
                      error(snapshot_event_timeout)
@@ -306,7 +306,7 @@ init_recover_corrupt(Config) ->
                                    checkpoint, State2),
     Fun2(),
     receive
-        {ra_log_event, {snapshot_written, {165, 2} = IdxTerm2, Indexes2, checkpoint}} ->
+        {ra_log_event, {snapshot_written, {165, 2} = IdxTerm2, Indexes2, checkpoint, _}} ->
             _ = ra_snapshot:complete_snapshot(IdxTerm2, checkpoint, Indexes2, State3),
             ok
     after 1000 ->
@@ -340,7 +340,7 @@ init_recover_multi_corrupt(Config) ->
                                     checkpoint, State0),
     Fun(),
     State2 = receive
-                 {ra_log_event, {snapshot_written, IdxTerm1, Indexes, checkpoint}} ->
+                 {ra_log_event, {snapshot_written, IdxTerm1, Indexes, checkpoint, _}} ->
                      ra_snapshot:complete_snapshot(IdxTerm1, checkpoint, Indexes, State1)
              after 1000 ->
                      error(snapshot_event_timeout)
@@ -353,7 +353,7 @@ init_recover_multi_corrupt(Config) ->
                                     checkpoint, State2),
     Fun2(),
     State4 = receive
-                 {ra_log_event, {snapshot_written, IdxTerm2, Indexes2, checkpoint}} ->
+                 {ra_log_event, {snapshot_written, IdxTerm2, Indexes2, checkpoint, _}} ->
                       ra_snapshot:complete_snapshot(IdxTerm2, checkpoint,
                                                     Indexes2, State3)
              after 1000 ->

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -412,7 +412,7 @@ sparse_read_out_of_range_2(Config) ->
     run_effs(Effs),
     {Log3, Effs3} = receive
                         {ra_log_event, {snapshot_written, {10, 2}, _,
-                                        snapshot} = Evt} ->
+                                        snapshot, _} = Evt} ->
                             ra_log:handle_event(Evt, Log2)
                     after 5000 ->
                               flush(),
@@ -549,7 +549,7 @@ written_event_after_snapshot(Config) ->
     run_effs(Effs),
     {Log3, _} = receive
                     {ra_log_event, {snapshot_written, {2, 1}, _,
-                                    snapshot} = Evt} ->
+                                    snapshot, _} = Evt} ->
                         ra_log:handle_event(Evt, Log2)
                 after 500 ->
                           exit(snapshot_written_timeout)
@@ -567,7 +567,7 @@ written_event_after_snapshot(Config) ->
                                                  Log6b),
     run_effs(Effs2),
     _ = receive
-            {ra_log_event, {snapshot_written, {4, 1}, _, snapshot} = E} ->
+            {ra_log_event, {snapshot_written, {4, 1}, _, snapshot, _} = E} ->
                 ra_log:handle_event(E, Log7)
         after 500 ->
                   exit(snapshot_written_timeout)
@@ -1248,7 +1248,7 @@ snapshot_written_after_installation(Config) ->
     run_effs(Effs),
     DelayedSnapWritten = receive
                              {ra_log_event, {snapshot_written, {5, 1}, _,
-                                             snapshot} = Evt} ->
+                                             snapshot, _} = Evt} ->
                                  Evt
                          after 1000 ->
                                    flush(),
@@ -1297,7 +1297,7 @@ oldcheckpoints_deleted_after_snapshot_install(Config) ->
     run_effs(Effs),
     DelayedSnapWritten = receive
                              {ra_log_event, {snapshot_written, {5, 1}, _,
-                                             checkpoint} = Evt} ->
+                                             checkpoint, _} = Evt} ->
                                  Evt
                          after 1000 ->
                                    flush(),
@@ -2181,7 +2181,7 @@ create_snapshot_chunk(Config, #{index := Idx} = Meta, MacState, Context) ->
     Fun(),
     Sn2 =
         receive
-            {ra_log_event, {snapshot_written, {Idx, 2} = IdxTerm, _, snapshot}} ->
+            {ra_log_event, {snapshot_written, {Idx, 2} = IdxTerm, _, snapshot, _}} ->
                 ra_snapshot:complete_snapshot(IdxTerm, snapshot,
 
                                               LiveIndexes, Sn1)

--- a/test/ra_snapshot_SUITE.erl
+++ b/test/ra_snapshot_SUITE.erl
@@ -105,7 +105,7 @@ take_snapshot(Config) ->
     {{55, 2}, snapshot} = ra_snapshot:pending(State1),
     receive
         {ra_log_event,
-         {snapshot_written, {55, 2} = IdxTerm, Indexes, snapshot}} ->
+         {snapshot_written, {55, 2} = IdxTerm, Indexes, snapshot, _}} ->
             State = ra_snapshot:complete_snapshot(IdxTerm, snapshot,
                                                   Indexes, State1),
             undefined = ra_snapshot:pending(State),
@@ -155,7 +155,7 @@ init_recover(Config) ->
          ra_snapshot:begin_snapshot(Meta, ?MACMOD, ?FUNCTION_NAME, snapshot, State0),
     Fun(),
     receive
-        {ra_log_event, {snapshot_written, IdxTerm, Indexes, snapshot}} ->
+        {ra_log_event, {snapshot_written, IdxTerm, Indexes, snapshot, _}} ->
             _ = ra_snapshot:complete_snapshot(IdxTerm, snapshot,
                                               Indexes, State1),
             ok
@@ -183,7 +183,7 @@ init_recover_voter_status(Config) ->
          ra_snapshot:begin_snapshot(Meta, ?MACMOD, ?FUNCTION_NAME, snapshot, State0),
     Fun(),
     receive
-        {ra_log_event, {snapshot_written, IdxTerm, Indexes, snapshot}} ->
+        {ra_log_event, {snapshot_written, IdxTerm, Indexes, snapshot, _}} ->
             _ = ra_snapshot:complete_snapshot(IdxTerm, snapshot, Indexes, State1),
             ok
     after 1000 ->
@@ -213,7 +213,7 @@ init_multi(Config) ->
     %% simulate ra worker execution
     Fun(),
     receive
-        {ra_log_event, {snapshot_written, IdxTerm, Indexes, snapshot}} ->
+        {ra_log_event, {snapshot_written, IdxTerm, Indexes, snapshot, _}} ->
             State2 = ra_snapshot:complete_snapshot(IdxTerm, snapshot, Indexes, State1),
             {State3, [{bg_work, Fun2, _}]} =
                 ra_snapshot:begin_snapshot(Meta2, ?MACMOD, ?FUNCTION_NAME,
@@ -256,7 +256,7 @@ init_recover_multi_corrupt(Config) ->
                                    snapshot, State0),
     Fun(),
     receive
-        {ra_log_event, {snapshot_written, IdxTerm, Indexes, snapshot}} ->
+        {ra_log_event, {snapshot_written, IdxTerm, Indexes, snapshot, _}} ->
             State2 = ra_snapshot:complete_snapshot(IdxTerm, snapshot, Indexes, State1),
             {State3, [{bg_work, Fun2, _}]} =
                 ra_snapshot:begin_snapshot(Meta2, ?MACMOD, ?FUNCTION_NAME,
@@ -305,7 +305,7 @@ init_recover_corrupt(Config) ->
                                    snapshot, State0),
     Fun(),
     _ = receive
-                 {ra_log_event, {snapshot_written, IdxTerm, Indexes, snapshot}} ->
+                 {ra_log_event, {snapshot_written, IdxTerm, Indexes, snapshot, _}} ->
                      ra_snapshot:complete_snapshot(IdxTerm, snapshot, Indexes, State1)
              after 1000 ->
                        error(snapshot_event_timeout)
@@ -336,7 +336,7 @@ read_snapshot(Config) ->
         ra_snapshot:begin_snapshot(Meta, ?MACMOD, MacRef, snapshot, State0),
     Fun(),
     State = receive
-                {ra_log_event, {snapshot_written, IdxTerm, Indexes, snapshot}} ->
+                {ra_log_event, {snapshot_written, IdxTerm, Indexes, snapshot, _}} ->
                     ra_snapshot:complete_snapshot(IdxTerm, snapshot, Indexes, State1)
             after 1000 ->
                       error(snapshot_event_timeout)
@@ -442,7 +442,7 @@ accept_receives_snapshot_written_with_higher_index(Config) ->
 
     %% then the snapshot written event is received
     receive
-        {ra_log_event, {snapshot_written, {55, 2} = IdxTerm, Indexes, snapshot}} ->
+        {ra_log_event, {snapshot_written, {55, 2} = IdxTerm, Indexes, snapshot, _}} ->
             State4 = ra_snapshot:complete_snapshot(IdxTerm, snapshot, Indexes, State3),
             undefined = ra_snapshot:pending(State4),
             {55, 2} = ra_snapshot:current(State4),
@@ -494,7 +494,7 @@ accept_receives_snapshot_written_with_higher_index_2(Config) ->
     %% then the snapshot written event is received after the higher index
     %% has been received
     receive
-        {ra_log_event, {snapshot_written, {55, 2} = IdxTerm, Indexes, snapshot}} ->
+        {ra_log_event, {snapshot_written, {55, 2} = IdxTerm, Indexes, snapshot, _}} ->
             State5 = ra_snapshot:complete_snapshot(IdxTerm, snapshot, Indexes, State4),
             undefined = ra_snapshot:pending(State5),
             {165, 2} = ra_snapshot:current(State5),


### PR DESCRIPTION
Include the time taken to write snapshots and checkpoints in the log output to help monitor snapshot write performance, especially for very large state machines.

Example log output:
```
ra_log: snapshot written at index 1454586 with 1000840 live indexes in 1234ms
```