### PR TITLE
Ensure target follower is up to date before leadership transfer

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -1161,6 +1161,8 @@ transfer_leadership(ServerId, TargetServerId) ->
 %% @doc Transfers leadership from the leader to a voter follower.
 %% Returns `already_leader' if the transfer target is already the leader.
 %% Leadership cannot be transferred to non-voters.
+%% Leadership can only be transferred to followers that are up to date
+%% with the leader's log, otherwise `{error, not_up_to_date}' is returned.
 %%
 %% @param ServerId the Ra server to send the command to
 %% @param TargetServerId the desired server to become the new leader

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1008,6 +1008,7 @@ handle_leader({transfer_leadership, Member},
     {leader, State, [{reply, {error, unknown_member}}]};
 handle_leader({transfer_leadership, ServerId},
               #{cfg := #cfg{log_id = LogId},
+                log := Log,
                 cluster := Cluster} = State) ->
     case Cluster of
         #{ServerId := #{voter_status := #{membership := Membership}}}
@@ -1015,16 +1016,23 @@ handle_leader({transfer_leadership, ServerId},
             ?INFO("~ts: transfer leadership requested but non-voter member ~tw",
                   [LogId, ServerId]),
             {leader, State, [{reply, {error, non_voter}}]};
-        _ ->
-            ?DEBUG("~ts: transfer leadership to ~tw requested",
-                   [LogId, ServerId]),
-            %% TODO find a timeout
-            {await_condition,
-             State#{condition =>
-                        #{predicate_fun => fun transfer_leadership_condition/2,
-                          timeout => #{effects => [],
-                                       transition_to => leader}}},
-             [{reply, ok}, {send_msg, ServerId, election_timeout, cast}]}
+        #{ServerId := #{next_index := PeerNextIdx}} ->
+            LeaderNextIdx = ra_log:next_index(Log),
+            if PeerNextIdx =:= LeaderNextIdx ->
+                    ?DEBUG("~ts: transfer leadership to ~tw requested",
+                           [LogId, ServerId]),
+                    %% TODO find a timeout
+                    {await_condition,
+                     State#{condition =>
+                                #{predicate_fun => fun transfer_leadership_condition/2,
+                                  timeout => #{effects => [],
+                                               transition_to => leader}}},
+                     [{reply, ok}, {send_msg, ServerId, election_timeout, cast}]};
+               true ->
+                    ?INFO("~ts: transfer leadership requested but member ~tw is not up to date",
+                          [LogId, ServerId]),
+                    {leader, State, [{reply, {error, not_up_to_date}}]}
+            end
     end;
 handle_leader(force_member_change, State0) ->
     {follower, State0#{votes => 0}, [{next_event, force_member_change}]};
@@ -1913,9 +1921,11 @@ handle_await_condition(#request_vote_rpc{} = Msg, State) ->
 handle_await_condition(#pre_vote_rpc{} = PreVote, State) ->
     process_pre_vote(await_condition, PreVote, State);
 handle_await_condition(election_timeout,
-                #{cfg := #cfg{log_id = LogId},
-                  membership := Membership} = State) when Membership =/= voter ->
-    ?DEBUG("~s: await_condition ignored election_timeout, replicate membership state: ~p",
+                       #{cfg := #cfg{log_id = LogId},
+                         membership := Membership} = State)
+  when Membership =/= voter ->
+    ?DEBUG("~s: await_condition ignored election_timeout, "
+           "replicate membership state: ~p",
            [LogId, Membership]),
     {await_condition, State, []};
 handle_await_condition(election_timeout, State) ->

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -102,6 +102,7 @@ all() ->
      wal_down_condition_follower,
      wal_down_condition_leader,
      wal_down_condition_leader_commands,
+     transfer_leadership,
      update_release_cursor,
      update_release_cursor_with_written_condition,
      update_release_cursor_with_no_snapshot_sends_condition,
@@ -1088,6 +1089,46 @@ wal_down_condition_leader_commands(_Config) ->
                                                 {transfer_leadership, _}}],
                                    transition_to := leader}}} = _State1, _}
         = ra_server:handle_leader({command, Cmd}, State0),
+    ok.
+
+transfer_leadership(_Config) ->
+    State0 = base_state(3, ?FUNCTION_NAME),
+    N1 = ?N1,
+    N2 = ?N2,
+    N3 = ?N3,
+    Unknown = {unknown, node()},
+
+    %% transfer to self
+    {leader, State0, [{reply, already_leader}]} =
+        ra_server:handle_leader({transfer_leadership, N1}, State0),
+
+    %% transfer to unknown member
+    {leader, State0, [{reply, {error, unknown_member}}]} =
+        ra_server:handle_leader({transfer_leadership, Unknown}, State0),
+
+    %% transfer to non-voter
+    Cluster0 = maps:get(cluster, State0),
+    #{N2 := Peer2} = Cluster0,
+    Peer2NonVoter = Peer2#{voter_status => #{membership => non_voter}},
+    StateNonVoter = State0#{cluster => Cluster0#{N2 => Peer2NonVoter}},
+    {leader, StateNonVoter, [{reply, {error, non_voter}}]} =
+        ra_server:handle_leader({transfer_leadership, N2}, StateNonVoter),
+
+    %% transfer to member that is not up to date
+    #{N3 := Peer3} = Cluster0,
+    Peer3Behind = Peer3#{next_index => 2},
+    StateBehind = State0#{cluster => Cluster0#{N3 => Peer3Behind}},
+    {leader, StateBehind, [{reply, {error, not_up_to_date}}]} =
+        ra_server:handle_leader({transfer_leadership, N3}, StateBehind),
+
+    %% transfer to valid voter
+    {await_condition,
+     #{condition := #{predicate_fun := _,
+                      timeout := #{effects := [],
+                                   transition_to := leader}}} = _State1,
+     [{reply, ok}, {send_msg, N2, election_timeout, cast}]} =
+        ra_server:handle_leader({transfer_leadership, N2}, State0),
+
     ok.
 
 update_release_cursor(_Config) ->

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1116,7 +1116,7 @@ transfer_leadership(_Config) ->
 
     %% transfer to member that is not up to date
     #{N3 := Peer3} = Cluster0,
-    Peer3Behind = Peer3#{next_index => 2},
+    Peer3Behind = Peer3#{match_index => 2, next_index => 3},
     StateBehind = State0#{cluster => Cluster0#{N3 => Peer3Behind}},
     {leader, StateBehind, [{reply, {error, not_up_to_date}}]} =
         ra_server:handle_leader({transfer_leadership, N3}, StateBehind),


### PR DESCRIPTION
This commit adds a check to `ra_server:handle_leader/2` when handling a `transfer_leadership` request. The leader now verifies that the target follower's `next_index` matches the leader's `next_index` before initiating the transfer.

This ensures there is a high likelihood that the leadership transfer will complete in a timely manner, preventing situations where the transfer causes a lone timeout or unavailability because the target follower is too far behind to quickly catch up and win an election.

A unit test for `transfer_leadership` is also added to `ra_server_SUITE` to cover the various transfer conditions (already leader, unknown member, non-voter, not up to date, and successful transfer).

