### PR TITLE
feat: FlexiRaft static quorums

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -369,6 +369,8 @@ init(#{id := Id,
     SnapModule = ra_machine:snapshot_module(Machine),
     Counter = maps:get(counter, Config, undefined),
     Flexi = maps:get(flexiraft_config, Config, #flexiraft_cfg{}),
+    ok = validate_flexiraft_config(Flexi, length(InitialNodes)),
+
     Log0 = ra_log:init(LogInitArgs#{snapshot_module => SnapModule,
                                     machine => Machine,
                                     system_config => SystemConfig,
@@ -4006,6 +4008,16 @@ maybe_promote_peer(PeerId, #{cluster := Cluster}, Effects) ->
             Effects
     end.
 
+-spec validate_flexiraft_config(#flexiraft_cfg{}, pos_integer()) -> pos_integer().
+validate_flexiraft_config(#flexiraft_cfg{quorum_type = classic_majority}, _N) ->
+    ok;
+validate_flexiraft_config(#flexiraft_cfg{quorum_type = static_quorum,
+                                         data_commit_static_quorum_size = M}, N) when M >= 1, M =< N ->
+    ok;
+validate_flexiraft_config(#flexiraft_cfg{data_commit_static_quorum_size = M}, N) ->
+    exit({invalid_flexiraft_config, {data_commit_static_quorum_size, M,
+                                     cluster_size, N}}).
+
 -spec required_quorum(ra_cluster(), non_neg_integer()) -> pos_integer().
 required_quorum(Cluster, DataCommitQuorumSize) ->
     required_quorum_count(count_voters(Cluster), DataCommitQuorumSize).
@@ -4293,6 +4305,25 @@ required_quorum_test() ->
     %% degenerate, useless case, but sanity check
     3 = required_quorum_count(5, 4),
 
+    ok.
+
+validate_flexiraft_config_test() ->
+    ok = validate_flexiraft_config(
+           #flexiraft_cfg{quorum_type = classic_majority}, 5),
+    ok = validate_flexiraft_config(
+           #flexiraft_cfg{quorum_type = static_quorum, data_commit_static_quorum_size = 3}, 5),
+    ok = validate_flexiraft_config(
+           #flexiraft_cfg{quorum_type = static_quorum, data_commit_static_quorum_size = 1}, 5),
+    ok = validate_flexiraft_config(
+           #flexiraft_cfg{quorum_type = static_quorum, data_commit_static_quorum_size = 5}, 5),
+    ?assertExit({invalid_flexiraft_config, _},
+                validate_flexiraft_config(
+                  #flexiraft_cfg{quorum_type = static_quorum,
+                                 data_commit_static_quorum_size = 0}, 5)),
+    ?assertExit({invalid_flexiraft_config, _},
+                validate_flexiraft_config(
+                  #flexiraft_cfg{quorum_type = static_quorum,
+                                 data_commit_static_quorum_size = 6}, 5)),
     ok.
 
 -endif.

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -4008,11 +4008,12 @@ maybe_promote_peer(PeerId, #{cluster := Cluster}, Effects) ->
             Effects
     end.
 
--spec validate_flexiraft_config(#flexiraft_cfg{}, pos_integer()) -> pos_integer().
+-spec validate_flexiraft_config(#flexiraft_cfg{}, non_neg_integer()) -> ok.
 validate_flexiraft_config(#flexiraft_cfg{quorum_type = classic_majority}, _N) ->
     ok;
 validate_flexiraft_config(#flexiraft_cfg{quorum_type = static_quorum,
                                          data_commit_static_quorum_size = M}, N) when M >= 1, M =< N ->
+    %% n.b. we do not validate that the M is _sane_, e.g. smaller than a classic majority
     ok;
 validate_flexiraft_config(#flexiraft_cfg{data_commit_static_quorum_size = M}, N) ->
     exit({invalid_flexiraft_config, {data_commit_static_quorum_size, M,

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1056,8 +1056,8 @@ handle_candidate(#request_vote_result{term = Term, vote_granted = true},
     NewVotes = Votes + 1,
     DataCommitQuorumSize = data_commit_quorum_size(Flexi),
     RequiredQuorum = required_quorum(Nodes, DataCommitQuorumSize),
-    ?DEBUG("~ts: vote granted for term ~b votes ~b --- ~b req ~b ~p",
-          [LogId, Term, NewVotes, Nodes, DataCommitQuorumSize, RequiredQuorum]),
+    ?DEBUG("~ts: vote granted for term ~b votes ~b  required quorum ~b ~p",
+          [LogId, Term, NewVotes, Nodes, RequiredQuorum]),
     case RequiredQuorum of
         NewVotes ->
             State = initialise_peers(State0#{leader_id => Id}),
@@ -3631,7 +3631,6 @@ append_entries_reply(Term, Success, #{log := Log} = State) ->
 evaluate_quorum(#{cfg := Cfg,
                   commit_index := CI0} = State0, Effects0) ->
     % TODO: shortcut function if commit index was not incremented
-    %%?INFO("CONFIG In evaluate_quorum ~p    ~p", [State0, Cfg]),
     State = #{commit_index := CI} = increment_commit_index(State0),
 
     Effects = case CI > CI0 of
@@ -3662,8 +3661,7 @@ increment_commit_index(State0 = #{current_term := CurrentTerm, cfg := #cfg{flexi
     case fetch_term(PotentialNewCommitIndex, State0) of
         {CurrentTerm, State} ->
             State#{commit_index => PotentialNewCommitIndex};
-        {Bad, State} ->
-?INFO("Oops, term mismatch ~p for term ~p (need ~p(", [PotentialNewCommitIndex, Bad, CurrentTerm]),
+        {_, State} ->
             State
     end.
 
@@ -3681,7 +3679,7 @@ query_indexes(#{cfg := #cfg{id = Id},
 
 match_indexes(#{cfg := #cfg{id = Id},
                 cluster := Cluster,
-                log := Log}) ->  %% commit indices of the cluster
+                log := Log}) ->
     {LWIdx, _} = ra_log:last_written(Log),
     maps:fold(fun (PeerId, _, Acc) when PeerId == Id ->
                       Acc;
@@ -3698,7 +3696,7 @@ agreed_commit(Indexes) ->  %% highest commit index agreed by a majority
     agreed_commit(Indexes, Nth).
 
 -spec agreed_commit(list(), pos_integer()) -> ra_index().
-agreed_commit(Indexes, Nth) -> %% return Mth highest
+agreed_commit(Indexes, Nth) ->  %% return Mth highest
     SortedIdxs = lists:sort(fun erlang:'>'/2, Indexes),
     lists:nth(Nth, SortedIdxs).
 
@@ -3844,7 +3842,8 @@ update_peer_query_index(PeerId, QueryIndex, #{cluster := Cluster} = State0) ->
     end.
 
 get_current_query_quorum(State) ->
-    agreed_commit(query_indexes(State)).  %% TODO Change me for flexiraft quorum
+    %% Explicitly not implemented for Flexiraft
+    agreed_commit(query_indexes(State)).
 
 -spec take_from_queue_while(fun((El) -> {true, Res} | false),
                                 queue:queue(El)) ->

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -231,6 +231,7 @@
 %% version, it switches to that new version. This was the default and only
 %% possible behavior in Ra up to 2.15.</li>
 %% </ul>
+
 -type ra_server_config() :: #{id := ra_server_id(),
                               uid := ra_uid(),
                               %% a friendly name to refer to a particular
@@ -4027,7 +4028,7 @@ required_quorum(Cluster, DataCommitQuorumSize) ->
 
 required_quorum_count(Voters, 0) ->
     trunc(Voters / 2) + 1;
-required_quorum_count(Voters, DataCommitQuorumSize)  ->
+required_quorum_count(Voters, DataCommitQuorumSize) ->
     max(trunc(Voters / 2) + 1, Voters - DataCommitQuorumSize + 1).
 
 count_voters(Cluster) ->

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1056,8 +1056,8 @@ handle_candidate(#request_vote_result{term = Term, vote_granted = true},
     NewVotes = Votes + 1,
     DataCommitQuorumSize = data_commit_quorum_size(Flexi),
     RequiredQuorum = required_quorum(Nodes, DataCommitQuorumSize),
-    ?DEBUG("~ts: vote granted for term ~b votes ~b  required quorum ~b ~p",
-          [LogId, Term, NewVotes, Nodes, RequiredQuorum]),
+    ?DEBUG("~ts: vote granted for term ~b votes ~b required quorum ~b",
+           [LogId, Term, NewVotes, RequiredQuorum]),
     case RequiredQuorum of
         NewVotes ->
             State = initialise_peers(State0#{leader_id => Id}),

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -263,7 +263,7 @@
                               %% snapshot/checkpoint before writing a recovery
                               %% checkpoint on shutdown. 0 disables (default).
                               min_recovery_checkpoint_interval => non_neg_integer()
-			     }.
+                             }.
 
 -type ra_server_info_key() :: machine_version | atom().
 %% Key one can get in `ra_server_info()'.
@@ -432,8 +432,8 @@ init(#{id := Id,
                counter = maps:get(counter, Config, undefined),
                system_config = SystemConfig,
                min_recovery_checkpoint_interval = MinRecoveryCheckpointInterval,
-	       flexiraft_config = Flexi
-	      },
+               flexiraft_config = Flexi
+              },
     put_counter(Cfg, ?C_RA_SVR_METRIC_COMMIT_INDEX, CommitIndex),
     put_counter(Cfg, ?C_RA_SVR_METRIC_LAST_APPLIED, SnapshotIdx),
     put_counter(Cfg, ?C_RA_SVR_METRIC_TERM, CurrentTerm),
@@ -549,7 +549,7 @@ handle_leader({PeerId, #append_entries_reply{term = Term, success = true,
             Effects00 = maybe_promote_peer(PeerId, State1, []),
             {State2, Effects0} = evaluate_quorum(State1, Effects00),
             {State3, Effects1} = process_pending_consistent_queries(State2,
-								    Effects0),
+                                                                    Effects0),
             Effects2 = [{next_event, info, pipeline_rpcs} | Effects1],
             case State3 of
                 #{cluster := #{Id := _}} ->
@@ -1047,7 +1047,7 @@ handle_leader(Msg, State) ->
 handle_candidate(#request_vote_result{term = Term, vote_granted = true},
                  #{cfg := #cfg{id = Id,
                                log_id = LogId,
-			       flexiraft_config = Flexi},
+                               flexiraft_config = Flexi},
                    current_term := Term,
                    votes := Votes,
                    cluster := Nodes} = State0) ->
@@ -3650,11 +3650,11 @@ data_commit_quorum_size(#flexiraft_cfg{quorum_type = static_quorum, data_commit_
 increment_commit_index(State0 = #{current_term := CurrentTerm, cfg := #cfg{flexiraft_config = Flexi}}) ->
     DataQuorumSize = data_commit_quorum_size(Flexi),
     PotentialNewCommitIndex = case DataQuorumSize of
-				  0 ->
-				      agreed_commit(match_indexes(State0));
-				  M ->
-				      agreed_commit(match_indexes(State0), M)
-			      end,
+                                  0 ->
+                                      agreed_commit(match_indexes(State0));
+                                  M ->
+                                      agreed_commit(match_indexes(State0), M)
+                              end,
     % leaders can only increment their commit index if the corresponding
     % log entry term matches the current term. See (§5.4.2)
     case fetch_term(PotentialNewCommitIndex, State0) of

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -3641,7 +3641,8 @@ evaluate_quorum(#{cfg := Cfg,
     {State1, Effects1} = apply_to(CI, State, Effects),
     maybe_emit_pending_release_cursor(State1, Effects1).
 
-increment_commit_index(State0 = #{current_term := CurrentTerm, data_commit_static_quorum_size := DataQuorumSize}) ->
+increment_commit_index(State0 = #{current_term := CurrentTerm}) ->
+    DataQuorumSize = maps:get(data_commit_static_quorum_size, State0, 0),
     PotentialNewCommitIndex = case DataQuorumSize of
 				  0 ->
 				      agreed_commit(match_indexes(State0));

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -4005,7 +4005,7 @@ required_quorum(Cluster, DataCommitQuorumSize) ->
 required_quorum_count(Voters, 0) ->
     trunc(Voters / 2) + 1;
 required_quorum_count(Voters, DataCommitQuorumSize)  ->
-    trunc(Voters / 2) + 1.
+    max(trunc(Voters / 2) + 1, Voters - DataCommitQuorumSize + 1).
 
 count_voters(Cluster) ->
     maps:fold(
@@ -4265,6 +4265,18 @@ required_quorum_test() ->
     2 = required_quorum_count(3, 0),
     %% 4 voters, no election quorum messing
     3 = required_quorum_count(4, 0),
+    %% 5 voters, no election quorum messing
+    3 = required_quorum_count(5, 0),
+
+    %% 5 voters, data commit quorum is 1
+    5 = required_quorum_count(5, 1),
+    %% 5 voters, data commit quorum is 2
+    4 = required_quorum_count(5, 2),
+    %% 5 voters, data commit quorum is 3
+    3 = required_quorum_count(5, 3),
+    %% 5 voters, data commit quorum is 4
+    %% degenerate, useless case, but sanity check
+    3 = required_quorum_count(5, 4),
 
     ok.
 

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -4230,6 +4230,20 @@ agreed_commit_test() ->
     4 = agreed_commit([3, 4, 4]),
     % 3 servers - only leader has seen new commit
     3 = agreed_commit([4, 2, 3]),
+
+    %% Nth
+    4 = agreed_commit([4], 1),
+    % 2 servers - only leader has seen new commit
+    4 = agreed_commit([4, 3], 1),
+    % 2 servers - all servers have seen new commit
+    4 = agreed_commit([4, 4, 4], 2),
+    % 3 servers - only leader has seen new commit
+    4 = agreed_commit([4, 3, 3], 1),
+    % only other servers have seen new commit
+    4 = agreed_commit([3, 4, 4], 1),
+    % 3 servers - only leader has seen new commit
+    4 = agreed_commit([4, 2, 3], 1),
+
     ok.
 
 -endif.

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -108,7 +108,8 @@
                                  [ra_machine:release_cursor_condition()]},
       %% temporary state for handle_receive_snapshot
       current_event_type => term(),
-      snapshot_has_live_indexes => boolean()
+      snapshot_has_live_indexes => boolean(),
+      data_commit_static_quorum_size => non_neg_integer()
      }.
 
 -type state() :: ra_server_state().
@@ -231,7 +232,6 @@
 %% version, it switches to that new version. This was the default and only
 %% possible behavior in Ra up to 2.15.</li>
 %% </ul>
-
 -type ra_server_config() :: #{id := ra_server_id(),
                               uid := ra_uid(),
                               %% a friendly name to refer to a particular
@@ -263,8 +263,10 @@
                               %% minimum number of log entries since last
                               %% snapshot/checkpoint before writing a recovery
                               %% checkpoint on shutdown. 0 disables (default).
-                              min_recovery_checkpoint_interval => non_neg_integer()
-                             }.
+                              min_recovery_checkpoint_interval => non_neg_integer(),
+			      %% default 0 implies not using static_quorum
+			      data_commit_static_quorum_size => non_neg_integer()          
+			     }.
 
 -type ra_server_info_key() :: machine_version | atom().
 %% Key one can get in `ra_server_info()'.
@@ -369,7 +371,7 @@ init(#{id := Id,
 
     SnapModule = ra_machine:snapshot_module(Machine),
     Counter = maps:get(counter, Config, undefined),
-
+    DataCommitQuorumSize = maps:get(data_commit_static_quorum_size, Config, 0),
     Log0 = ra_log:init(LogInitArgs#{snapshot_module => SnapModule,
                                     machine => Machine,
                                     system_config => SystemConfig,
@@ -464,7 +466,8 @@ init(#{id := Id,
       aux_state => ra_machine:init_aux(MacMod, Name),
       query_index => 0,
       queries_waiting_heartbeats => queue:new(),
-      pending_consistent_queries => []}.
+      pending_consistent_queries => [],
+      data_commit_static_quorum_size => DataCommitQuorumSize}.
 
 recover(#{cfg := #cfg{log_id = LogId,
                       machine_version = MacVer},
@@ -1050,9 +1053,10 @@ handle_candidate(#request_vote_result{term = Term, vote_granted = true},
                    votes := Votes,
                    cluster := Nodes} = State0) ->
     NewVotes = Votes + 1,
-    ?DEBUG("~ts: vote granted for term ~b votes ~b",
-          [LogId, Term, NewVotes]),
-    case required_quorum(Nodes) of
+    ?DEBUG("~ts: vote granted for term ~b votes ~b --- ~p",
+          [LogId, Term, NewVotes, Nodes]),
+    DataCommitQuorumSize = maps:get(data_commit_static_quorum_size, State0, 0),
+    case required_quorum(Nodes, DataCommitQuorumSize) of
         NewVotes ->
             State = initialise_peers(State0#{leader_id => Id}),
             Effects = post_election_effects(State),
@@ -1239,7 +1243,8 @@ handle_pre_vote(#pre_vote_result{term = Term, vote_granted = true,
           [LogId, Token, Term, Votes + 1]),
     NewVotes = Votes + 1,
     State = update_term(Term, State0),
-    case required_quorum(Nodes) of
+    DataCommitQuorumSize = maps:get(data_commit_static_quorum_size, State, 0),
+    case required_quorum(Nodes, DataCommitQuorumSize) of
         NewVotes ->
             call_for_election(candidate, State);
         _ ->
@@ -3636,8 +3641,13 @@ evaluate_quorum(#{cfg := Cfg,
     {State1, Effects1} = apply_to(CI, State, Effects),
     maybe_emit_pending_release_cursor(State1, Effects1).
 
-increment_commit_index(State0 = #{current_term := CurrentTerm}) ->
-    PotentialNewCommitIndex = agreed_commit(match_indexes(State0)),
+increment_commit_index(State0 = #{current_term := CurrentTerm, data_commit_static_quorum_size := DataQuorumSize}) ->
+    PotentialNewCommitIndex = case DataQuorumSize of
+				  0 ->
+				      agreed_commit(match_indexes(State0));
+				  M ->
+				      agreed_commit(match_indexes(State0), M)
+			      end,
     % leaders can only increment their commit index if the corresponding
     % log entry term matches the current term. See (§5.4.2)
     case fetch_term(PotentialNewCommitIndex, State0) of
@@ -3677,7 +3687,7 @@ agreed_commit(Indexes) ->
     Nth = trunc(length(Indexes) / 2) + 1,
     agreed_commit(Indexes, Nth).
 
--spec agreed_commit(list(), integer()) -> ra_index().
+-spec agreed_commit(list(), pos_integer()) -> ra_index().
 agreed_commit(Indexes, Nth) -> %% return Mth highest
     SortedIdxs = lists:sort(fun erlang:'>'/2, Indexes),
     lists:nth(Nth, SortedIdxs).
@@ -3988,9 +3998,13 @@ maybe_promote_peer(PeerId, #{cluster := Cluster}, Effects) ->
             Effects
     end.
 
--spec required_quorum(ra_cluster()) -> pos_integer().
-required_quorum(Cluster) ->
-    Voters = count_voters(Cluster),
+-spec required_quorum(ra_cluster(), pos_integer()) -> pos_integer().
+required_quorum(Cluster, DataCommitQuorumSize) ->
+    required_quorum_count(count_voters(Cluster), DataCommitQuorumSize).
+
+required_quorum_count(Voters, 0) ->
+    trunc(Voters / 2) + 1;
+required_quorum_count(Voters, DataCommitQuorumSize)  ->
     trunc(Voters / 2) + 1.
 
 count_voters(Cluster) ->
@@ -4245,5 +4259,14 @@ agreed_commit_test() ->
     4 = agreed_commit([4, 2, 3], 1),
 
     ok.
+
+required_quorum_test() ->
+    %% 3 voters, no election quorum messing
+    2 = required_quorum_count(3, 0),
+    %% 4 voters, no election quorum messing
+    3 = required_quorum_count(4, 0),
+
+    ok.
+
 
 -endif.

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -263,7 +263,8 @@
                               %% minimum number of log entries since last
                               %% snapshot/checkpoint before writing a recovery
                               %% checkpoint on shutdown. 0 disables (default).
-                              min_recovery_checkpoint_interval => non_neg_integer()
+                              min_recovery_checkpoint_interval => non_neg_integer(),
+                              flexiraft_config => #flexiraft_cfg{}
                              }.
 
 -type ra_server_info_key() :: machine_version | atom().
@@ -4288,6 +4289,9 @@ agreed_commit_test() ->
     3 = agreed_commit([5, 5, 3, 2, 1], 3),
     % one way ahead of the rest
     1 = agreed_commit([5, 2, 1, 1, 1], 4),
+
+    % degenerate clamping
+    2 = agreed_commit([3, 3, 2], 15),
 
     ok.
 

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -4260,6 +4260,13 @@ agreed_commit_test() ->
     % 3 servers - only leader has seen new commit
     4 = agreed_commit([4, 2, 3], 1),
 
+    % 2 of the 3 have seen commit 3
+    3 = agreed_commit([3, 3, 2], 2),
+    % 2 ahead, 2 behind
+    3 = agreed_commit([5, 5, 3, 2, 1], 3),
+    % one way ahead of the rest
+    1 = agreed_commit([5, 2, 1, 1, 1], 4),
+
     ok.
 
 required_quorum_test() ->
@@ -4281,6 +4288,5 @@ required_quorum_test() ->
     3 = required_quorum_count(5, 4),
 
     ok.
-
 
 -endif.

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -3699,9 +3699,9 @@ agreed_commit(Indexes) ->  %% highest commit index agreed by a majority
     agreed_commit(Indexes, Nth).
 
 -spec agreed_commit(list(), pos_integer()) -> ra_index().
-agreed_commit(Indexes, Nth) ->  %% return Mth highest
+agreed_commit(Indexes, Nth) ->  %% return Nth highest
     SortedIdxs = lists:sort(fun erlang:'>'/2, Indexes),
-    lists:nth(Nth, SortedIdxs).
+    lists:nth(min(Nth, length(SortedIdxs)), SortedIdxs).
 
 log_unhandled_msg(RaState, Msg, #{cfg := #cfg{log_id = LogId}}) ->
     ?DEBUG("~ts: ~w received unhandled msg: ~W", [LogId, RaState, Msg, 6]).

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -3645,10 +3645,12 @@ evaluate_quorum(#{cfg := Cfg,
 
 data_commit_quorum_size(#flexiraft_cfg{quorum_type = classic_majority}) ->
     0;
-data_commit_quorum_size(#flexiraft_cfg{quorum_type = static_quorum, data_commit_static_quorum_size = N}) ->
+data_commit_quorum_size(#flexiraft_cfg{quorum_type = static_quorum,
+                                       data_commit_static_quorum_size = N}) ->
     N.
 
-increment_commit_index(State0 = #{current_term := CurrentTerm, cfg := #cfg{flexiraft_config = Flexi}}) ->
+increment_commit_index(State0 = #{current_term := CurrentTerm,
+                                  cfg := #cfg{flexiraft_config = Flexi}}) ->
     DataQuorumSize = data_commit_quorum_size(Flexi),
     PotentialNewCommitIndex = case DataQuorumSize of
                                   0 ->
@@ -4011,7 +4013,8 @@ maybe_promote_peer(PeerId, #{cluster := Cluster}, Effects) ->
 validate_flexiraft_config(#flexiraft_cfg{quorum_type = classic_majority}, _N) ->
     ok;
 validate_flexiraft_config(#flexiraft_cfg{quorum_type = static_quorum,
-                                         data_commit_static_quorum_size = M}, N) when M >= 1, M =< N ->
+                                         data_commit_static_quorum_size = M}, N)
+  when M >= 1, M =< N ->
     %% n.b. we do not validate that the M is _sane_, e.g. smaller than a classic majority
     ok;
 validate_flexiraft_config(#flexiraft_cfg{data_commit_static_quorum_size = M}, N) ->

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -3674,8 +3674,12 @@ match_indexes(#{cfg := #cfg{id = Id},
 
 -spec agreed_commit(list()) -> ra_index().
 agreed_commit(Indexes) ->
+    Nth = trunc(length(Indexes) / 2) + 1,
+    agreed_commit(Indexes, Nth).
+
+-spec agreed_commit(list(), integer()) -> ra_index().
+agreed_commit(Indexes, Nth) -> %% return Mth highest
     SortedIdxs = lists:sort(fun erlang:'>'/2, Indexes),
-    Nth = trunc(length(SortedIdxs) / 2) + 1,
     lists:nth(Nth, SortedIdxs).
 
 log_unhandled_msg(RaState, Msg, #{cfg := #cfg{log_id = LogId}}) ->

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -1053,10 +1053,11 @@ handle_candidate(#request_vote_result{term = Term, vote_granted = true},
                    votes := Votes,
                    cluster := Nodes} = State0) ->
     NewVotes = Votes + 1,
-    ?DEBUG("~ts: vote granted for term ~b votes ~b --- ~p",
-          [LogId, Term, NewVotes, Nodes]),
     DataCommitQuorumSize = maps:get(data_commit_static_quorum_size, State0, 0),
-    case required_quorum(Nodes, DataCommitQuorumSize) of
+    RequiredQuorum = required_quorum(Nodes, DataCommitQuorumSize),
+    ?DEBUG("~ts: vote granted for term ~b votes ~b --- ~b req ~b ~p",
+          [LogId, Term, NewVotes, Nodes, DataCommitQuorumSize, RequiredQuorum]),
+    case RequiredQuorum of
         NewVotes ->
             State = initialise_peers(State0#{leader_id => Id}),
             Effects = post_election_effects(State),

--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -108,8 +108,7 @@
                                  [ra_machine:release_cursor_condition()]},
       %% temporary state for handle_receive_snapshot
       current_event_type => term(),
-      snapshot_has_live_indexes => boolean(),
-      data_commit_static_quorum_size => non_neg_integer()
+      snapshot_has_live_indexes => boolean()
      }.
 
 -type state() :: ra_server_state().
@@ -263,9 +262,7 @@
                               %% minimum number of log entries since last
                               %% snapshot/checkpoint before writing a recovery
                               %% checkpoint on shutdown. 0 disables (default).
-                              min_recovery_checkpoint_interval => non_neg_integer(),
-			      %% default 0 implies not using static_quorum
-			      data_commit_static_quorum_size => non_neg_integer()          
+                              min_recovery_checkpoint_interval => non_neg_integer()
 			     }.
 
 -type ra_server_info_key() :: machine_version | atom().
@@ -371,7 +368,7 @@ init(#{id := Id,
 
     SnapModule = ra_machine:snapshot_module(Machine),
     Counter = maps:get(counter, Config, undefined),
-    DataCommitQuorumSize = maps:get(data_commit_static_quorum_size, Config, 0),
+    Flexi = maps:get(flexiraft_config, Config, #flexiraft_cfg{}),
     Log0 = ra_log:init(LogInitArgs#{snapshot_module => SnapModule,
                                     machine => Machine,
                                     system_config => SystemConfig,
@@ -434,7 +431,9 @@ init(#{id := Id,
                max_append_entries_rpc_batch_size = MaxAERBatchSize,
                counter = maps:get(counter, Config, undefined),
                system_config = SystemConfig,
-               min_recovery_checkpoint_interval = MinRecoveryCheckpointInterval},
+               min_recovery_checkpoint_interval = MinRecoveryCheckpointInterval,
+	       flexiraft_config = Flexi
+	      },
     put_counter(Cfg, ?C_RA_SVR_METRIC_COMMIT_INDEX, CommitIndex),
     put_counter(Cfg, ?C_RA_SVR_METRIC_LAST_APPLIED, SnapshotIdx),
     put_counter(Cfg, ?C_RA_SVR_METRIC_TERM, CurrentTerm),
@@ -466,8 +465,7 @@ init(#{id := Id,
       aux_state => ra_machine:init_aux(MacMod, Name),
       query_index => 0,
       queries_waiting_heartbeats => queue:new(),
-      pending_consistent_queries => [],
-      data_commit_static_quorum_size => DataCommitQuorumSize}.
+      pending_consistent_queries => []}.
 
 recover(#{cfg := #cfg{log_id = LogId,
                       machine_version = MacVer},
@@ -551,7 +549,7 @@ handle_leader({PeerId, #append_entries_reply{term = Term, success = true,
             Effects00 = maybe_promote_peer(PeerId, State1, []),
             {State2, Effects0} = evaluate_quorum(State1, Effects00),
             {State3, Effects1} = process_pending_consistent_queries(State2,
-                                                                   Effects0),
+								    Effects0),
             Effects2 = [{next_event, info, pipeline_rpcs} | Effects1],
             case State3 of
                 #{cluster := #{Id := _}} ->
@@ -1048,12 +1046,13 @@ handle_leader(Msg, State) ->
     {ra_state(), ra_server_state(), effects()}.
 handle_candidate(#request_vote_result{term = Term, vote_granted = true},
                  #{cfg := #cfg{id = Id,
-                               log_id = LogId},
+                               log_id = LogId,
+			       flexiraft_config = Flexi},
                    current_term := Term,
                    votes := Votes,
                    cluster := Nodes} = State0) ->
     NewVotes = Votes + 1,
-    DataCommitQuorumSize = maps:get(data_commit_static_quorum_size, State0, 0),
+    DataCommitQuorumSize = data_commit_quorum_size(Flexi),
     RequiredQuorum = required_quorum(Nodes, DataCommitQuorumSize),
     ?DEBUG("~ts: vote granted for term ~b votes ~b --- ~b req ~b ~p",
           [LogId, Term, NewVotes, Nodes, DataCommitQuorumSize, RequiredQuorum]),
@@ -1236,7 +1235,7 @@ handle_pre_vote(#pre_vote_result{term = Term, vote_granted = true,
                                  token = Token},
                 #{current_term := Term,
                   votes := Votes,
-                  cfg := #cfg{log_id = LogId},
+                  cfg := #cfg{log_id = LogId, flexiraft_config = Flexi},
                   pre_vote_token := Token,
                   cluster := Nodes,
                   membership := voter} = State0) ->
@@ -1244,7 +1243,7 @@ handle_pre_vote(#pre_vote_result{term = Term, vote_granted = true,
           [LogId, Token, Term, Votes + 1]),
     NewVotes = Votes + 1,
     State = update_term(Term, State0),
-    DataCommitQuorumSize = maps:get(data_commit_static_quorum_size, State, 0),
+    DataCommitQuorumSize = data_commit_quorum_size(Flexi),
     case required_quorum(Nodes, DataCommitQuorumSize) of
         NewVotes ->
             call_for_election(candidate, State);
@@ -3630,6 +3629,7 @@ append_entries_reply(Term, Success, #{log := Log} = State) ->
 evaluate_quorum(#{cfg := Cfg,
                   commit_index := CI0} = State0, Effects0) ->
     % TODO: shortcut function if commit index was not incremented
+    %%?INFO("CONFIG In evaluate_quorum ~p    ~p", [State0, Cfg]),
     State = #{commit_index := CI} = increment_commit_index(State0),
 
     Effects = case CI > CI0 of
@@ -3642,8 +3642,13 @@ evaluate_quorum(#{cfg := Cfg,
     {State1, Effects1} = apply_to(CI, State, Effects),
     maybe_emit_pending_release_cursor(State1, Effects1).
 
-increment_commit_index(State0 = #{current_term := CurrentTerm}) ->
-    DataQuorumSize = maps:get(data_commit_static_quorum_size, State0, 0),
+data_commit_quorum_size(#flexiraft_cfg{quorum_type = classic_majority}) ->
+    0;
+data_commit_quorum_size(#flexiraft_cfg{quorum_type = static_quorum, data_commit_static_quorum_size = N}) ->
+    N.
+
+increment_commit_index(State0 = #{current_term := CurrentTerm, cfg := #cfg{flexiraft_config = Flexi}}) ->
+    DataQuorumSize = data_commit_quorum_size(Flexi),
     PotentialNewCommitIndex = case DataQuorumSize of
 				  0 ->
 				      agreed_commit(match_indexes(State0));
@@ -3655,7 +3660,8 @@ increment_commit_index(State0 = #{current_term := CurrentTerm}) ->
     case fetch_term(PotentialNewCommitIndex, State0) of
         {CurrentTerm, State} ->
             State#{commit_index => PotentialNewCommitIndex};
-        {_, State} ->
+        {Bad, State} ->
+?INFO("Oops, term mismatch ~p for term ~p (need ~p(", [PotentialNewCommitIndex, Bad, CurrentTerm]),
             State
     end.
 
@@ -3673,7 +3679,7 @@ query_indexes(#{cfg := #cfg{id = Id},
 
 match_indexes(#{cfg := #cfg{id = Id},
                 cluster := Cluster,
-                log := Log}) ->
+                log := Log}) ->  %% commit indices of the cluster
     {LWIdx, _} = ra_log:last_written(Log),
     maps:fold(fun (PeerId, _, Acc) when PeerId == Id ->
                       Acc;
@@ -3685,7 +3691,7 @@ match_indexes(#{cfg := #cfg{id = Id},
               end, [LWIdx], Cluster).
 
 -spec agreed_commit(list()) -> ra_index().
-agreed_commit(Indexes) ->
+agreed_commit(Indexes) ->  %% highest commit index agreed by a majority
     Nth = trunc(length(Indexes) / 2) + 1,
     agreed_commit(Indexes, Nth).
 
@@ -3836,7 +3842,7 @@ update_peer_query_index(PeerId, QueryIndex, #{cluster := Cluster} = State0) ->
     end.
 
 get_current_query_quorum(State) ->
-    agreed_commit(query_indexes(State)).
+    agreed_commit(query_indexes(State)).  %% TODO Change me for flexiraft quorum
 
 -spec take_from_queue_while(fun((El) -> {true, Res} | false),
                                 queue:queue(El)) ->
@@ -4000,7 +4006,7 @@ maybe_promote_peer(PeerId, #{cluster := Cluster}, Effects) ->
             Effects
     end.
 
--spec required_quorum(ra_cluster(), pos_integer()) -> pos_integer().
+-spec required_quorum(ra_cluster(), non_neg_integer()) -> pos_integer().
 required_quorum(Cluster, DataCommitQuorumSize) ->
     required_quorum_count(count_voters(Cluster), DataCommitQuorumSize).
 

--- a/src/ra_server.hrl
+++ b/src/ra_server.hrl
@@ -36,5 +36,5 @@
          %% minimum number of log entries since last snapshot/checkpoint
          %% before writing a recovery checkpoint on shutdown. 0 disables (default).
          min_recovery_checkpoint_interval = 0 :: non_neg_integer(),
-	 flexiraft_config = #flexiraft_cfg{} :: #flexiraft_cfg{}
+         flexiraft_config = #flexiraft_cfg{} :: #flexiraft_cfg{}
         }).

--- a/src/ra_server.hrl
+++ b/src/ra_server.hrl
@@ -13,9 +13,9 @@
 
 -type flexiraft_quorum_type() :: classic_majority | static_quorum.
 -record(flexiraft_cfg, 
-	{quorum_type = classic_majority :: flexiraft_quorum_type(),
-	 %% default 0 implies not using static_quorum
-	 data_commit_static_quorum_size = 0 :: non_neg_integer()}).
+    {quorum_type = classic_majority :: flexiraft_quorum_type(),
+     %% default 0 implies not using static_quorum
+     data_commit_static_quorum_size = 0 :: non_neg_integer()}).
 
 -record(cfg,
         {id :: ra_server_id(),

--- a/src/ra_server.hrl
+++ b/src/ra_server.hrl
@@ -36,5 +36,5 @@
          %% minimum number of log entries since last snapshot/checkpoint
          %% before writing a recovery checkpoint on shutdown. 0 disables (default).
          min_recovery_checkpoint_interval = 0 :: non_neg_integer(),
-	 flexiraft_config = #flexiraft_cfg{}
+	 flexiraft_config = #flexiraft_cfg{} :: #flexiraft_cfg{}
         }).

--- a/src/ra_server.hrl
+++ b/src/ra_server.hrl
@@ -12,7 +12,7 @@
 -define(FLUSH_COMMANDS_SIZE, 16).
 
 -type flexiraft_quorum_type() :: classic_majority | static_quorum.
--record(flexiraft_cfg, 
+-record(flexiraft_cfg,
     {quorum_type = classic_majority :: flexiraft_quorum_type(),
      %% default 0 implies not using static_quorum
      data_commit_static_quorum_size = 0 :: non_neg_integer()}).

--- a/src/ra_server.hrl
+++ b/src/ra_server.hrl
@@ -11,6 +11,12 @@
 -define(DEFAULT_MACHINE_UPGRADE_STRATEGY, all).
 -define(FLUSH_COMMANDS_SIZE, 16).
 
+-type flexiraft_quorum_type() :: classic_majority | static_quorum.
+-record(flexiraft_cfg, 
+	{quorum_type = classic_majority :: flexiraft_quorum_type(),
+	 %% default 0 implies not using static_quorum
+	 data_commit_static_quorum_size = 0 :: non_neg_integer()}).
+
 -record(cfg,
         {id :: ra_server_id(),
          uid :: ra_uid(),
@@ -29,5 +35,6 @@
          system_config :: ra_system:config(),
          %% minimum number of log entries since last snapshot/checkpoint
          %% before writing a recovery checkpoint on shutdown. 0 disables (default).
-         min_recovery_checkpoint_interval = 0 :: non_neg_integer()
+         min_recovery_checkpoint_interval = 0 :: non_neg_integer(),
+	 flexiraft_config = #flexiraft_cfg{}
         }).

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -36,6 +36,7 @@ all() ->
      follower_leader_change_before_written,
      append_entries_reply_success,
      append_entries_reply_success_quorum,
+     append_entries_reply_cluster_smaller_than_quorum,
      append_entries_reply_no_success,
      append_entries_reply_no_success_from_unknown_peer,
      follower_request_vote,
@@ -1422,7 +1423,8 @@ append_entries_reply_success_quorum(_Config) ->
                 N3 => new_peer_with(#{next_index => 1, match_index => 0}),
                 N4 => new_peer_with(#{next_index => 1, match_index => 0}),
                 N5 => new_peer_with(#{next_index => 1, match_index => 0})},
-    Flexi = #flexiraft_cfg{quorum_type = static_quorum, data_commit_static_quorum_size = 2},
+    Flexi = #flexiraft_cfg{quorum_type = static_quorum,
+                           data_commit_static_quorum_size = 2},
     State0 = (base_state(5, ?FUNCTION_NAME))#{commit_index => 0, cluster => Cluster},
     Cfg0 = maps:get(cfg, State0),
     State1 = State0#{cfg => Cfg0#cfg{flexiraft_config = Flexi}},
@@ -1436,6 +1438,28 @@ append_entries_reply_success_quorum(_Config) ->
       commit_index := 3
      } = State,
     ok.
+
+append_entries_reply_cluster_smaller_than_quorum(_Config) ->
+    N1 = ?N1, N2 = ?N2, N3 = ?N3,
+    Cluster = #{N1 => new_peer_with(#{next_index => 1, match_index => 0}),
+                N2 => new_peer_with(#{next_index => 1, match_index => 0})},
+    Flexi = #flexiraft_cfg{quorum_type = static_quorum,
+                           data_commit_static_quorum_size = 3},  %% clamped
+    State0 = (base_state(2, ?FUNCTION_NAME))#{commit_index => 0,
+                                              cluster => Cluster},
+    Cfg0 = maps:get(cfg, State0),
+    State1 = State0#{cfg => Cfg0#cfg{flexiraft_config = Flexi}},
+    Msg = {N2, #append_entries_reply{success = true, term = 5,
+                                     next_index = 4, last_term = 5,
+                                     last_index = 3}},
+    {leader, State2, _} = ra_server:handle_leader(Msg, State1),
+    #{cluster := #{N2 := #{next_index := 4, match_index := 3}},
+      commit_index := 3
+     } = State2,
+
+    ok.
+    
+
 
 append_entries_reply_no_success(_Config) ->
     N1 = ?N1, N2 = ?N2, N3 = ?N3,

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1428,7 +1428,7 @@ append_entries_reply_success_quorum(_Config) ->
     State1 = State0#{cfg => Cfg0#cfg{flexiraft_config = Flexi}},
 
     Msg = {N2, #append_entries_reply{success = true, term = 5,
-                                     next_index = 4,
+                                     next_index = 4, last_term = 5,
                                      last_index = 3}},
     {leader,
      State,

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1435,18 +1435,17 @@ append_entries_reply_success_quorum(_Config) ->
     {leader, State, _} = ra_server:handle_leader(Msg, State1),
     %% With data_commit_static_quorum_size 2, we only need one ack to commit
     #{cluster := #{N2 := #{next_index := 4, match_index := 3}},
-      commit_index := 3
-     } = State,
+      commit_index := 3} = State,
     ok.
 
 append_entries_reply_cluster_smaller_than_quorum(_Config) ->
-    N1 = ?N1, N2 = ?N2, N3 = ?N3,
-    Cluster = #{N1 => new_peer_with(#{next_index => 1, match_index => 0}),
-                N2 => new_peer_with(#{next_index => 1, match_index => 0})},
+    N1 = ?N1, N2 = ?N2, N3 = ?N3, N4 = ?N4,
+    Cluster0 = #{N1 => new_peer_with(#{next_index => 1, match_index => 0}),
+                 N2 => new_peer_with(#{next_index => 1, match_index => 0})},
     Flexi = #flexiraft_cfg{quorum_type = static_quorum,
                            data_commit_static_quorum_size = 3},  %% clamped
     State0 = (base_state(2, ?FUNCTION_NAME))#{commit_index => 0,
-                                              cluster => Cluster},
+                                              cluster => Cluster0},
     Cfg0 = maps:get(cfg, State0),
     State1 = State0#{cfg => Cfg0#cfg{flexiraft_config = Flexi}},
     Msg = {N2, #append_entries_reply{success = true, term = 5,
@@ -1454,12 +1453,8 @@ append_entries_reply_cluster_smaller_than_quorum(_Config) ->
                                      last_index = 3}},
     {leader, State2, _} = ra_server:handle_leader(Msg, State1),
     #{cluster := #{N2 := #{next_index := 4, match_index := 3}},
-      commit_index := 3
-     } = State2,
-
+      commit_index := 3} = State2,
     ok.
-    
-
 
 append_entries_reply_no_success(_Config) ->
     N1 = ?N1, N2 = ?N2, N3 = ?N3,

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1431,6 +1431,7 @@ append_entries_reply_success_quorum(_Config) ->
      State,
      _} = ra_server:handle_leader(Msg, State0),
     ?INFO("state ~p", [State]),
+    %% With data_commit_static_quorum_size 2, we only need one ack to commit
     #{cluster := #{N2 := #{next_index := 4, match_index := 3}}, 
      commit_index := 3} = State,
     ok.

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -2493,7 +2493,7 @@ candidate_election(_Config) ->
      ]} = ra_server:handle_leader(Noop, State2),
     ok.
 
-candidate_election_quorum(_config) ->
+candidate_election_quorum(_Config) ->
     N2 = ?N2, N3 = ?N3, N4 = ?N4, N5 = ?N5,
     Flexi = #flexiraft_cfg{quorum_type = static_quorum, data_commit_static_quorum_size = 2},
     State0 = (base_state(5, ?FUNCTION_NAME))#{current_term => 6, votes => 1},

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1439,7 +1439,7 @@ append_entries_reply_success_quorum(_Config) ->
     ok.
 
 append_entries_reply_cluster_smaller_than_quorum(_Config) ->
-    N1 = ?N1, N2 = ?N2, N3 = ?N3, N4 = ?N4,
+    N1 = ?N1, N2 = ?N2,
     Cluster0 = #{N1 => new_peer_with(#{next_index => 1, match_index => 0}),
                  N2 => new_peer_with(#{next_index => 1, match_index => 0})},
     Flexi = #flexiraft_cfg{quorum_type = static_quorum,
@@ -2517,9 +2517,7 @@ candidate_election_quorum(_Config) ->
     Flexi = #flexiraft_cfg{quorum_type = static_quorum, data_commit_static_quorum_size = 2},
     State0 = (base_state(5, ?FUNCTION_NAME))#{current_term => 6, votes => 1},
     Cfg0 = maps:get(cfg, State0),
-    State = State0#{cfg => Cfg0#cfg{flexiraft_config = Flexi},
-                    current_term => 6,
-                    votes => 1},
+    State = State0#{cfg => Cfg0#cfg{flexiraft_config = Flexi}},
     Reply = #request_vote_result{term = 6, vote_granted = true},
     {candidate, #{votes := 2} = State1, []}
         = ra_server:handle_candidate(Reply, State),

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1430,10 +1430,7 @@ append_entries_reply_success_quorum(_Config) ->
     Msg = {N2, #append_entries_reply{success = true, term = 5,
                                      next_index = 4, last_term = 5,
                                      last_index = 3}},
-    {leader,
-     State,
-     _} = ra_server:handle_leader(Msg, State1),
-    ?INFO("state ~p", [State]),
+    {leader, State, _} = ra_server:handle_leader(Msg, State1),
     %% With data_commit_static_quorum_size 2, we only need one ack to commit
     #{cluster := #{N2 := #{next_index := 4, match_index := 3}},
       commit_index := 3

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -52,6 +52,7 @@ all() ->
      leader_receives_pre_vote,
      leader_pre_vote_sends_snapshot_to_backoff_peer,
      candidate_election,
+     candidate_election_quorum,
      is_new,
      command,
      command_notify,
@@ -2469,6 +2470,29 @@ candidate_election(_Config) ->
       {send_rpc, N2, _}
      ]} = ra_server:handle_leader(Noop, State2),
     ok.
+
+candidate_election_quorum(_config) ->
+    N2 = ?N2, N3 = ?N3, N4 = ?N4, N5 = ?N5,
+    State = (base_state(5, ?FUNCTION_NAME))#{current_term => 6, votes => 1, data_commit_static_quorum_size => 2},
+    Reply = #request_vote_result{term = 6, vote_granted = true},
+    {candidate, #{votes := 2} = State1, []}
+        = ra_server:handle_candidate(Reply, State),
+    {candidate, #{votes := 3} = State2, []}
+        = ra_server:handle_candidate(Reply, State1),
+    {leader, State3, _}
+        = ra_server:handle_candidate(Reply, State2),
+
+    PeerState = new_peer_with(#{next_index => 3+1, % leaders last log index + 1
+                                match_index => 0}), % initd to 0
+    #{cluster := #{N2 := PeerState,
+    		   N3 := PeerState,
+     		   N4 := PeerState,
+     		   N5 := PeerState}} = State3,
+    ok.
+
+
+
+
 
 pre_vote_election(_Config) ->
     Token = make_ref(),

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -35,6 +35,7 @@ all() ->
      follower_aer_dupe,
      follower_leader_change_before_written,
      append_entries_reply_success,
+     append_entries_reply_success_quorum,
      append_entries_reply_no_success,
      append_entries_reply_no_success_from_unknown_peer,
      follower_request_vote,
@@ -1413,6 +1414,25 @@ append_entries_reply_success(_Config) ->
                current_term := 7,
                machine_state := <<"hi1">>}, _} =
         ra_server:handle_leader(Msg1, State0#{current_term := 7}),
+    ok.
+
+append_entries_reply_success_quorum(_Config) ->
+    N1 = ?N1, N2 = ?N2, N3 = ?N3, N4 = ?N4, N5 = ?N5,
+    Cluster = #{N1 => new_peer_with(#{next_index => 1, match_index => 0}),
+		N2 => new_peer_with(#{next_index => 1, match_index => 0}),
+                N3 => new_peer_with(#{next_index => 1, match_index => 0}),
+                N4 => new_peer_with(#{next_index => 1, match_index => 0}),
+                N5 => new_peer_with(#{next_index => 1, match_index => 0})},
+    State0 = (base_state(5, ?FUNCTION_NAME))#{commit_index => 0, data_commit_static_quorum_size => 2, cluster => Cluster},
+    Msg = {N2, #append_entries_reply{success = true, term = 5,
+				     next_index = 4,
+                                     last_index = 3}},
+    {leader, 
+     State,
+     _} = ra_server:handle_leader(Msg, State0),
+    ?INFO("state ~p", [State]),
+    #{cluster := #{N2 := #{next_index := 4, match_index := 3}}, 
+     commit_index := 3} = State,
     ok.
 
 append_entries_reply_no_success(_Config) ->

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1368,7 +1368,6 @@ follower_leader_change_before_written(_Config) ->
     ok.
 
 append_entries_reply_success(_Config) ->
-
     N1 = ?N1, N2 = ?N2, N3 = ?N3,
     Cluster = #{N1 => new_peer_with(#{next_index => 5, match_index => 4}),
                 N2 => new_peer_with(#{next_index => 1, match_index => 0,
@@ -1423,17 +1422,22 @@ append_entries_reply_success_quorum(_Config) ->
                 N3 => new_peer_with(#{next_index => 1, match_index => 0}),
                 N4 => new_peer_with(#{next_index => 1, match_index => 0}),
                 N5 => new_peer_with(#{next_index => 1, match_index => 0})},
-    State0 = (base_state(5, ?FUNCTION_NAME))#{commit_index => 0, data_commit_static_quorum_size => 2, cluster => Cluster},
+    Flexi = #flexiraft_cfg{quorum_type = static_quorum, data_commit_static_quorum_size = 2},
+    State0 = (base_state(5, ?FUNCTION_NAME))#{commit_index => 0, cluster => Cluster},
+    Cfg0 = maps:get(cfg, State0),
+    State1 = State0#{cfg => Cfg0#cfg{flexiraft_config = Flexi}},
+
     Msg = {N2, #append_entries_reply{success = true, term = 5,
 				     next_index = 4,
                                      last_index = 3}},
-    {leader, 
+    {leader,
      State,
-     _} = ra_server:handle_leader(Msg, State0),
+     _} = ra_server:handle_leader(Msg, State1),
     ?INFO("state ~p", [State]),
     %% With data_commit_static_quorum_size 2, we only need one ack to commit
-    #{cluster := #{N2 := #{next_index := 4, match_index := 3}}, 
-     commit_index := 3} = State,
+    #{cluster := #{N2 := #{next_index := 4, match_index := 3}},
+      commit_index := 3
+     } = State,
     ok.
 
 append_entries_reply_no_success(_Config) ->
@@ -2494,7 +2498,12 @@ candidate_election(_Config) ->
 
 candidate_election_quorum(_config) ->
     N2 = ?N2, N3 = ?N3, N4 = ?N4, N5 = ?N5,
-    State = (base_state(5, ?FUNCTION_NAME))#{current_term => 6, votes => 1, data_commit_static_quorum_size => 2},
+    Flexi = #flexiraft_cfg{quorum_type = static_quorum, data_commit_static_quorum_size = 2},
+    State0 = (base_state(5, ?FUNCTION_NAME))#{current_term => 6, votes => 1},
+    Cfg0 = maps:get(cfg, State0),
+    State = State0#{cfg => Cfg0#cfg{flexiraft_config = Flexi},
+		    current_term => 6,
+		    votes => 1},
     Reply = #request_vote_result{term = 6, vote_granted = true},
     {candidate, #{votes := 2} = State1, []}
         = ra_server:handle_candidate(Reply, State),
@@ -2510,10 +2519,6 @@ candidate_election_quorum(_config) ->
      		   N4 := PeerState,
      		   N5 := PeerState}} = State3,
     ok.
-
-
-
-
 
 pre_vote_election(_Config) ->
     Token = make_ref(),

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -1418,7 +1418,7 @@ append_entries_reply_success(_Config) ->
 append_entries_reply_success_quorum(_Config) ->
     N1 = ?N1, N2 = ?N2, N3 = ?N3, N4 = ?N4, N5 = ?N5,
     Cluster = #{N1 => new_peer_with(#{next_index => 1, match_index => 0}),
-		N2 => new_peer_with(#{next_index => 1, match_index => 0}),
+                N2 => new_peer_with(#{next_index => 1, match_index => 0}),
                 N3 => new_peer_with(#{next_index => 1, match_index => 0}),
                 N4 => new_peer_with(#{next_index => 1, match_index => 0}),
                 N5 => new_peer_with(#{next_index => 1, match_index => 0})},
@@ -1428,7 +1428,7 @@ append_entries_reply_success_quorum(_Config) ->
     State1 = State0#{cfg => Cfg0#cfg{flexiraft_config = Flexi}},
 
     Msg = {N2, #append_entries_reply{success = true, term = 5,
-				     next_index = 4,
+                                     next_index = 4,
                                      last_index = 3}},
     {leader,
      State,
@@ -2502,8 +2502,8 @@ candidate_election_quorum(_config) ->
     State0 = (base_state(5, ?FUNCTION_NAME))#{current_term => 6, votes => 1},
     Cfg0 = maps:get(cfg, State0),
     State = State0#{cfg => Cfg0#cfg{flexiraft_config = Flexi},
-		    current_term => 6,
-		    votes => 1},
+                    current_term => 6,
+                    votes => 1},
     Reply = #request_vote_result{term = 6, vote_granted = true},
     {candidate, #{votes := 2} = State1, []}
         = ra_server:handle_candidate(Reply, State),
@@ -2515,9 +2515,9 @@ candidate_election_quorum(_config) ->
     PeerState = new_peer_with(#{next_index => 3+1, % leaders last log index + 1
                                 match_index => 0}), % initd to 0
     #{cluster := #{N2 := PeerState,
-    		   N3 := PeerState,
-     		   N4 := PeerState,
-     		   N5 := PeerState}} = State3,
+                   N3 := PeerState,
+                   N4 := PeerState,
+                   N5 := PeerState}} = State3,
     ok.
 
 pre_vote_election(_Config) ->


### PR DESCRIPTION
## Proposed Changes

Adds support for the simplest optimization from FlexiRaft #500 : static quorums not confined to the classic majority.

Operators can configure a static data-commit quorum size. In particular, this is useful if it is set below the classic majority - allowing data to be committed with fewer acks. To guarantee safety, the leader election quorum is increased, forcing the property that the data commit quorum and the leader election quorum intersect (`|Qd| + |Qe| > N`)

Out of scope:
* dynamic quorums and quorums-of-sets as defined in FlexiRaft, or other optimizations pertaining to cluster resize
* consistent-read query path (bound to classic majority)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [ ] I have read the `CONTRIBUTING.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
