### PR TITLE
Handle delete_and_terminate throws in recovery

### DIFF
--- a/src/ra_server.erl
+++ b/src/ra_server.erl
@@ -481,51 +481,54 @@ recover(#{cfg := #cfg{log_id = LogId,
            [LogId, Cfg#cfg.effective_machine_version, MacVer,
             LastApplied1, CommitIndex]),
     Before = erlang:system_time(millisecond),
-    {#{log := Log0,
-       cfg := #cfg{effective_machine_version = EffMacVerAfter}} = State2, _} =
-        apply_to(CommitIndex,
-                 fun({_Idx, _, _} = E, S0) ->
-                         %% Clear out the effects and notifies map
-                         %% to avoid memory explosion
-                         {Mod, LastAppl, S, MacSt, _E, _N, LastTs} =
-                             apply_with(E, S0),
-                         put_counter(Cfg, ?C_RA_SVR_METRIC_LAST_APPLIED, LastAppl),
-                         {Mod, LastAppl, S, MacSt, [], #{}, LastTs}
-                 end,
-                 State1, []),
-    After = erlang:system_time(millisecond),
-    ?DEBUG("~ts: recovery of state machine version ~b:~b "
-           "from index ~b to ~b took ~bms",
-           [LogId, EffMacVerAfter, MacVer, LastApplied1, CommitIndex,
-            After - Before]),
-    %% scan from CommitIndex + 1 until NextIndex - 1 to see if there are
-    %% any further cluster changes
-    FromScan = CommitIndex + 1,
-    {ToScan, _} = ra_log:last_index_term(Log0),
-    ?DEBUG("~ts: scanning for cluster changes ~b:~b ",
-           [LogId, FromScan, ToScan]),
-    %% if we're recovering after a partial sparse write phase this will fail
-    {{LastScannedIdx, State3}, Log1} = ra_log:fold(fun cluster_scan_fun/2,
-                                                   FromScan, ToScan,
-                                                   {CommitIndex, State2}, Log0,
-                                                   return),
-
-    State = case LastScannedIdx < ToScan of
-                true ->
-                    ?DEBUG("~ts: scan detected sparse log last scanned ~b:~b "
-                           "resetting log to last contiguous index ~b",
-                           [LogId, LastScannedIdx, ToScan, LastScannedIdx]),
-                    %% the end of the log is sparse and needs to be reset
-                    {ok, Log2} = ra_log:set_last_index(LastScannedIdx, Log1),
-                    State3#{log => Log2};
-                false ->
-                    State3
-            end,
-
-    put_counter(Cfg, ?C_RA_SVR_METRIC_COMMIT_LATENCY, 0),
-    State#{
-           %% reset commit latency as recovery may calculate a very old value
-           commit_latency => 0}.
+    try
+        {#{log := Log0,
+           cfg := #cfg{effective_machine_version = EffMacVerAfter}} = State2, _} =
+            apply_to(CommitIndex,
+                     fun({_Idx, _, _} = E, S0) ->
+                             %% Clear out the effects and notifies map
+                             %% to avoid memory explosion
+                             {Mod, LastAppl, S, MacSt, _E, _N, LastTs} =
+                                 apply_with(E, S0),
+                             put_counter(Cfg, ?C_RA_SVR_METRIC_LAST_APPLIED,
+                                         LastAppl),
+                             {Mod, LastAppl, S, MacSt, [], #{}, LastTs}
+                     end,
+                     State1, []),
+        After = erlang:system_time(millisecond),
+        ?DEBUG("~ts: recovery of state machine version ~b:~b "
+               "from index ~b to ~b took ~bms",
+               [LogId, EffMacVerAfter, MacVer, LastApplied1, CommitIndex,
+                After - Before]),
+        %% scan from CommitIndex + 1 until NextIndex - 1 to see if there are
+        %% any further cluster changes
+        FromScan = CommitIndex + 1,
+        {ToScan, _} = ra_log:last_index_term(Log0),
+        ?DEBUG("~ts: scanning for cluster changes ~b:~b ",
+               [LogId, FromScan, ToScan]),
+        %% if we're recovering after a partial sparse write phase this will fail
+        {{LastScannedIdx, State3}, Log1} = ra_log:fold(fun cluster_scan_fun/2,
+                                                       FromScan, ToScan,
+                                                       {CommitIndex, State2},
+                                                       Log0, return),
+        State = case LastScannedIdx < ToScan of
+                    true ->
+                        ?DEBUG("~ts: scan detected sparse log last scanned ~b:~b "
+                               "resetting log to last contiguous index ~b",
+                               [LogId, LastScannedIdx, ToScan, LastScannedIdx]),
+                        %% the end of the log is sparse and needs to be reset
+                        {ok, Log2} = ra_log:set_last_index(LastScannedIdx, Log1),
+                        State3#{log => Log2};
+                    false ->
+                        State3
+                end,
+        put_counter(Cfg, ?C_RA_SVR_METRIC_COMMIT_LATENCY, 0),
+        %% reset commit latency as recovery may calculate a very old value
+        State#{commit_latency => 0}
+    catch
+        throw:{delete_and_terminate, State4, _Effects} ->
+            {delete_and_terminate, State4}
+    end.
 
 -spec handle_leader(ra_msg(), ra_server_state()) ->
     {ra_state(), ra_server_state(), effects()}.

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -432,12 +432,17 @@ recover(enter, OldState, State0) ->
     {State, Actions} = handle_enter(?FUNCTION_NAME, OldState, State0),
     {keep_state, State, Actions};
 recover(internal, go, State = #state{server_state = ServerState0}) ->
-    ServerState = ra_server:recover(ServerState0),
-    incr_counter(State#state.conf, ?C_RA_SRV_GCS, 1),
-    %% we have to issue the next_event here so that the recovered state is
-    %% only passed through very briefly
-    next_state(recovered, State#state{server_state = ServerState},
-               [{next_event, internal, next}]);
+    case ra_server:recover(ServerState0) of
+        {delete_and_terminate, ServerState} ->
+            next_state(terminating_follower,
+                       State#state{server_state = ServerState}, []);
+        ServerState ->
+            incr_counter(State#state.conf, ?C_RA_SRV_GCS, 1),
+            %% we have to issue the next_event here so that the recovered
+            %% state is only passed through very briefly
+            next_state(recovered, State#state{server_state = ServerState},
+                       [{next_event, internal, next}])
+    end;
 recover(_, _, State) ->
     % all other events need to be postponed until we can return
     % `next_event` from init

--- a/test/ra_server_SUITE.erl
+++ b/test/ra_server_SUITE.erl
@@ -63,6 +63,7 @@ all() ->
      follower_install_snapshot_machine_version,
      recovery_checkpoint_reinitialises_aux_state,
      recovery_checkpoint_reinitialises_aux_state_same_version,
+     recover_survives_committed_delete_entry,
      leader_server_join,
      leader_server_join_nonvoter,
      leader_server_leave,
@@ -2004,6 +2005,46 @@ recovery_checkpoint_reinitialises_aux_state_same_version(_Config) ->
                   effective_machine_module = Mod},
       machine_state := recovered_machine_state,
       aux_state := fresh_aux_state} = ra_server:recover(State00),
+    ok.
+
+recover_survives_committed_delete_entry(_Config) ->
+    %% simulates a node that crashed after a '$ra_cluster' delete entry was
+    %% durably logged and committed, but before last_applied was persisted
+    %% past it: on restart, recover/1 replays the same entry and must not
+    %% crash.
+    Mod = ?FUNCTION_NAME,
+    mock_machine(Mod),
+    DeleteCmd = {'$ra_cluster', meta(), delete, await_consensus},
+    Log0 = ra_log:append({1, 1, DeleteCmd},
+                         ra_log:init(#{system_config => ra_system:default_config(),
+                                       uid => <<>>})),
+    {Log, _} = ra_log:handle_event({written, 1, [{1, 1}]}, Log0),
+    Cfg = #cfg{id = ?N1,
+               uid = <<"n1">>,
+               log_id = <<"n1">>,
+               metrics_key = n1,
+               metrics_labels = #{},
+               machine = {machine, Mod, #{}},
+               machine_version = 0,
+               machine_versions = [{0, 0}],
+               effective_machine_version = 0,
+               effective_machine_module = Mod,
+               system_config = ra_system:default_config()},
+    State0 = #{cfg => Cfg,
+               leader_id => ?N1,
+               cluster => #{?N1 => new_peer_with(#{next_index => 2,
+                                                    match_index => 1})},
+               cluster_index_term => {0, 0},
+               cluster_change_permitted => true,
+               machine_state => init_state,
+               current_term => 1,
+               commit_index => 1,
+               last_applied => 0,
+               log => Log,
+               query_index => 0,
+               queries_waiting_heartbeats => queue:new(),
+               pending_consistent_queries => []},
+    ?assertMatch({delete_and_terminate, _}, ra_server:recover(State0)),
     ok.
 
 leader_server_join(_Config) ->


### PR DESCRIPTION
`ra_server:recover/1` folded through the log but did not catch the throw for `delete_and_terminate`. This leads to a crash loop on boot if the server appends a deletion command, does not apply it, and then reboots. We can `try`/`catch` and transition to terminating_follower instead.

I saw this in a 3.13 cluster recently and saw that it's still possible on the latest main, at least theoretically. I'll post a redacted snippet of the raft log I captured where this occurred.