### PR TITLE
Add ra_system_sup:child_spec/1 builder

### DIFF
--- a/src/ra_system_registration.erl
+++ b/src/ra_system_registration.erl
@@ -1,0 +1,48 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2017-2025 Broadcom. All Rights Reserved. The term Broadcom refers to Broadcom Inc. and/or its subsidiaries.
+
+%% @hidden
+%%
+%% Owns the {'$ra_system', Name} persistent_term registration lifecycle for a
+%% single Ra system.
+-module(ra_system_registration).
+
+-behaviour(gen_server).
+
+-export([start_link/1]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-spec start_link(ra_system:config()) ->
+    {ok, pid()} | ignore | {error, term()}.
+start_link(#{name := _Name} = Config) ->
+    gen_server:start_link(?MODULE, Config, []).
+
+init(#{name := _Name} = Config) ->
+    process_flag(trap_exit, true),
+    ok = ra_system:store(Config),
+    {ok, Config}.
+
+handle_call(_Request, _From, Config) ->
+    {reply, ok, Config}.
+
+handle_cast(_Msg, Config) ->
+    {noreply, Config}.
+
+handle_info(_Msg, Config) ->
+    {noreply, Config}.
+
+terminate(_Reason, #{name := Name}) ->
+    _ = persistent_term:erase({'$ra_system', Name}),
+    ok.
+
+code_change(_OldVsn, Config, _Extra) ->
+    {ok, Config}.

--- a/src/ra_system_sup.erl
+++ b/src/ra_system_sup.erl
@@ -12,7 +12,8 @@
 -include("ra.hrl").
 
 %% API functions
--export([start_link/1]).
+-export([start_link/1,
+         child_spec/1]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -21,6 +22,22 @@
 start_link(Config) ->
     supervisor:start_link(?MODULE, Config).
 
+%% @doc Build a child spec for a Ra system so that it can be started as a
+%% static child of a consuming application's own supervision tree, rather than
+%% as a dynamic child of `ra_systems_sup'.
+%%
+%% A system started this way still registers itself (see
+%% `ra_system_registration', the first child started by this supervisor) so the
+%% rest of the Ra API can discover it by name.
+%%
+%% This is an alternative to `ra:start_system/1' which places the system under
+%% an arbitrary supervision tree rather than `ra_systems_sup'.
+-spec child_spec(ra_system:config()) -> supervisor:child_spec().
+child_spec(#{name := Name} = Config) ->
+    #{id => Name,
+      type => supervisor,
+      start => {?MODULE, start_link, [Config]}}.
+
 init(#{data_dir := DataDir,
        name := Name,
        names := _Names} = Cfg) ->
@@ -28,6 +45,8 @@ init(#{data_dir := DataDir,
         ok ->
             ?DEBUG("ra system '~s' starting", [Name]),
             SupFlags = #{strategy => one_for_all, intensity => 1, period => 5},
+            Registration = #{id => ra_system_registration,
+                             start => {ra_system_registration, start_link, [Cfg]}},
             %% the ra log ets process is supervised by the system to keep mem tables
             %% alive whilst the rest of the log infra might be down
             Ets = #{id => ra_log_ets,
@@ -40,7 +59,7 @@ init(#{data_dir := DataDir,
                                start => {ra_server_sup_sup, start_link, [Cfg]}},
             Recover = #{id => ra_system_recover,
                         start => {ra_system_recover, start_link, [maps:get(name, Cfg)]}},
-            {ok, {SupFlags, [Ets, RaLogSup, RaServerSupSup, Recover]}};
+            {ok, {SupFlags, [Registration, Ets, RaLogSup, RaServerSupSup, Recover]}};
         {error, Code} ->
             ?ERR("Failed to create Ra data directory at '~ts', file system operation error: ~p", [DataDir, Code]),
             exit({error, "Ra could not create its data directory. See the log for details."})

--- a/src/ra_systems_sup.erl
+++ b/src/ra_systems_sup.erl
@@ -30,7 +30,6 @@ start_system(#{name := Name,
                data_dir := Dir} = Config) when is_atom(Name) ->
     ?INFO("starting Ra system: ~ts in directory: ~ts", [Name, Dir]),
     %% TODO: validate configuration
-    ok = ra_system:store(Config),
     RaSystemsSup = #{id => Name,
                      type => supervisor,
                      start => {ra_system_sup, start_link, [Config]}},
@@ -56,7 +55,6 @@ stop_system(Name) when is_atom(Name) ->
 
 cleanup(Name) when is_atom(Name) ->
     ?CATCH(supervisor:delete_child(?MODULE, Name)),
-    _ = persistent_term:erase({'$ra_system', Name}),
     ok.
 
 init([]) ->


### PR DESCRIPTION
This allows other OTP applications to start a system under their own supervision tree, rather than the dynamic `ra_system_sup` supervisor. This makes for finer control over lifecycle, for example making it possible for a consuming application to naturally terminate itself if the system goes down, if the system is a critical part of the application.

The child_spec/1 builder is pretty trivial

```erlang
child_spec(#{name := Name} = Config) ->
    #{id => Name,
      type => supervisor,
      start => {?MODULE, start_link, [Config]}}.
```

This change also moves the ownership of the `{'$ra_system', Name}` from ra_systems_sup into a separate server so that it is set and cleared consistently.

See https://github.com/rabbitmq/ra/issues/585