### PR TITLE
Fix stale last_written_index_term on log truncation

### DIFF
--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -551,15 +551,41 @@ write([{FstIdx, _, _} | _Rest] = Entries,
       #?MODULE{cfg = Cfg,
                range = Range,
                pending = Pend0,
+               snapshot_state = SnapState,
+               last_written_index_term = {LWIdx0, LWTerm0},
                mem_table = Mt0} = State0)
   when Range == undefined orelse
        (FstIdx =< element(2, Range) + 1 andalso
         FstIdx >= 0) ->
+    %% If the new entries overwrite existing uncommitted entries,
+    %% we must immediately adjust `last_written_index_term` downwards.
+    %% Otherwise, we might report a stale, higher `last_written` index in
+    %% `append_entries_reply`, causing the leader to mistakenly advance its
+    %% `match_index` and commit unpersisted entries.
+    LWIdx = min(FstIdx - 1, LWIdx0),
+    {LWTerm, State1} =
+        if LWIdx == LWIdx0 ->
+               {LWTerm0, State0};
+           true ->
+               case ra_snapshot:current(SnapState) of
+                   {LWIdx, SnapTerm} ->
+                       {SnapTerm, State0};
+                   _ when LWIdx =< 0 ->
+                       {0, State0};
+                   _ ->
+                       {Term2, S} = fetch_term(LWIdx, State0),
+                       true = Term2 =/= undefined,
+                       {Term2, S}
+               end
+        end,
     case stage_entries(Cfg, Entries, Mt0) of
         {ok, Mt} ->
             Pend = ra_seq:limit(FstIdx - 1, Pend0),
-            wal_write_batch(State0#?MODULE{mem_table = Mt,
-                                           pending = Pend}, Entries);
+            put_counter(Cfg, ?C_RA_SVR_METRIC_LAST_WRITTEN_INDEX, LWIdx),
+            State = State1#?MODULE{mem_table = Mt,
+                                   pending = Pend,
+                                   last_written_index_term = {LWIdx, LWTerm}},
+            wal_write_batch(State, Entries);
         Error ->
             Error
     end;

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -26,6 +26,7 @@ all_tests() ->
      snapshot_before_written,
      handle_overwrite,
      handle_overwrite_append,
+     follower_aer_stale_last_written,
      receive_segment,
      delete_during_segment_flush,
      read_one,
@@ -181,6 +182,30 @@ snapshot_before_written(Config) ->
                               {19, 1} == LW andalso
                               NP == 0
                       end),
+    ok.
+
+follower_aer_stale_last_written(Config) ->
+    Log0 = ra_log_init(Config),
+    {ok, Log1} = ra_log:write([{1, 1, "one"},
+                               {2, 1, "two"}], Log0),
+
+    %% process WAL write completion for 1 and 2
+    Log2 = receive
+               {ra_log_event, {written, 1, [2, 1]} = Evt} ->
+                   element(1, ra_log:handle_event(Evt, Log1))
+           after 2000 ->
+                     exit(written_timeout)
+           end,
+
+    %% verify last_written is 2
+    {2, 1} = ra_log:last_written(Log2),
+
+    %% Leader change, new leader sends entry 1 in term 2, truncating index 2
+    {ok, Log3} = ra_log:write([{1, 2, "new_one"}], Log2),
+
+    %% verify last_written is truncated to 0 since index 1 is not yet written
+    {0, 0} = ra_log:last_written(Log3),
+
     ok.
 
 handle_overwrite(Config) ->


### PR DESCRIPTION
When a new leader sends `append_entries` that overwrite existing uncommitted entries in a follower's log (log truncation), the follower must immediately adjust its `last_written_index_term` downwards to reflect the newly truncated state.

Previously, `ra_log:write/2` failed to adjust this value during truncation. This caused `ra_server` to report a stale, higher `last_written` index in its `append_entries_reply`. Consequently, the leader could mistakenly advance its `match_index` for that follower and prematurely commit entries that had not actually been persisted to disk, leading to assertion failures or data loss.

This commit updates `ra_log:write/2` to calculate the correct `last_written_index_term` when truncation occurs and pass it to the WAL batch writer.

A new test case `follower_aer_stale_last_written` is added to `ra_log_2_SUITE` to verify this behavior.

