### PR TITLE
Update GitHub Actions to pinned SHA versions

### DIFF
--- a/.github/scripts/check-actions-updates.sh
+++ b/.github/scripts/check-actions-updates.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+declare -i update_count=0
+
+tmp="$(mktemp)"
+readonly tmp
+
+function cleanup {
+    rm -f "$tmp"
+}
+
+trap cleanup EXIT
+
+set +o errexit
+npx actions-up --dry-run > "$tmp" 2>&1
+set -o errexit
+
+if grep -Fq 'would be updated' "$tmp"
+then
+    update_count="$(awk '/would be updated/ { print $1 }' "$tmp")"
+    declare -ri update_count
+fi
+
+if (( update_count > 0 ))
+then
+    echo "has-updates=true" >> "$GITHUB_OUTPUT"
+    echo "update-count=$update_count" >> "$GITHUB_OUTPUT"
+else
+    echo "has-updates=false" >> "$GITHUB_OUTPUT"
+    echo "update-count=0" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/check-actions-updates.yml
+++ b/.github/workflows/check-actions-updates.yml
@@ -1,0 +1,26 @@
+name: Check-Actions-Updates
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 16 * * 2' # Runs Tuesdays at 16:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  check-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - id: actions-check
+        run: ${{ github.workspace }}/.github/scripts/check-actions-updates.sh
+      - if: steps.actions-check.outputs.has-updates == 'true'
+        run: |
+          echo "::error:: Found ${{ steps.actions-check.outputs.update-count }} outdated GitHub Actions!"
+          echo "::info:: You can update them by running: "npx actions-up --yes" and opening a PR."
+          exit 1

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -13,9 +13,9 @@ jobs:
         otp_version: [26, 27, 28]
     steps:
     - name: CHECKOUT
-      uses: actions/checkout@v2
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: CONFIGURE ERLANG
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
       with:
         otp-version: ${{ matrix.otp_version }}
     - name: XREF
@@ -34,7 +34,7 @@ jobs:
     - name: PROPER
       run: make proper
     - name: CAPTURE TEST LOGS ON FAILURE
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       if: failure()
       with:
         name: ct-logs-${{matrix.otp_version}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: CHECKOUT
-      uses: actions/checkout@v3
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         path: ra
     - name: CONFIGURE OTP & ELIXIR
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
       with:
         otp-version: 26
     - name: ASSERT VERSIONS
@@ -33,7 +33,7 @@ jobs:
           https://github.com/${{ github.repository }}/archive/${{ github.ref }}.tar.gz
     - name: CREATE RELEASE
       id: create-release
-      uses: ncipollo/release-action@v1.13.0
+      uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0
       with:
         allowUpdates: true
         artifactErrorsFailBuild: true

--- a/.github/workflows/trigger-jepsen.yml
+++ b/.github/workflows/trigger-jepsen.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Trigger RA Jepsen Tests
-      uses: peter-evans/repository-dispatch@v2
+      uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
       with:
         event-type: ra_change
         repository: rabbitmq/ra-kv-store


### PR DESCRIPTION
The workflow files use unpinned action versions (e.g., `@v2`, `@v1`), which can introduce breaking changes or security vulnerabilities when action maintainers publish new releases under the same tag.

This change updates all GitHub Actions to use pinned SHA versions with version comments for readability:

- `actions/checkout@v2` → `@8e8c483` (v6.0.1)
- `erlef/setup-beam@v1` → `@e6d7c94` (v1.20.4)
- `actions/upload-artifact@v4` → `@b7c566a` (v6.0.0)
- `ncipollo/release-action@v1.13.0` → `@b7eabc9` (v1.20.0)
- `peter-evans/repository-dispatch@v2` → `@2895959` (v4.0.1)

Additionally, this adds a new workflow and script to detect outdated actions automatically. The `check-actions-updates.sh` script uses `actions-up` to identify available updates and fails the workflow when updates are found, ensuring the team is notified to keep actions current.