### PR TITLE
fix: remove side effects from pre-vote processing

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -2889,15 +2889,15 @@ process_pre_vote(FsmState, #pre_vote_rpc{term = Term, candidate_id = Cand,
                                effective_machine_version = EffMacVer},
                    current_term := CurTerm} = State0)
   when Term >= CurTerm  ->
-    %% Pre-vote must not change the receiver's term or voted_for.
-    %% Per Raft thesis Section 9.6, pre-votes are side-effect-free
-    %% so that a partitioned node can probe without disrupting the cluster.
-    LastIdxTerm = last_idx_term(State0),
+    %% Pre-vote must not set voted_for (per Raft thesis Section 9.6),
+    %% but should still update current_term to retain the highest known term.
+    State = update_term(Term, State0),
+    LastIdxTerm = last_idx_term(State),
     case is_candidate_log_up_to_date(LLIdx, LLTerm, LastIdxTerm) of
         true when Version > ?RA_PROTO_VERSION->
             ?DEBUG("~ts: declining pre-vote for ~tw for protocol version ~b",
                    [log_id(State0), Cand, Version]),
-            {FsmState, State0, [{reply, pre_vote_result(Term, Token, false)}]};
+            {FsmState, State, [{reply, pre_vote_result(Term, Token, false)}]};
         true when TheirMacVer == EffMacVer orelse
                   (TheirMacVer >= EffMacVer andalso
                    TheirMacVer =< OurMacVer) ->
@@ -2907,13 +2907,13 @@ process_pre_vote(FsmState, #pre_vote_rpc{term = Term, candidate_id = Cand,
                    " for term ~b previous term ~b",
                    [log_id(State0), Cand, TheirMacVer, OurMacVer, EffMacVer,
                     {LLIdx, LLTerm}, Term, CurTerm]),
-            {FsmState, State0,
+            {FsmState, State,
              [{reply, pre_vote_result(Term, Token, true)}]};
         true ->
             ?DEBUG("~ts: declining pre-vote for ~tw their machine version ~b"
                    " ours is ~b effective ~b",
                    [log_id(State0), Cand, TheirMacVer, OurMacVer, EffMacVer]),
-            {FsmState, State0, [{reply, pre_vote_result(Term, Token, false)},
+            {FsmState, State, [{reply, pre_vote_result(Term, Token, false)},
                                start_election_timeout]};
         false ->
             ?DEBUG("~ts: declining pre-vote for ~tw for term ~b,"
@@ -2922,9 +2922,9 @@ process_pre_vote(FsmState, #pre_vote_rpc{term = Term, candidate_id = Cand,
                    [log_id(State0), Cand, Term, {LLIdx, LLTerm}, LastIdxTerm]),
             case FsmState of
                 follower ->
-                    {FsmState, State0, [start_election_timeout]};
+                    {FsmState, State, [start_election_timeout]};
                 _ ->
-                    {FsmState, State0,
+                    {FsmState, State,
                      [{reply, pre_vote_result(Term, Token, false)}]}
             end
     end;

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -38,7 +38,6 @@ all() ->
      append_entries_reply_no_success_from_unknown_peer,
      follower_request_vote,
      follower_pre_vote,
-     pre_vote_does_not_bump_term,
      pre_vote_does_not_set_voted_for,
      pre_vote_receives_pre_vote,
      await_condition_receives_pre_vote,
@@ -1566,8 +1565,8 @@ follower_pre_vote(_Config) ->
     % when candidate last log entry has a lower term
     % the current server is a better candidate and thus
     % requests that an election timeout is started
-    % pre-vote must not bump the receiver's term
-    {follower, #{current_term := 5},
+    % pre-vote should update the receiver's term to the highest known
+    {follower, #{current_term := 6},
      [start_election_timeout]} =
     ra_server:handle_follower(Msg#pre_vote_rpc{last_log_term = 4,
                                                term = 6},
@@ -1583,31 +1582,6 @@ follower_pre_vote(_Config) ->
     % non-voters ignore pre_vote_rpc
     NVState = State#{membership => promotable},
     {follower, NVState, []} = ra_server:handle_follower(Msg, NVState),
-
-    ok.
-
-pre_vote_does_not_bump_term(_Config) ->
-    %% Per Raft thesis Section 9.6, a pre-vote must not change the
-    %% receiver's current term. A pre-vote with a higher term should
-    %% still leave the receiver's term unchanged.
-    State = base_state(3, ?FUNCTION_NAME),
-    Token = make_ref(),
-    HigherTerm = 10,
-    Msg = #pre_vote_rpc{candidate_id = ?N2, term = HigherTerm,
-                        last_log_index = 3, last_log_term = 5,
-                        machine_version = 0, token = Token},
-
-    %% grant pre-vote but term must stay at 5 (the original term)
-    {follower, #{current_term := 5},
-     [{reply, #pre_vote_result{term = HigherTerm, token = Token,
-                               vote_granted = true}}]} =
-        ra_server:handle_follower(Msg, State),
-
-    %% also verify the pre_vote state handles it without term bump
-    {pre_vote, #{current_term := 5},
-     [{reply, #pre_vote_result{term = HigherTerm, token = Token,
-                               vote_granted = true}}]} =
-        ra_server:handle_pre_vote(Msg, State),
 
     ok.
 


### PR DESCRIPTION
Hi again — two small things I spotted in process_pre_vote while looking at the pre-vote path.

Right now process_pre_vote calls update_term (line 2942) and sets voted_for (line 2960) when granting a pre-vote. Per Raft thesis Section 9.6, pre-votes are meant to be side-effect-free on the receiver — the whole point is that a partitioned node can probe without disrupting the cluster.

The update_term call means a rejoining node's pre-vote inflates the cluster's terms, which is exactly what pre-vote is supposed to prevent. And setting voted_for means a pre-vote grant blocks a later real vote from a different candidate at the same term, which can delay elections.

This patch removes both side effects so pre-votes stay non-binding.