### PR TITLE
Replace catch with try/catch in handle_leader/2

### DIFF
--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1323,7 +1323,7 @@ handle_enter(RaftState, OldRaftState,
 
 handle_leader(Msg, #state{server_state = ServerState0} = State0) ->
     try ra_server:handle_leader(Msg, ServerState0) of
-        {NextState, ServerState, Effects}  ->
+        {NextState, ServerState, Effects} ->
             State1 = State0#state{server_state =
                                   ra_server:persist_last_applied(ServerState)},
             %% The last applied index made progress. Check if there are
@@ -1331,11 +1331,20 @@ handle_leader(Msg, #state{server_state = ServerState0} = State0) ->
             {State, Actions} = perform_pending_queries(leader, State1),
             maybe_record_cluster_change(State0, State),
             {NextState, State, Effects ++ Actions}
-    catch Class:Reason:Stacktrace ->
-              ?ERR("~ts: handle_leader err ~p ~0P~n~p",
-                   [log_id(State0), Class, Reason, 10,
-                    safe_stacktrace(Stacktrace)]),
-              exit(Reason)
+    catch
+        throw:{NextState, ServerState, Effects} when is_atom(NextState) andalso
+                                                     is_map(ServerState) andalso
+                                                     is_list(Effects) ->
+            State1 = State0#state{server_state =
+                                  ra_server:persist_last_applied(ServerState)},
+            {State, Actions} = perform_pending_queries(leader, State1),
+            maybe_record_cluster_change(State0, State),
+            {NextState, State, Effects ++ Actions};
+        Class:Reason:Stacktrace ->
+            ?ERR("~ts: handle_leader err ~p ~0P~n~p",
+                 [log_id(State0), Class, Reason, 10,
+                  safe_stacktrace(Stacktrace)]),
+            exit(Reason)
     end.
 
 handle_raft_state(RaftState, Msg,


### PR DESCRIPTION
The catch expression captured the full exception term including
the stacktrace, which could contain the entire Ra server state
in its function arguments. Logging this with ~p caused
io_lib_pretty to traverse the massive term, triggering extreme
memory allocation and OOM crashes for servers with large machine
states (e.g. millions of messages).

In this case the node crashed due to OOM because there was a
function_clause error in the state machine implementation where the
state machine had a huge state.
We still need the stack trace to locate where the function_clause
originates from.

Prior to this commit, the following function_clause caused the node to run out of memory. With this commit, we will get the following log printed:
```
 queue 'my-jms-queue' in vhost '/': handle_leader err error function_clause
 [{rabbit_jms_machine,merge_consumer,7,
                      [{file,"rabbit_jms_machine.erl"},{line,2240}]},
  {rabbit_jms_machine,apply_,3,[{file,"rabbit_jms_machine.erl"},{line,409}]},
  {ra_server,apply_with,2,[{file,"src/ra_server.erl"},{line,3279}]},
  {ra_log_segment,fold0,7,[{file,"src/ra_log_segment.erl"},{line,674}]},
  {ra_log_segments,'-segment_fold/6-fun-0-',5,
                   [{file,"src/ra_log_segments.erl"},{line,592}]},
  {ra_log_segments,'-segment_fold/6-lists^foldl/2-1-',3,
                   [{file,"src/ra_log_segments.erl"},{line,589}]},
  {ra_log_segments,segment_fold,6,
                   [{file,"src/ra_log_segments.erl"},{line,589}]},
  {ra_log,fold,6,[{file,"src/ra_log.erl"},{line,633}]}]

```
