### PR TITLE
Fix doubly-wrapped log entries after sparse write and recovery

### DIFF
--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -567,7 +567,7 @@ write([{Idx, _, _} | _], #?MODULE{cfg = #cfg{uid = UId},
 
 -spec write_sparse(log_entry(), option(ra:index()), state()) ->
     {ok, state()} | {error, wal_down | gap_detected}.
-write_sparse({Idx, Term, _} = Entry, PrevIdx0,
+write_sparse({Idx, Term, Cmd} = Entry, PrevIdx0,
              #?MODULE{cfg = #cfg{uid = UId,
                                  wal = Wal} = Cfg,
                       range = Range,
@@ -581,7 +581,7 @@ write_sparse({Idx, Term, _} = Entry, PrevIdx0,
     Tid = ra_mt:tid(Mt),
     PrevIdx = previous_wal_index(State0),
     case ra_log_wal:write(Wal, {UId, self()}, Tid, PrevIdx, Idx,
-                          Term, Entry) of
+                          Term, Cmd) of
         {ok, Pid} ->
             ok = incr_counter(Cfg, ?C_RA_LOG_WRITE_OPS, 1),
             put_counter(Cfg, ?C_RA_SVR_METRIC_LAST_INDEX, Idx),

--- a/test/ra_log_SUITE.erl
+++ b/test/ra_log_SUITE.erl
@@ -23,6 +23,7 @@ all_tests() ->
      append_then_fetch,
      write_then_fetch,
      write_sparse_then_fetch,
+     write_sparse_then_recover,
      append_then_fetch_no_wait,
      write_then_overwrite,
      append_integrity_error,
@@ -116,6 +117,35 @@ write_sparse_then_fetch(Config) ->
     {Idx5, Term} = ra_log:last_written(Log),
     {Idx5, _} = ra_log:last_index_term(Log),
     {{Idx5, Term, "entry+5"}, Log} = ra_log:fetch(Idx5, Log),
+    ok.
+
+write_sparse_then_recover(Config) ->
+    Log0 = ?config(ra_log, Config),
+    InitFun = ?config(init_fun, Config),
+    Term = 1,
+    Idx = ra_log:next_index(Log0),
+    Idx5 = Idx + 5,
+    Entry1 = {Idx, Term, "entry"},
+    %% sparse
+    Entry2 = {Idx5, Term, "entry+5"},
+
+    {LastIdx0, _} = ra_log:last_index_term(Log0),
+    {ok, Log1} = ra_log:write_sparse(Entry1, LastIdx0, Log0),
+    {ok, Log2} = ra_log:write_sparse(Entry2, Idx, Log1),
+    Log3 = await_written_idx(Idx5, Term, Log2),
+
+    %% close log
+    ok = ra_log:close(Log3),
+
+    %% restart ra to force WAL recovery from disk
+    application:stop(ra),
+    {ok, _} = ra:start_in(?config(priv_dir, Config)),
+
+    %% recover
+    Log4 = InitFun(write_sparse_then_recover),
+
+    {{Idx, Term, "entry"}, Log5} = ra_log:fetch(Idx, Log4),
+    {{Idx5, Term, "entry+5"}, _Log6} = ra_log:fetch(Idx5, Log5),
     ok.
 
 append_then_fetch_no_wait(Config) ->


### PR DESCRIPTION
When a follower receives a pre-snapshot chunk, it uses `ra_log:write_sparse/3` to write the entries to the WAL. However, `write_sparse/3` was passing the entire `log_entry()` tuple `{Idx, Term, Cmd}` as the payload to the WAL, instead of just the `Cmd`.

When the node is restarted, the WAL recovery process reads the payload and wraps it in a new `{Idx, Term, Payload}` tuple. Because the payload was already a full `log_entry()` tuple, the recovered entry became doubly-wrapped: `{Idx, Term, {Idx, Term, Cmd}}`.

This caused a `badmatch` error in `rabbit_jms_machine:exec_read/3` when `rabbit_jms_queue_client` attempted to read messages for delivery. The `ra_server:transform_for_partial_read/3` function failed to strip the Raft metadata because the doubly-wrapped entry did not match the expected `{'$usr', ...}` pattern, causing raw Raft metadata to be returned instead of the expected JMS message.

This commit fixes the issue by passing only the `Cmd` to the WAL in `write_sparse/3`, matching the behavior of normal appends. A test case has been added to verify that sparse writes survive recovery without being doubly-wrapped.
