### PR TITLE
ra_server: Evaluate member promotion in `#install_snapshot_result{}`

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -775,7 +775,8 @@ handle_leader({PeerId, #install_snapshot_result{last_index = LastIndex}},
             %% Check if pending release cursor can now proceed
             %% (no_snapshot_sends condition may now be satisfied)
             {State2, Effects1} = maybe_emit_pending_release_cursor(State1, Effects0),
-            {State, _, Effects} = make_pipelined_rpc_effects(State2, Effects1),
+            Effects2 = maybe_promote_peer(PeerId, State2, Effects1),
+            {State, _, Effects} = make_pipelined_rpc_effects(State2, Effects2),
             {leader, State, Effects}
     end;
 handle_leader(pipeline_rpcs, State0) ->

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -82,6 +82,7 @@ all() ->
      snapshotted_follower_received_append_entries,
      leader_received_append_entries_reply_with_stale_last_index,
      leader_receives_install_snapshot_result,
+     leader_received_install_snapshot_result_and_promotes_voter,
      leader_received_append_entries_reply_and_promotes_voter,
      leader_replies_to_append_entries_rpc_with_lower_term,
      follower_aer_1,
@@ -3004,7 +3005,22 @@ leader_receives_install_snapshot_result(_Config) ->
                          (_) -> false end, Effects)),
     ok.
 
-leader_received_append_entries_reply_and_promotes_voter(_config) ->
+leader_received_install_snapshot_result_and_promotes_voter(_Config) ->
+    N2 = ?N2, N3 = ?N3, State = base_state(3, ?FUNCTION_NAME),
+    State1 = set_peer_voter_status(State, N3, #{membership => promotable,
+                                                target => 3}),
+    ISR = #install_snapshot_result{term = 5,
+                                   last_index = 3,
+                                   last_term = 5},
+    {leader, _,
+     [{send_rpc, N2, #append_entries_rpc{entries = []}},
+      {next_event,
+       {command, {'$ra_join', _,
+                     #{id := N3, voter_status := #{membership := voter}},
+        noreply}}}]} = ra_server:handle_leader({N3, ISR}, State1),
+    ok.
+
+leader_received_append_entries_reply_and_promotes_voter(_Config) ->
     N3 = ?N3, State = base_state(3, ?FUNCTION_NAME),
     AER = #append_entries_reply{term = 5, success = true,
                                 next_index = 5,


### PR DESCRIPTION
Currently, promotable members can get "stuck" as promotable until the next command is appended if they join the cluster and only install a snapshot from the leader. We can evaluate promoting the peer when handling `#install_snapshot_result{}` to ensure the member becomes a voter.

I haven't been able to reproduce this yet but I've seen this in the wild with RabbitMQ 4.2.0:

```json
[
{"Node Name":"rabbit@<node1>","Raft State":"follower","Membership":"promotable","Last Log Index":219,"Last Written":219,"Last Applied":219,"Commit Index":219,"Snapshot Index":219,"Term":1,"Machine Version":7}
,{"Node Name":"rabbit@<node2>","Raft State":"follower","Membership":"voter","Last Log Index":219,"Last Written":219,"Last Applied":219,"Commit Index":219,"Snapshot Index":219,"Term":1,"Machine Version":7}
,{"Node Name":"rabbit@<node3>","Raft State":"leader","Membership":"voter","Last Log Index":219,"Last Written":219,"Last Applied":219,"Commit Index":219,"Snapshot Index":219,"Term":1,"Machine Version":7}
]
```

~I'll look at writing a test...~ :heavy_check_mark: 