### PR TITLE
Wal gap detection fixes

### DIFF
--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1210,6 +1210,7 @@ terminate(Reason, StateName,
             %% This is so that the segment writer can avoid
             %% crashing if it detects a missing key
             catch ra_directory:unregister_name(Names, UId),
+            catch ra_log_wal:forget_writer(maps:get(wal, Names), UId),
             _ = ra_server:terminate(ServerState, Reason),
             catch ra_log_meta:delete_sync(MetaName, UId),
             catch ra_counters:delete(Id),

--- a/test/ra_log_wal_writers_bench.erl
+++ b/test/ra_log_wal_writers_bench.erl
@@ -1,0 +1,80 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Micro-benchmark for measuring the overhead of persisting the WAL
+%% writers snapshot file at roll-over time.
+%%
+%% Usage from an Erlang shell (after compiling):
+%%   ra_log_wal_writers_bench:run().
+-module(ra_log_wal_writers_bench).
+
+-export([run/0]).
+
+run() ->
+    Dir = filename:join(["/tmp", "ra_wal_writers_bench_" ++
+                         integer_to_list(erlang:system_time(microsecond))]),
+    ok = filelib:ensure_dir(filename:join(Dir, "dummy")),
+    try
+        io:format("~n=== WAL Writers Snapshot Micro-Benchmark ===~n~n"),
+        io:format("~-15s ~-15s ~-15s ~-15s~n",
+                  ["Writers", "Serialize(us)", "Write(us)", "Total(us)"]),
+        io:format("~s~n", [lists:duplicate(60, $-)]),
+        lists:foreach(
+          fun (N) ->
+                  bench_writers(Dir, N)
+          end, [10, 100, 1000, 10000]),
+        io:format("~n=== Baseline: roll-over file operations ===~n~n"),
+        bench_rollover_baseline(Dir),
+        io:format("~nDone.~n")
+    after
+        os:cmd("rm -rf " ++ Dir)
+    end.
+
+bench_writers(Dir, NumWriters) ->
+    Writers = maps:from_list(
+                [{list_to_binary(io_lib:format("uid_~6..0b", [I])),
+                  {in_seq, rand:uniform(1000000)}}
+                 || I <- lists:seq(1, NumWriters)]),
+    Iters = 100,
+    WritersFile = filename:join(Dir, "writers.snapshot"),
+    TmpFile = WritersFile ++ ".tmp",
+    {SerUs, WriteUs} =
+        lists:foldl(
+          fun (_I, {SAcc, WAcc}) ->
+                  {SerTime, Bin} = timer:tc(fun () ->
+                                                    term_to_binary(Writers)
+                                            end),
+                  {WriteTime, ok} = timer:tc(fun () ->
+                                                     ok = ra_lib:write_file(TmpFile, Bin),
+                                                     prim_file:rename(TmpFile, WritersFile)
+                                             end),
+                  {SAcc + SerTime, WAcc + WriteTime}
+          end, {0, 0}, lists:seq(1, Iters)),
+    AvgSer = SerUs div Iters,
+    AvgWrite = WriteUs div Iters,
+    io:format("~-15b ~-15b ~-15b ~-15b~n",
+              [NumWriters, AvgSer, AvgWrite, AvgSer + AvgWrite]).
+
+bench_rollover_baseline(Dir) ->
+    Iters = 100,
+    io:format("Measuring file open + close + sync_dir (~b iterations):~n", [Iters]),
+    TotalUs =
+        lists:foldl(
+          fun (I, Acc) ->
+                  File = filename:join(Dir, io_lib:format("baseline_~b.wal", [I])),
+                  Tmp = File ++ ".tmp",
+                  {ok, TmpFd} = file:open(Tmp, [write, binary, raw]),
+                  ok = file:write(TmpFd, <<"RAWA", 1:8/unsigned>>),
+                  ok = file:sync(TmpFd),
+                  ok = file:close(TmpFd),
+                  {Time, _} = timer:tc(fun () ->
+                                               ok = prim_file:rename(Tmp, File),
+                                               {ok, Fd} = file:open(File, [raw, write, read, binary]),
+                                               {ok, 5} = file:position(Fd, 5),
+                                               ok = file:close(Fd)
+                                       end),
+                  Acc + Time
+          end, 0, lists:seq(1, Iters)),
+    Avg = TotalUs div Iters,
+    io:format("  Average roll-over file ops: ~b us~n", [Avg]).


### PR DESCRIPTION

The WAL writers map tracks the last index written by each ra server
and is used for gap detection. Previously this state was only recovered
by replaying .wal files on disk, so if the segment writer deleted a
WAL file and the WAL then crashed before the new file had any entries,
all tracking was lost. Subsequent writes with gaps would be silently
accepted, leading to gaps in segments.

Write a writers.snapshot file in the WAL directory on every roll-over.
During recovery, seed the writers map from this file before replaying
any WAL files. The snapshot is overwritten in place on each roll-over
so there is no cleanup needed.

Micro-benchmark shows < 200us overhead per roll-over for typical
deployments (up to a few hundred writers).

GC stale entries from the WAL writers map

The writers map grows monotonically -- when a ra server is deleted its
entry persists in memory and in the writers.snapshot file forever.

Add two complementary cleanup mechanisms:

1. At recovery time, trim the writers map against ra_directory to
   remove entries for UIDs that are no longer registered.

2. At runtime, accept a forget_writer cast so that servers being
   deleted can evict their entry immediately. Called from
   ra_server_proc:terminate/3 on {shutdown, delete}.

Phase 1 is the reliable catch-all; phase 2 handles the common case
without waiting for a WAL restart.

Fix log state divergence after mem table overwrites segment range

During init, when the mem table contains entries that overwrite part of
the segment range, the segment range upper bound was not being clamped.
This caused MaxConfirmedWrittenIdx and LastSegRefIdx to be derived from
stale segment indexes, leading to incorrect last_written_index_term and
pending state after restart.

Fix ra_range:combine/2 to clamp the upper bound to AddRange's end,
since AddRange represents newer data that supersedes the tail of the
existing range. Compute a TruncSegmentRange in ra_log:init/1 that
excludes segment indexes overwritten by the mem table, and use it
when recovering MaxConfirmedWrittenIdx and LastSegRefIdx.

Harden take_after_overwrite_and_init to assert that the log overview
is consistent across close and re-init