### PR TITLE
Export `ra:membership()` type

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -107,6 +107,7 @@
 -type idxterm() :: ra_idxterm().
 -type server_id() :: ra_server_id().
 -type cluster_name() :: ra_cluster_name().
+-type membership() :: ra_membership().
 -type range() :: ra_range:range().
 -type uid() :: ra_uid().
 
@@ -126,6 +127,7 @@
               idxterm/0,
               server_id/0,
               cluster_name/0,
+              membership/0,
               range/0,
               query_ctx/0,
               query_opts/0,


### PR DESCRIPTION
This type can be specified in a `ra_server:config()` so it's useful to have it exported.

For an example it could be used in a spec for [`rabbit_quorum_queue:make_ra_conf`](https://github.com/rabbitmq/rabbitmq-server/blob/62a9a19c2e5e231c772ef00d3babd3e71d1bc08a/deps/rabbit/src/rabbit_quorum_queue.erl#L2280-L2335) functions.