### PR TITLE
Do not clear pending if points to the checkpoint

### DIFF
--- a/src/ra_snapshot.erl
+++ b/src/ra_snapshot.erl
@@ -724,8 +724,16 @@ complete_snapshot({Idx, _} = IdxTerm, snapshot, LiveIndexes, SnapshotSize,
                   current = IdxTerm,
                   snapshot_size = SnapshotSize};
 complete_snapshot(IdxTerm, checkpoint, _LiveIndexes, _SnapshotSize,
-                  #?MODULE{checkpoints = Checkpoints0} = State) ->
-    State#?MODULE{pending = undefined,
+                  #?MODULE{pending = Pending,
+                           checkpoints = Checkpoints0} = State) ->
+    %% Only clear pending if it still points at this checkpoint.
+    %% A concurrent promote_checkpoint may have overwritten pending
+    %% with a snapshot entry that must not be discarded.
+    NewPending = case Pending of
+                     {IdxTerm, checkpoint} -> undefined;
+                     _ -> Pending
+                 end,
+    State#?MODULE{pending = NewPending,
                   checkpoints = [IdxTerm | Checkpoints0]}.
 
 -spec begin_accept(meta(), state()) ->


### PR DESCRIPTION
With Rav3 Tanzu DQ's log writer errors as soon as snapshot is requested. For example,

```
2026-03-25 22:50:44.857425+01:00 [warning] <0.1364.0> segment_writer: missing index 313868 in mem table for uid DQ_2F_57D0UL0CNGN2start index 313868 checking to see if UId has been unregistered
2026-03-25 22:50:44.857523+01:00 [error] <0.1364.0> segment_writer: uid <redacted> is registered, exiting...
2026-03-25 22:50:44.857629+01:00 [error] <0.1341.0> segment_writer: 1 failures encountered during segment flush. Errors: [{{<<"redacted">>,
2026-03-25 22:50:44.857629+01:00 [error] <0.1341.0>                                                                         [{#Ref<0.588533474.2887385091.231957>,
2026-03-25 22:50:44.857629+01:00 [error] <0.1341.0>                                                                           [{313868,
2026-03-25 22:50:44.857629+01:00 [error] <0.1341.0>                                                                             699049}]}]},
2026-03-25 22:50:44.857629+01:00 [error] <0.1341.0>                                                                        {missing_index,
2026-03-25 22:50:44.857629+01:00 [error] <0.1341.0>                                                                         <<"redacted">>,
2026-03-25 22:50:44.857629+01:00 [error] <0.1341.0>                                                                         313868}}]
```

initially I thought it is due to the [] being the default for live indexes, but looks like it is due to some race here, in complete_snapshot.