### PR TITLE
GitHub Actions: Use the `windows-2022` runner

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         otp_version: [26, 27, 28]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2022]
     steps:
     - name: CHECKOUT
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
## Why

The `windows-2025` looks way slower than the previous runners. Like it is twice as slow as the ubuntu-2024 runner for the same job.

## How

Using the `windows-2022` runner is also slower than the `ubuntu-2024` one, but only by about 20-25%.