### PR TITLE
fix: handle install_snapshot_rpc in candidate state

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1118,6 +1118,25 @@ handle_candidate(#request_vote_result{}, State) ->
 handle_candidate(#pre_vote_result{}, State) ->
     %% handle to avoid logging as unhandled
     {candidate, State, []};
+handle_candidate(#install_snapshot_rpc{term = Term} = ISR,
+                 #{current_term := CurTerm,
+                   cfg := #cfg{log_id = LogId}} = State0)
+  when Term >= CurTerm ->
+    ?INFO("~ts: candidate received install_snapshot_rpc for term ~b,"
+          " stepping down from term ~b", [LogId, Term, CurTerm]),
+    {follower, State0#{votes => 0}, [{next_event, ISR}]};
+handle_candidate(#install_snapshot_rpc{term = Term,
+                                       meta = #{index := LastIndex,
+                                                 term := LastTerm}},
+                 #{cfg := #cfg{log_id = LogId},
+                   current_term := CurTerm} = State)
+  when Term < CurTerm ->
+    ?DEBUG("~ts: candidate install_snapshot old term ~b in ~b",
+          [LogId, LastIndex, LastTerm]),
+    Reply = #install_snapshot_result{term = CurTerm,
+                                     last_term = LastTerm,
+                                     last_index = LastIndex},
+    {candidate, State, [{reply, Reply}]};
 handle_candidate({ra_log_event, Evt}, State = #{log := Log0}) ->
     % simply forward all other events to ra_log
     {Log, Effects} = ra_log:handle_event(Evt, Log0),

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -105,6 +105,7 @@ all() ->
      follower_heartbeat_reply,
      candidate_heartbeat,
      candidate_heartbeat_reply,
+     candidate_install_snapshot_rpc,
      pre_vote_heartbeat,
      pre_vote_heartbeat_reply,
 
@@ -3183,6 +3184,33 @@ candidate_heartbeat_reply(_Config) ->
     {follower, #{current_term := NewTerm,
                  voted_for := undefined}, []}
         = ra_server:handle_candidate({{no_peer, node()}, HeartbeatReply#heartbeat_reply{term = NewTerm}}, State).
+
+candidate_install_snapshot_rpc(_Config) ->
+    N1 = ?N1,
+    State = base_state(3, ?FUNCTION_NAME),
+    #{current_term := Term} = State,
+    Meta = #{index => 99, term => 99,
+             cluster => #{}, machine_version => 0},
+    ISRpc = #install_snapshot_rpc{term = Term, leader_id = N1,
+                                  chunk_state = {1, last},
+                                  meta = Meta, data = []},
+
+    %% Same term: step down to follower and re-dispatch
+    {follower, #{votes := 0}, [{next_event, ISRpc}]}
+        = ra_server:handle_candidate(ISRpc, State),
+
+    %% Higher term: step down to follower and re-dispatch
+    HigherTermISRpc = ISRpc#install_snapshot_rpc{term = Term + 1},
+    {follower, #{votes := 0}, [{next_event, HigherTermISRpc}]}
+        = ra_server:handle_candidate(HigherTermISRpc, State),
+
+    %% Lower term: reject with install_snapshot_result
+    LowerTermISRpc = ISRpc#install_snapshot_rpc{term = Term - 1},
+    {candidate, State,
+     [{reply, #install_snapshot_result{term = Term,
+                                       last_term = 99,
+                                       last_index = 99}}]}
+        = ra_server:handle_candidate(LowerTermISRpc, State).
 
 pre_vote_heartbeat(_Config) ->
     State = (base_state(3, ?FUNCTION_NAME))#{votes => 1},


### PR DESCRIPTION
Hi, thanks for merging #600!

I noticed that handle_candidate doesn't have a clause for install_snapshot_rpc. If a lagging node becomes a candidate while the leader is trying to send it a snapshot, the snapshot message gets dropped and the candidate keeps running elections it can't win — its log is too far behind. Meanwhile the leader keeps trying to send the snapshot, which keeps getting ignored.

The fix adds an install_snapshot_rpc clause to handle_candidate that steps down to follower first (since only a valid leader sends snapshots), then processes the snapshot normally.