### PR TITLE
ra_server: Evaluate member promotion in `#install_snapshot_result{}` (backport #584)

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -719,7 +719,8 @@ handle_leader({PeerId, #install_snapshot_result{last_index = LastIndex}},
                            _ -> []
                        end,
 
-            {State, _, Effects} = make_pipelined_rpc_effects(State1, Effects0),
+            Effects1 = maybe_promote_peer(PeerId, State1, Effects0),
+            {State, _, Effects} = make_pipelined_rpc_effects(State1, Effects1),
             {leader, State, Effects}
     end;
 handle_leader(pipeline_rpcs, State0) ->

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -67,6 +67,7 @@ all() ->
      snapshotted_follower_received_append_entries,
      leader_received_append_entries_reply_with_stale_last_index,
      leader_receives_install_snapshot_result,
+     leader_received_install_snapshot_result_and_promotes_voter,
      leader_received_append_entries_reply_and_promotes_voter,
      leader_replies_to_append_entries_rpc_with_lower_term,
      follower_aer_1,
@@ -2598,7 +2599,22 @@ leader_receives_install_snapshot_result(_Config) ->
                          (_) -> false end, Effects)),
     ok.
 
-leader_received_append_entries_reply_and_promotes_voter(_config) ->
+leader_received_install_snapshot_result_and_promotes_voter(_Config) ->
+    N2 = ?N2, N3 = ?N3, State = base_state(3, ?FUNCTION_NAME),
+    State1 = set_peer_voter_status(State, N3, #{membership => promotable,
+                                                target => 3}),
+    ISR = #install_snapshot_result{term = 5,
+                                   last_index = 3,
+                                   last_term = 5},
+    {leader, _,
+     [{send_rpc, N2, #append_entries_rpc{entries = []}},
+      {next_event,
+       {command, {'$ra_join', _,
+                     #{id := N3, voter_status := #{membership := voter}},
+        noreply}}}]} = ra_server:handle_leader({N3, ISR}, State1),
+    ok.
+
+leader_received_append_entries_reply_and_promotes_voter(_Config) ->
     N3 = ?N3, State = base_state(3, ?FUNCTION_NAME),
     AER = #append_entries_reply{term = 5, success = true,
                                 next_index = 5,


### PR DESCRIPTION
Currently, promotable members can get "stuck" as promotable until the next command is appended if they join the cluster and only install a snapshot from the leader. We can evaluate promoting the peer when handling `#install_snapshot_result{}` to ensure the member becomes a voter.

#584 is a small change so I think we should backport it to v2.17.x.