### PR TITLE
Log snapshot size

### DIFF
--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -1019,8 +1019,8 @@ handle_event({snapshot_written, {SnapIdx, _} = Snap, LiveIndexes,
     % ?assert(ra_snapshot:pending(SnapState0) =/= undefined),
     SnapState1 = ra_snapshot:complete_snapshot(Snap, SnapKind, LiveIndexes,
                                                SnapshotSize, SnapState0),
-    ?DEBUG("~ts: ra_log: ~s written at index ~b with ~b live indexes in ~bms",
-           [LogId, SnapKind, SnapIdx, ra_seq:length(LiveIndexes), Duration]),
+    ?DEBUG("~ts: ra_log: ~s with ~b bytes written at index ~b with ~b live indexes in ~bms",
+           [LogId, SnapKind, SnapshotSize, SnapIdx, ra_seq:length(LiveIndexes), Duration]),
     case SnapKind of
         snapshot ->
             put_counter(Cfg, ?C_RA_SVR_METRIC_SNAPSHOT_INDEX, SnapIdx),


### PR DESCRIPTION
Log the snapshot size after a snapshot got written.

Example log:
```
2026-04-10 13:40:54.572501+00:00 [debug] <0.571.0> queue 'bla' in vhost '/': ra_log: snapshot with 28192277 bytes written at index 23776 with 23773 live indexes in 145ms
```
