### PR TITLE
Ensure multi delete specs dont terminate half way through

### DIFF
--- a/src/ra_log_segments.erl
+++ b/src/ra_log_segments.erl
@@ -526,8 +526,8 @@ segment_read_plan(#cfg{log_id = LogId} = Cfg,
         undefined ->
             %% not found, not good
             ?WARN("~ts: read plan request did not find all requested indexes"
-                  " missing ~w segrefs left ~w",
-                  [LogId, Indexes, SegRefs]),
+                  " missing ~w ~b segrefs left to search ~0P",
+                  [LogId, Indexes, ra_lol:len(SegRefs), SegRefs, 10]),
             lists:reverse(Acc)
     end.
 

--- a/src/ra_mt.erl
+++ b/src/ra_mt.erl
@@ -354,7 +354,13 @@ delete({delete, Tid}) ->
 delete({multi, Specs}) ->
     lists:foldl(
       fun (Spec, Acc) ->
-              Acc + delete(Spec)
+              try delete(Spec) of
+                  Sz ->
+                      Acc + Sz
+              catch _:badarg ->
+                        %% table probably didn't exist
+                        Acc
+              end
       end, 0, Specs).
 
 

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -2107,7 +2107,7 @@ read_entries0(From, Idxs, #state{server_state = #{log := Log}} = State) ->
     {keep_state, State, [{reply, From, {ok, ReadState}}]}.
 
 send_snapshots(Id, Term, {_, ToNode} = To, ChunkSize,
-               InstallTimeout, SnapState, Machine, LogId, UId) ->
+               InstallTimeout, SnapState, Machine, LogId, UID = UId) ->
     Context = ra_snapshot:context(SnapState, ToNode),
     case ra_snapshot:begin_read(SnapState, Context) of
         {error, Reason} ->
@@ -2123,7 +2123,8 @@ send_snapshots(Id, Term, {_, ToNode} = To, ChunkSize,
             %% only send the snapshot if the target server can accept it
             case SnapMacVer > TheirMacVer of
                 true ->
-                    ?DEBUG("~ts: not sending snapshot to ~tw as their machine version ~b "
+                    ?DEBUG("~ts: not sending snapshot to ~tw as "
+                           "their machine version ~b "
                            "is lower than snapshot machine version ~b",
                            [LogId, To, TheirMacVer, SnapMacVer]),
                     ok;
@@ -2137,27 +2138,29 @@ send_snapshots(Id, Term, {_, ToNode} = To, ChunkSize,
                     %% Query ra_log_snapshot_state table for live indexes
                     case ra_log_snapshot_state:read(ra_log_snapshot_state, UId) of
                         undefined ->
-                            ?DEBUG("~ts: no snapshot state found in ra_log_snapshot_state for ~tw",
+                            ?DEBUG("~ts: no snapshot state found in "
+                                   "ra_log_snapshot_state for ~tw",
                                    [LogId, To]),
                             ok;
-                        {UId, SnapIdx, _SmallestIdx, LiveIndexes} ->
+                        {UID, SnapIdx, _SmallestIdx, LiveIndexes} ->
                             %% first send the init phase
                             try gen_statem:call(To, RPC,
                                                 {dirty_timeout, InstallTimeout}) of
                                 #install_snapshot_result{} ->
                                     ok;
                                 Unexp ->
-                                    ?INFO("~ts: ~tw returned an unexpected install snapshot "
-                                          "result ~w",
+                                    ?INFO("~ts: ~tw returned an unexpected"
+                                          " install snapshot result ~w",
                                           [LogId, To, Unexp]),
                                     exit(unexpected_install_snapshot_result)
                             catch exit:{noproc, _}:_ ->
                                       ?INFO("~ts: ~tw not ready to receive snapshot, "
                                             "reason: noproc", [LogId, To]),
-                                      %% no process, not ready yet, exit to reduce sasl logging
+                                      %% no process, not ready yet, exit to
+                                      %% reduce sasl logging
                                       exit(snapshot_receiver_not_ready_yet);
                                   C:E:S ->
-                                      erlang:raise(C, E, S)
+                                      erlang:raise(C, E, safe_stacktrace(S))
                             end,
                             %% there are live indexes to send before the snapshot
                             #{last_applied := LastApplied} =
@@ -2165,15 +2168,28 @@ send_snapshots(Id, Term, {_, ToNode} = To, ChunkSize,
                                           [To, [last_applied]]),
                             %% remove all indexes lower than the target's last applied
                             Indexes = ra_seq:floor(LastApplied + 1, LiveIndexes),
-                            ?DEBUG("~ts: sending ~b live indexes in the range ~w to ~tw ",
-                                   [LogId, ra_seq:length(Indexes), ra_seq:range(Indexes), To]),
-                            MaybeFlru = send_pre_snapshot_entries(Id, To, RPC, Indexes,
-                                                                  InstallTimeout, undefined),
-                            _ = maybe_evict_flru(MaybeFlru),
+                            ?DEBUG("~ts: sending ~b live indexes in the "
+                                   "range ~w to ~tw ",
+                                   [LogId, ra_seq:length(Indexes),
+                                    ra_seq:range(Indexes), To]),
+                            try send_pre_snapshot_entries(Id, To, RPC, Indexes,
+                                                          InstallTimeout,
+                                                          undefined) of
+                                MaybeFlru ->
+                                    _ = maybe_evict_flru(MaybeFlru),
+                                    ok
+                            catch Class:Err:Stack ->
+                                      ?INFO("~ts: send_pre_snapshot_entries "
+                                            "encountered an error: ~w",
+                                            [LogId, Err]),
+                                      erlang:raise(Class, Err,
+                                                   safe_stacktrace(Stack))
+                            end,
                             ok;
-                        {UId, TableSnapIdx, _SmallestIdx, _LiveIndexes} ->
+                        {UID, TableSnapIdx, _SmallestIdx, _LiveIndexes} ->
                             ?INFO("~ts: aborting snapshot send to ~tw: "
-                                  "table snapshot index ~b does not match requested index ~b",
+                                  "table snapshot index ~b does not match "
+                                  "requested index ~b",
                                   [LogId, To, TableSnapIdx, SnapIdx]),
                             exit({snapshot_index_mismatch, TableSnapIdx, SnapIdx})
                     end,

--- a/test/ra_mt_SUITE.erl
+++ b/test/ra_mt_SUITE.erl
@@ -39,6 +39,7 @@ all_tests() ->
      stage_abort,
      range_overlap,
      stage_commit_2,
+     multi_spec_delete_with_missing_tid,
      perf,
      perf_sparse_insert,
      sparse,
@@ -650,6 +651,62 @@ sparse_after_non_sparse(_Config) ->
     ?assertMatch(#{size := 0,
                    range := undefined}, ra_mt:info(Mt6)),
     ?assertEqual(0, ets:info(Tid2, size)),
+    ok.
+
+multi_spec_delete_with_missing_tid(_Config) ->
+    %% Test that multi-spec delete gracefully handles the case where
+    %% one of the Tids in the spec has already been deleted (missing).
+    %% This can happen if a prior memtable cleanup was accelerated or
+    %% another operation deleted the table before the multi-spec is processed.
+    Tid1 = ets:new(t1, [set, public]),
+    Mt0 = ra_mt:init(Tid1),
+    Mt1 = lists:foldl(
+            fun (I, Acc) ->
+                    element(2, ra_mt:insert({I, 1, <<"banana">>}, Acc))
+            end, Mt0, lists:seq(1, 100)),
+
+    Tid2 = ets:new(t2, [set, public]),
+    Mt2 = ra_mt:init_successor(Tid2, read_write, Mt1),
+    Mt3 = lists:foldl(
+            fun (I, Acc) ->
+                    element(2, ra_mt:insert({I, 2, <<"apple">>}, Acc))
+            end, Mt2, lists:seq(50, 150)),
+
+    Tid3 = ets:new(t3, [set, public]),
+    Mt4 = ra_mt:init_successor(Tid3, read_write, Mt3),
+    Mt5 = lists:foldl(
+            fun (I, Acc) ->
+                    element(2, ra_mt:insert({I, 3, <<"cherry">>}, Acc))
+            end, Mt4, lists:seq(100, 200)),
+
+    %% Generate a multi-spec that would normally include cleanup of Tid1 and Tid2
+    {MultiSpec, Mt6} = ra_mt:record_flushed(Tid3, [{100, 150}], Mt5),
+    ?assertMatch({multi, _}, MultiSpec),
+
+    Specs = element(2, MultiSpec),
+    ?assert(lists:member({delete, Tid2}, Specs)),
+    ?assert(lists:member({delete, Tid1}, Specs)),
+    {_, SpecsAfterTid2} = lists:splitwith(fun (Item) ->
+                                                  Item =/= {delete, Tid2}
+                                          end, Specs),
+    ?assert(lists:member({delete, Tid1}, SpecsAfterTid2)),
+
+    %% Delete Tid2 before executing the multi-spec delete.
+    %% This simulates the "missing tid" condition on an earlier spec.
+    true = ets:delete(Tid2),
+
+    %% The multi-spec delete should gracefully skip the missing Tid2
+    %% and still apply later specs. Should not crash or throw badarg.
+    DeletedCount = ra_mt:delete(MultiSpec),
+    ?assert(is_integer(DeletedCount)),
+    ?assert(DeletedCount >= 0),
+
+    %% Verify later specs were still applied after the missing Tid2.
+    ?assertEqual(undefined, ets:info(Tid1)),
+
+    %% Verify the current memtable still contains its range
+    Range = ra_mt:range(Mt6),
+    ?assertNotEqual(undefined, Range),
     ok.
 
 %%% Util


### PR DESCRIPTION
Fix memtable multi-spec deletion and improve snapshot error handling

This commit addresses several issues across memtable cleanup and snapshotting:

- `ra_mt`: Update `delete({multi, Specs})` to catch `badarg` exceptions. This ensures that if an ETS table in the spec was already deleted (e.g., by an accelerated cleanup or another operation), the deletion process gracefully skips it and continues with the remaining specs instead of crashing.
- `ra_server_proc`: Enhance error handling in `send_snapshots/9` by wrapping `send_pre_snapshot_entries` in a `try...catch` block to log errors and safely re-raise them using `safe_stacktrace/1`. Also improves log formatting and clarifies `UID` pattern matching.
- `ra_log_segments`: Fix a format specifier mismatch in a warning log (changed `~w` to `~b` and added `~0P` for segment references).
- `ra_mt_SUITE`: Add the `multi_spec_delete_with_missing_tid` test to verify the new resilient multi-spec deletion behavior.