### PR TITLE
ci: temporary fix for windows-latest changed

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -23,9 +23,9 @@ jobs:
       env:
         # windows-latest now reports ImageOS=win25-vs2026, which the pinned
         # setup-beam does not recognize (it keys on the exact string "win25").
-        # Override so the OS lookup resolves to windows-2025. Remove once
-        # https://github.com/erlef/setup-beam/pull/461 ships.
-        ImageOS: win25
+        # Override to "win25" on Windows
+        # Remove once https://github.com/erlef/setup-beam/pull/461 ships.
+        ImageOS: ${{ matrix.os == 'windows-latest' && 'win25' || env.ImageOS }}
       with:
         otp-version: ${{ matrix.otp_version }}
         rebar3-version: '3.25.1'

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -13,6 +13,13 @@ jobs:
       matrix:
         otp_version: [26, 27, 28]
         os: [ubuntu-latest, windows-latest]
+        # Pin ImageOS per OS: windows-latest reports win25-vs2026, which the
+        # pinned setup-beam can't map. Drop once erlef/setup-beam#461 ships.
+        include:
+          - os: ubuntu-latest
+            image_os: ubuntu24
+          - os: windows-latest
+            image_os: win25
     steps:
     - name: Checkout
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -21,11 +28,7 @@ jobs:
       # the time of commit).
       uses: erlef/setup-beam@566deebc640988a494af16ecdf6f820fe0d3fea4
       env:
-        # windows-latest now reports ImageOS=win25-vs2026, which the pinned
-        # setup-beam does not recognize (it keys on the exact string "win25").
-        # Override to "win25" on Windows
-        # Remove once https://github.com/erlef/setup-beam/pull/461 ships.
-        ImageOS: ${{ matrix.os == 'windows-latest' && 'win25' || env.ImageOS }}
+        ImageOS: ${{ matrix.image_os }}
       with:
         otp-version: ${{ matrix.otp_version }}
         rebar3-version: '3.25.1'

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -20,6 +20,12 @@ jobs:
       # Pin setup-beam to a version that works with Windows (not released at
       # the time of commit).
       uses: erlef/setup-beam@566deebc640988a494af16ecdf6f820fe0d3fea4
+      env:
+        # windows-latest now reports ImageOS=win25-vs2026, which the pinned
+        # setup-beam does not recognize (it keys on the exact string "win25").
+        # Override so the OS lookup resolves to windows-2025. Remove once
+        # https://github.com/erlef/setup-beam/pull/461 ships.
+        ImageOS: win25
       with:
         otp-version: ${{ matrix.otp_version }}
         rebar3-version: '3.25.1'


### PR DESCRIPTION
## Proposed Changes

I noticed on https://github.com/rabbitmq/ra/pull/638 the CI is broken for windows images - the Github ImageOS is not known to setup-beam yet, so the setup fails. Once https://github.com/erlef/setup-beam/pull/461 merges we can undo this change. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
