### PR TITLE
Export ra_log_segment:dump/2 helper

### DIFF
--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -29,6 +29,7 @@
          copy/3]).
 
 -export([dump/1,
+         dump/2,
          dump_index/1]).
 
 -include("ra.hrl").


### PR DESCRIPTION
This can be useful when debugging segment file contents, for example to decode the record with `erlang:binary_to_term/1` or to find each record's byte size.

I think it may have just been an oversight that it was not already exported since `dump/1` is.