### PR TITLE
Propagate IO errors to the writer on log segment close

### DIFF
--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -313,6 +313,8 @@ sync(State0) ->
     end.
 
 -spec flush(state()) -> {ok, state()} | {error, term()}.
+flush(#state{pending_index = []} = State) ->
+    {ok, State};
 flush(#state{cfg = #cfg{fd = Fd},
              pending_data = PendData,
              pending_index = PendIndex,
@@ -711,7 +713,7 @@ segref(#state{range = Range,
 segref(Filename) ->
     {ok, Seg} = open(Filename, #{mode => read}),
     SegRef = segref(Seg),
-    close(Seg),
+    close_fd(Seg),
     SegRef.
 
 -type infos() :: #{size => non_neg_integer(),
@@ -788,13 +790,20 @@ info(Filename, Live0)
 is_same_as(#state{cfg = #cfg{filename = Fn0}}, Fn) ->
     is_same_filename_all(Fn0, Fn).
 
--spec close(state()) -> ok.
-close(#state{cfg = #cfg{fd = Fd,
-                        mode = append,
-                        file_advise = FileAdvise}} = State) ->
-    % close needs to be defensive and idempotent so we ignore the return
-    % values here
-    _ = sync(State),
+-spec close(state()) -> ok | {error, term()}.
+close(#state{cfg = #cfg{mode = read}} = State) ->
+    close_fd(State);
+close(#state{} = State0) ->
+    case sync(State0) of
+        {ok, State} ->
+            close_fd(State);
+        {error, _} = Err ->
+            Err
+    end.
+
+close_fd(#state{cfg = #cfg{fd = Fd,
+                           mode = append,
+                           file_advise = FileAdvise}} = State) ->
     _ = case is_full(State) of
             true ->
                 file:advise(Fd, 0, 0, FileAdvise);
@@ -803,7 +812,7 @@ close(#state{cfg = #cfg{fd = Fd,
         end,
     _ = file:close(Fd),
     ok;
-close(#state{cfg = #cfg{fd = Fd}}) ->
+close_fd(#state{cfg = #cfg{fd = Fd}}) ->
     _ = file:close(Fd),
     ok.
 
@@ -814,7 +823,7 @@ copy(#state{} = State0, FromFile, Indexes)
     {ok, From} = open(FromFile, #{mode => read}),
     SortedIndexes = lists:sort(Indexes),
     State = copy_with_cache(From, State0, SortedIndexes),
-    close(From),
+    close_fd(From),
     sync(State).
 
 %% Optimized copy that batches reads for consecutive index runs.
@@ -1025,7 +1034,7 @@ dump(File, Fun) ->
     {Idx, Last} = range(S0),
     L = fold(S0, Idx, Last, Fun,
              fun (E, A) -> [E | A] end, []),
-    close(S0),
+    close_fd(S0),
     lists:reverse(L).
 
 

--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -208,7 +208,7 @@ handle_cast({truncate_segments, Who, {Name, _Range} = SegRef},
                 {ok, Seg} ->
                     case ra_log_segment:segref(Seg) of
                         SegRef ->
-                            _ = ra_log_segment:close(Seg),
+                            ok = ra_log_segment:close(Seg),
                             %% it has not changed - we can delete that too
                             _ = prim_file:delete(Pivot),
                             %% as we are deleting the last segment - create an empty
@@ -224,7 +224,7 @@ handle_cast({truncate_segments, Who, {Name, _Range} = SegRef},
                                     %% segment was opened
                                     {noreply, State0};
                                 Succ ->
-                                    _ = ra_log_segment:close(Succ),
+                                    ok = ra_log_segment:close(Succ),
                                     {noreply, State0}
                             end;
                         _ ->
@@ -234,7 +234,7 @@ handle_cast({truncate_segments, Who, {Name, _Range} = SegRef},
                                                             millisecond),
                             ?DEBUG("segment_writer in '~w': ~s for ~s took ~bms",
                                    [System, ?FUNCTION_NAME, Who, Diff]),
-                            _ = ra_log_segment:close(Seg),
+                            ok = ra_log_segment:close(Seg),
                             {noreply, State0}
                     end;
                 {error, enoent} ->
@@ -367,7 +367,7 @@ flush_mem_table_range(ServerUId, {Tid, Seq},
                                       [SRef | ClosedSegRefs]
                               end,
 
-                    _ = ra_log_segment:close(Segment),
+                    close_segment(Segment),
                     _ = ra_lib:sync_dir(Dir),
                     SegRefs
             end
@@ -460,6 +460,7 @@ append_to_segment(UId, Tid, {Idx, SeqIter} = Cur, Seg0, Closed, State) ->
                     append_to_segment(UId, Tid, ra_seq:next(SeqIter), Seg, Closed, State);
                 {error, full} ->
                     % close and open a new segment
+                    close_segment(Seg0),
                     case open_successor_segment(Seg0, State#state.segment_conf) of
                         enoent ->
                             %% a successor cannot be opened - this is most likely due
@@ -511,7 +512,6 @@ segment_files(Dir) ->
 open_successor_segment(CurSeg, SegConf) ->
     Fn0 = ra_log_segment:filename(CurSeg),
     Fn = ra_lib:zpad_filename_incr(Fn0),
-    ok = ra_log_segment:close(CurSeg),
     case ra_log_segment:open(Fn, SegConf) of
         {error, enoent} ->
             %% the directory has been deleted whilst segments were being
@@ -519,6 +519,14 @@ open_successor_segment(CurSeg, SegConf) ->
             enoent;
         {ok, Seg} ->
             Seg
+    end.
+
+close_segment(CurSeg) ->
+    case ra_log_segment:close(CurSeg) of
+        ok -> ok;
+        {error, Posix} ->
+            FileName = ra_log_segment:filename(CurSeg),
+            error({segment_writer_sync_close_error, FileName, Posix})
     end.
 
 open_file(Dir, SegConf) ->

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -2453,12 +2453,11 @@ init_after_missing_segments_event(Config) ->
     ok.
 
 segment_close_flush_error_recovery(Config) ->
-    %% This test demonstrates that `ra_log_segment:close/1` silently discards
-    %% the return value of `flush/1`, causing the segment writer to report
-    %% segment refs covering entries that were never persisted to disk.
-    %% After restart the WAL file has already been deleted, hence:
-    %% 1. Those entries are permanently lost.
-    %% 2. Subsequent writes may lead to holes in log segments.
+    %% This test verifies that any IO errors during log segment flush
+    %% are propagated back to the log segment writer, including those
+    %% that happen at the time when log segment need to be closed.
+    %% Also correct recovery from such failures is verified, assuming
+    %% they are transient in nature.
 
     %% 1. Write entries 1-5 and flush them to a segment
     Log0 = ra_log_init(Config),
@@ -2488,8 +2487,8 @@ segment_close_flush_error_recovery(Config) ->
                 end),
 
     %% 4. Force WAL roll-over.
-    %%    Segment flush will fail but the log will still report success with a
-    %%    segref covering {0, 10}.
+    %%    Segment flush will fail initially and cause WAL to crash, but
+    %%    will succeed on WAL restart.
     ok = ra_log_wal:force_roll_over(ra_log_wal),
     Log6 = deliver_log_events_cond(
              Log5,
@@ -2498,7 +2497,6 @@ segment_close_flush_error_recovery(Config) ->
              end, 100),
 
     %% 5. Write two more entries to the log.
-    %%    Assuming there's just enough disk space for them.
     Log7 = write_n(11, 13, 1, Log6),
     Log8 = assert_log_events(Log7,
                              fun (L) -> {12, 1} =:= ra_log:last_written(L) end),
@@ -2509,8 +2507,6 @@ segment_close_flush_error_recovery(Config) ->
     start_ra(Config),
 
     %% 7. Re-init the log and verify all entries are persisted.
-    %%    With the bug, the segment on disk only contains entries 1-5 and 11-12,
-    %%    but not 6-10.
     Log9 = ra_log_init(Config),
     ct:pal("after recovery: ~p", [ra_log:overview(Log9)]),
 

--- a/test/ra_log_segment_SUITE.erl
+++ b/test/ra_log_segment_SUITE.erl
@@ -417,12 +417,12 @@ term_query(Config) ->
     {ok, Seg0} = ra_log_segment:open(Fn),
     {ok, Seg1} = ra_log_segment:append(Seg0, 5, 2, <<"a">>),
     {ok, Seg2} = ra_log_segment:append(Seg1, 6, 3, <<"b">>),
-    _ = ra_log_segment:close(Seg2),
+    ok = ra_log_segment:close(Seg2),
     {ok, Seg} = ra_log_segment:open(Fn, #{mode => read}),
     2 = ra_log_segment:term_query(Seg, 5),
     3 = ra_log_segment:term_query(Seg, 6),
     undefined = ra_log_segment:term_query(Seg, 7),
-    _ = ra_log_segment:close(Seg),
+    ok = ra_log_segment:close(Seg),
     ok.
 
 write_many(Config) ->
@@ -510,13 +510,13 @@ copy(Config) ->
                      {ok, S} = ra_log_segment:append(S0, I, 1, term_to_binary(I)),
                      S
              end, SrcSeg0, Indexes),
-    _ = ra_log_segment:close(SrcSeg1),
+    ok = ra_log_segment:close(SrcSeg1),
 
     Fn = filename:join(Dir, <<"TARGET.segment">>),
     {ok, Seg0} = ra_log_segment:open(Fn),
     CopyIndexes = lists:seq(1, 100, 2),
     {ok, Seg} = ra_log_segment:copy(Seg0, SrcFn, CopyIndexes),
-    ra_log_segment:close(Seg),
+    ok = ra_log_segment:close(Seg),
     {ok, R} = ra_log_segment:open(Fn, #{mode => read,
                                         access_pattern => random}),
     %%TODO: consider makeing read_sparse tolerant to missing indexes somehow
@@ -570,7 +570,7 @@ binary_mode_term_query(Config) ->
     {ok, Seg1} = ra_log_segment:append(Seg0, 5, 2, <<"a">>),
     {ok, Seg2} = ra_log_segment:append(Seg1, 6, 3, <<"b">>),
     {ok, Seg3} = ra_log_segment:append(Seg2, 7, 4, <<"c">>),
-    _ = ra_log_segment:close(Seg3),
+    ok = ra_log_segment:close(Seg3),
     
     %% Query with binary mode
     {ok, Seg} = ra_log_segment:open(Fn, #{mode => read, index_mode => binary}),
@@ -579,7 +579,7 @@ binary_mode_term_query(Config) ->
     4 = ra_log_segment:term_query(Seg, 7),
     undefined = ra_log_segment:term_query(Seg, 8),
     undefined = ra_log_segment:term_query(Seg, 4),
-    _ = ra_log_segment:close(Seg),
+    ok = ra_log_segment:close(Seg),
     ok.
 
 binary_mode_sequential_ascending(Config) ->

--- a/test/ra_log_segments_SUITE.erl
+++ b/test/ra_log_segments_SUITE.erl
@@ -907,7 +907,7 @@ run_scenario(Config, Segs0, [{entries, Term, IndexesOrEntries} | Rem]) ->
                        || I <- IndexesOrEntries]
               end,
     {Seg, Refs} = append_to_segment(Seg0, Entries, [], SegConf),
-    _ = ra_log_segment:close(Seg),
+    ok = ra_log_segment:close(Seg),
     {Segs, _Overwritten} = ra_log_segments:update_segments(Refs, Segs0),
     %% TODO: what to do about overwritten
     ?FUNCTION_NAME(Config, Segs, Rem);


### PR DESCRIPTION
## Proposed Changes

This PR is a followup to a [discussion](https://github.com/rabbitmq/ra/pull/578#issuecomment-3968084873) in #578.

IO errors during log segment close are now propagated to the segment writer, causing whole WAL flush operation to fail. 

This change essentially makes IO error handling consistent: before this PR, such errors were properly propagated during flush-on-append [[1]](https://github.com/rabbitmq/ra/blob/153810b521439e1418b03c67a1aec5acb3a8efb0/src/ra_log_segment_writer.erl#L484) but not during flush-on-close [[2]](https://github.com/rabbitmq/ra/blob/153810b521439e1418b03c67a1aec5acb3a8efb0/src/ra_log_segment_writer.erl#L370) [[3]](https://github.com/rabbitmq/ra/blob/153810b521439e1418b03c67a1aec5acb3a8efb0/src/ra_log_segment.erl#L797). This could have subsequently caused affected log segments to have holes in the index sequence, which is demonstrated in `segment_close_flush_error_recovery` testcase.

I did my best to make it reviewable commit-by-commit.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added necessary documentation (if appropriate)~~
- [ ] ~~Any dependent changes have been merged and published in related repositories~~
