### PR TITLE
Avoid race condition when sending snapshot.

### DIFF
--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -863,7 +863,11 @@ copy_with_cache_loop(SrcFd, SrcIndex, DstState, [Idx | Rem] = Indexes, Cache0)
                                          Data, Crc),
             copy_with_cache_loop(SrcFd, SrcIndex, DstState1, Rem, Cache0)
     end;
-copy_with_cache_loop(_SrcFd, _SrcIndex, _DstState, [Idx | _], _Cache) ->
+copy_with_cache_loop(_SrcFd, SrcIndex,
+                     #state{cfg = #cfg{filename = DstFilename}} = _DstState,
+                     [Idx | _] = Idxs, _Cache) ->
+    ?DEBUG("copy_missing_key: DstFile: ~ts, SrcIndex: ~w, Idxs; ~w",
+           [DstFilename, maps:keys(SrcIndex), Idxs]),
     exit({copy_missing_key, Idx}).
 
 %% Append an entry with a pre-computed CRC, avoiding CRC recomputation.

--- a/src/ra_log_segments.erl
+++ b/src/ra_log_segments.erl
@@ -525,7 +525,7 @@ segment_read_plan(#cfg{log_id = LogId} = Cfg,
             end;
         undefined ->
             %% not found, not good
-            ?WARN("~ts: read plan request did not found all requested indexes"
+            ?WARN("~ts: read plan request did not find all requested indexes"
                   " missing ~w segrefs left ~w",
                   [LogId, Indexes, SegRefs]),
             lists:reverse(Acc)

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -1708,10 +1708,11 @@ handle_effect(leader, {send_snapshot, {_, ToNode} = To, {SnapState, _Id, Term}},
                                    0
                            end,
             Id = ra_server:id(SS0),
+            UId = ra_server:uid(SS0),
             Pid = spawn(fun () ->
                                 send_snapshots(Id, Term, To,
                                                ChunkSize, InstallSnapTimeout,
-                                               SnapState, Machine, LogId)
+                                               SnapState, Machine, LogId, UId)
                         end),
             ok = incr_counter(Conf, ?C_RA_SRV_SNAPSHOTS_SENT, 1),
             %% update the peer state so that no pipelined entries are sent
@@ -2106,7 +2107,7 @@ read_entries0(From, Idxs, #state{server_state = #{log := Log}} = State) ->
     {keep_state, State, [{reply, From, {ok, ReadState}}]}.
 
 send_snapshots(Id, Term, {_, ToNode} = To, ChunkSize,
-               InstallTimeout, SnapState, Machine, LogId) ->
+               InstallTimeout, SnapState, Machine, LogId, UId) ->
     Context = ra_snapshot:context(SnapState, ToNode),
     case ra_snapshot:begin_read(SnapState, Context) of
         {error, Reason} ->
@@ -2133,9 +2134,13 @@ send_snapshots(Id, Term, {_, ToNode} = To, ChunkSize,
                                                 leader_id = Id,
                                                 chunk_state = {0, init},
                                                 meta = Meta},
-                    SnapDir = ra_snapshot:current_snapshot_dir(SnapState),
-                    case ra_snapshot:indexes(SnapDir) of
-                        {ok, [_|_] = Indexes0} ->
+                    %% Query ra_log_snapshot_state table for live indexes
+                    case ra_log_snapshot_state:read(ra_log_snapshot_state, UId) of
+                        undefined ->
+                            ?DEBUG("~ts: no snapshot state found in ra_log_snapshot_state for ~tw",
+                                   [LogId, To]),
+                            ok;
+                        {UId, SnapIdx, _SmallestIdx, LiveIndexes} ->
                             %% first send the init phase
                             try gen_statem:call(To, RPC,
                                                 {dirty_timeout, InstallTimeout}) of
@@ -2159,15 +2164,18 @@ send_snapshots(Id, Term, {_, ToNode} = To, ChunkSize,
                                 erpc:call(ToNode, ra_counters, counters,
                                           [To, [last_applied]]),
                             %% remove all indexes lower than the target's last applied
-                            Indexes = ra_seq:floor(LastApplied + 1, Indexes0),
+                            Indexes = ra_seq:floor(LastApplied + 1, LiveIndexes),
                             ?DEBUG("~ts: sending ~b live indexes in the range ~w to ~tw ",
                                    [LogId, ra_seq:length(Indexes), ra_seq:range(Indexes), To]),
                             MaybeFlru = send_pre_snapshot_entries(Id, To, RPC, Indexes,
                                                                   InstallTimeout, undefined),
                             _ = maybe_evict_flru(MaybeFlru),
                             ok;
-                        _ ->
-                            ok
+                        {UId, TableSnapIdx, _SmallestIdx, _LiveIndexes} ->
+                            ?INFO("~ts: aborting snapshot send to ~tw: "
+                                  "table snapshot index ~b does not match requested index ~b",
+                                  [LogId, To, TableSnapIdx, SnapIdx]),
+                            exit({snapshot_index_mismatch, TableSnapIdx, SnapIdx})
                     end,
 
                     Result = send_snapshot_chunks(RPC, To, ReadState, 1,


### PR DESCRIPTION
When the snapshot is deleted midway through it may end up with
an empty live indexes accidentally which it treats as a valid
value and snapshot send completes without sending any live
indexes.

Logging tweaks
