### PR TITLE
Segment writer: read the full snapshot state ETS record atomically.

### DIFF
--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -269,11 +269,9 @@ flush_mem_table_ranges({ServerUId, TidSeqs0},
                        #state{system = System} = State) ->
     %% Get the smallest index that should be written to segments.
     %% This is the minimum of (snapshot_index + 1) and the first live index.
-    SmallestIdx = smallest_live_idx(ServerUId),
     %% Get the sparse sequence of live indexes that must be preserved
     %% beyond the snapshot boundary for compaction.
-    LiveIndexes = live_indexes(ServerUId),
-    SnapIdx = snapshot_idx(ServerUId),
+    {_, SnapIdx, SmallestIdx, LiveIndexes} = snapshot_state(ServerUId),
     %% TidSeqs arrive here sorted new -> old.
 
     %% Truncate and limit all seqs to create a non-overlapping list of
@@ -380,11 +378,13 @@ start_index(ServerUId, StartIdx0) ->
 smallest_live_idx(ServerUId) ->
     ra_log_snapshot_state:smallest(ra_log_snapshot_state, ServerUId).
 
-snapshot_idx(ServerUId) ->
-    ra_log_snapshot_state:snapshot(ra_log_snapshot_state, ServerUId).
-
-live_indexes(ServerUId) ->
-    ra_log_snapshot_state:live_indexes(ra_log_snapshot_state, ServerUId).
+snapshot_state(ServerUId) ->
+    case ra_log_snapshot_state:read(ra_log_snapshot_state, ServerUId) of
+        undefined ->
+            {ServerUId, -1, 0, []};
+        Res ->
+            Res
+    end.
 
 %% @doc Sends segment update notification to the Ra server.
 %% If the server is not running, cleans up the memtable entries

--- a/src/ra_log_snapshot_state.erl
+++ b/src/ra_log_snapshot_state.erl
@@ -11,7 +11,8 @@
          delete/2,
          smallest/2,
          live_indexes/2,
-         snapshot/2
+         snapshot/2,
+         read/2
         ]).
 
 -spec insert(ets:table(), ra:uid(), -1 | ra:index(), ra:index(), ra_seq:state()) ->
@@ -42,6 +43,20 @@ live_indexes(Table, UId) when is_binary(UId) ->
     ra:index() | -1.
 snapshot(Table, UId) when is_binary(UId) ->
     ets:lookup_element(Table, UId, 2, -1).
+
+-spec read(ets:table(), ra:uid()) ->
+    undefined |
+    {UId :: ra:uid(),
+     SnapIdx :: -1 | ra:index(),
+     SmallestIdx :: ra:index(),
+     LiveIndexes :: ra_seq:state()}.
+read(Table, UId) when is_binary(UId) ->
+    case ets:lookup(Table, UId) of
+        [] ->
+            undefined;
+        [Record] ->
+            Record
+    end.
 
 %%% ===================
 %%% Internal unit tests


### PR DESCRIPTION
The current approoch of reading the snapshot index then the live indexes is prone to a race condition where the snapshot state is updated in betweeen reading the snapshot index and the live indexes.

E.g.

Snapshot is taken at index 10 with [7, 5, 3, 1]
Snapshot is taken at index 15 with [13, 11, 5, 3, 1]

Segment writer reads live indexes [7, 5, 3, 1] but snapshot index 15.

13 and 11 will not be written but 7 will be unnecesarily.
