### PR TITLE
Bump `gen_batch_server` to `0.9.0`

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-        {gen_batch_server, "0.8.9"},
+        {gen_batch_server, "0.9.0"},
         {aten, "0.6.0"},
         {seshat, "1.0.1"}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 {"1.2.0",
 [{<<"aten">>,{pkg,<<"aten">>,<<"0.6.0">>},0},
- {<<"gen_batch_server">>,{pkg,<<"gen_batch_server">>,<<"0.8.9">>},0},
+ {<<"gen_batch_server">>,{pkg,<<"gen_batch_server">>,<<"0.9.0">>},0},
  {<<"seshat">>,{pkg,<<"seshat">>,<<"1.0.1">>},0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
This `gen_batch_server` release requires Erlang/OTP 26+, which is perfectly fine for modern Osiris and RabbitMQ.

Besides improved modern `gen_server` compatibility there are mid-single digit % throughput gains (a positive side effect from the refactoring).

See https://github.com/rabbitmq/gen-batch-server/releases/tag/v0.9.0.