### PR TITLE
Handle DOWN signals in candidate state

### DIFF
--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -700,6 +700,11 @@ candidate(EventType, {aux_command, Cmd}, State0) ->
     {keep_state, State, Actions};
 candidate({call, From}, ping, State) ->
     {keep_state, State, [{reply, From, {pong, candidate}}]};
+candidate(info, {'DOWN', _MRef, process, Pid, Info}, State0) ->
+    handle_process_down(Pid, Info, ?FUNCTION_NAME, State0);
+candidate(info, {Status, Node, InfoList}, State0)
+  when Status =:= nodedown orelse Status =:= nodeup ->
+    handle_node_status_change(Node, Status, InfoList, ?FUNCTION_NAME, State0);
 candidate(info, {node_event, _Node, _Evt}, State) ->
     {keep_state, State};
 candidate(_, tick_timeout,


### PR DESCRIPTION
## Proposed Changes

This PR adds a couple of missing clauses to `candidate` state handler to make it handle process monitor and node signals consistently with other states. This, for example, prevents aux handlers from losing monitor signal emitted when the server is in `candidate` state.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added necessary documentation (if appropriate)~~
- [ ] ~~Any dependent changes have been merged and published in related repositories~~
