### PR TITLE
Set last_applied counter when a snapshot is installed

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1598,6 +1598,7 @@ handle_receive_snapshot(#install_snapshot_rpc{term = Term,
                                         cluster => make_cluster(Id, ClusterIds),
                                         membership => get_membership(ClusterIds, State0),
                                         machine_state => MacState}),
+            put_counter(Cfg, ?C_RA_SVR_METRIC_LAST_APPLIED, SnapIndex),
             %% it was the last snapshot chunk so we can revert back to
             %% follower status
             {follower, persist_last_applied(State), [{reply, Reply} |


### PR DESCRIPTION
When a follower installs a snapshot it moves its last-applied index forward to the snapshot index. This was done for the `last_applied` key in the server state and the last-applied index was persisted, but the corresponding counter was not set to the new index. So, after installing a snapshot, a follower's last-applied index reflected the pre-snapshot-installation index until the server handled any new commands. This change sets the last-applied index counter after the snapshot is installed.

NOTE: this change was already made in #494. This PR backports the change to a new v2.17.x branch I've pushed which we can use for fixes for 4.2.x patch releases. Fixes https://github.com/rabbitmq/rabbitmq-server/issues/15382