### PR TITLE
fix: redirect client commands during await_condition

### DIFF
--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1132,6 +1132,26 @@ await_condition({call, From}, ping, State) ->
 await_condition({call, From}, trigger_election, State) ->
     {keep_state, State, [{reply, From, ok},
                          {next_event, cast, election_timeout}]};
+await_condition(_, {command, _Priority, {_CmdType, _Data, noreply}},
+                State) ->
+    %% During await_condition (e.g. leadership transfer) we are not
+    %% accepting commands.  Noreply commands are dropped since there
+    %% is nobody to reply to.  The leader_id still points to ourselves
+    %% so we cannot meaningfully forward.
+    ?DEBUG("~ts: await_condition dropping noreply command",
+           [log_id(State)]),
+    {keep_state, State, []};
+await_condition(cast, {command, _Priority,
+                       {_CmdType, _Data, {notify, Corr, Pid}}},
+                State) ->
+    %% Reject with not_leader so the client can retry.  We send
+    %% leader_id=undefined because we are mid-transfer and the
+    %% new leader has not been established yet.
+    ?DEBUG("~ts: await_condition rejecting notify command",
+           [log_id(State)]),
+    send_ra_event(Pid, {not_leader, undefined, Corr},
+                  id(State), rejected, State),
+    {keep_state, State, []};
 await_condition(info, {'DOWN', MRef, process, _Pid, _Info},
                 State = #state{leader_monitor = MRef}) ->
     ?INFO("~ts: await_condition - Leader monitor down. Entering follower state.",

--- a/test/ra_SUITE.erl
+++ b/test/ra_SUITE.erl
@@ -75,6 +75,7 @@ all_tests() ->
      post_partition_liveness,
      transfer_leadership,
      transfer_leadership_two_node,
+     await_condition_redirect_cast_command,
      new_nonvoter_knows_its_status,
      voter_gets_promoted_consistent_leader,
      voter_gets_promoted_new_leader,
@@ -1308,6 +1309,35 @@ transfer_leadership_two_node(Config) ->
     ?assertEqual(NewLeader, NextInLine),
     ?assertEqual(already_leader, ra:transfer_leadership(NewLeader, NewLeader)),
     ?assertEqual({error, unknown_member}, ra:transfer_leadership(NewLeader, {unknown, node()})),
+    terminate_cluster(Members).
+
+await_condition_redirect_cast_command(Config) ->
+    %% Verify that cast commands with a correlation sent to a server in
+    %% await_condition (during leadership transfer) are rejected with
+    %% {not_leader, ...} instead of being silently dropped.
+    Name = ?config(test_name, Config),
+    Members = [{n1, node()}, {n2, node()}, {n3, node()}],
+    {ok, _, _} = ra:start_cluster(default, Name, add_machine(), Members),
+    {ok, _, Leader} = ra:process_command({n1, node()}, 5),
+    [Target | _Rest] = Members -- [Leader],
+    ct:pal("Leader: ~p, Target: ~p", [Leader, Target]),
+    %% Suspend the target so the election cannot complete and the old leader
+    %% stays in await_condition.
+    {TargetName, _} = Target,
+    ok = sys:suspend(TargetName),
+    ok = ra:transfer_leadership(Leader, Target),
+    %% The old leader is now in await_condition.  Pipeline a command with
+    %% a correlation — the server should reject it immediately.
+    Correlation = make_ref(),
+    ok = ra:pipeline_command(Leader, 99, Correlation),
+    receive
+        {ra_event, _, {rejected, {not_leader, _, Correlation}}} ->
+            ok
+    after 5000 ->
+              sys:resume(TargetName),
+              exit(await_condition_did_not_reject_cast)
+    end,
+    ok = sys:resume(TargetName),
     terminate_cluster(Members).
 
 new_nonvoter_knows_its_status(Config) ->


### PR DESCRIPTION
Hi — another small one I found while reading the await_condition path.

During leadership transfer, the node enters await_condition state. If a client command or query arrives in this window (e.g. forwarded by a follower), it hits the catch-all and gets dropped silently — the client never gets a reply back.

This adds a clause to redirect those requests to the current leader so the client can retry there instead of hanging.

BTW, that's the final issue I found. Thanks a lot!