### PR TITLE
Add metrics_labels to MUTABLE_CONFIG_KEYS to introduce the value in 3.13 migrated queues config, in line with 4.2 queues

### DIFF
--- a/src/ra_server_sup_sup.erl
+++ b/src/ra_server_sup_sup.erl
@@ -12,6 +12,7 @@
 -define(MUTABLE_CONFIG_KEYS,
         [cluster_name,
          metrics_key,
+         metrics_labels,
          broadcast_time,
          tick_timeout,
          install_snap_rpc_timeout,


### PR DESCRIPTION
## Proposed Changes

This is the companion to https://github.com/rabbitmq/rabbitmq-server/pull/17184, which makes metrics_labels as an allowed mutable key.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue [rabbitmq-server](https://github.com/rabbitmq/rabbitmq-server/issues/17183))
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I am not sure of the status of our CA/CLA, we have contributed code before, but my knowledgable people are on leave.