### PR TITLE
docs: use MFA tuple in leader_query example

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Use `ra:leader_query/{2,3}` to perform a leader query:
 %% find current Raft cluster leader
 {ok, _Members, LeaderId} = ra:members(quick_start),
 %% perform a leader query on the leader node
-QueryFun = fun(StateVal) -> StateVal end,
+QueryFun = {ra_lib, id, []},
 {ok, {_TermMeta, State}, LeaderId1} = ra:leader_query(LeaderId, QueryFun).
 ```
 


### PR DESCRIPTION
## Proposed Changes

leader_query/2,3 stopped accepting funs in dc8276e . The README example still passed a fun, which fails with no function clause matching.

The starter example in the README is out of date since the commit 
```
(ra3@127.0.0.1)17> ra:leader_query(LeaderId, QueryFun).
  ** exception error: no function clause matching ra:leader_query({quick_start,'ra3@127.0.0.1'},#Fun<erl_eval.42.39164016>)
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
