### PR TITLE
Add support for timeouts to ra force delete server operations

### DIFF
--- a/src/ra.erl
+++ b/src/ra.erl
@@ -50,6 +50,7 @@
          restart_server/3,
          stop_server/2,
          force_delete_server/2,
+         force_delete_server/3,
          trigger_election/1,
          trigger_election/2,
          %% membership changes
@@ -256,7 +257,21 @@ stop_server(System, ServerId)
 -spec force_delete_server(atom(), ServerId :: ra_server_id()) ->
     ok | {error, term()} | {badrpc, term()}.
 force_delete_server(System, ServerId) ->
-    ra_server_sup_sup:delete_server(System, ServerId).
+    force_delete_server(System, ServerId, infinity).
+
+%% @doc Deletes a ra server, bounding the operation by a timeout.
+%% The server is forcefully deleted. The timeout bounds the remote calls made
+%% to the server's node, so a member on a slow or unreachable node fails with
+%% `{badrpc, timeout}' instead of blocking indefinitely.
+%% @param ServerId the ra_server_id() of the server
+%% @param Timeout the timeout in milliseconds or `infinity'
+%% @returns `ok | {error, nodedown} | {badrpc, Reason}'
+%% @end
+-spec force_delete_server(atom(), ServerId :: ra_server_id(),
+                          Timeout :: timeout()) ->
+    ok | {error, term()} | {badrpc, term()}.
+force_delete_server(System, ServerId, Timeout) ->
+    ra_server_sup_sup:delete_server(System, ServerId, Timeout).
 
 %% @doc Starts or restarts a ra cluster.
 %%

--- a/src/ra_server_sup_sup.erl
+++ b/src/ra_server_sup_sup.erl
@@ -26,7 +26,6 @@
          restart_server/3,
          stop_server/2,
          stop_server/3,
-         delete_server/2,
          delete_server/3,
          remove_all/1,
          start_link/1,
@@ -163,11 +162,6 @@ prepare_server_stop_rpc(System, RaName) ->
             Parent =  ra_directory:where_is_parent(Names, RaName),
             {ok, Parent, SrvSup}
     end.
-
--spec delete_server(atom(), ServerId :: ra_server_id()) ->
-    ok | {error, term()} | {badrpc, term()}.
-delete_server(System, ServerId) ->
-    delete_server(System, ServerId, infinity).
 
 -spec delete_server(atom(), ServerId :: ra_server_id(), Timeout :: timeout()) ->
     ok | {error, term()} | {badrpc, term()}.

--- a/src/ra_server_sup_sup.erl
+++ b/src/ra_server_sup_sup.erl
@@ -25,7 +25,9 @@
 -export([start_server/2,
          restart_server/3,
          stop_server/2,
+         stop_server/3,
          delete_server/2,
+         delete_server/3,
          remove_all/1,
          start_link/1,
          recover_config/2,
@@ -130,11 +132,17 @@ restart_server_rpc(System, {RaName, _Node}, AddConfig)
 
 -spec stop_server(System :: atom(), RaNodeId :: ra_server_id()) ->
     ok | {error, term()}.
-stop_server(System, ServerId) when is_atom(System) ->
+stop_server(System, ServerId) ->
+    stop_server(System, ServerId, infinity).
+
+-spec stop_server(System :: atom(), RaNodeId :: ra_server_id(),
+                  Timeout :: timeout()) ->
+    ok | {error, term()}.
+stop_server(System, ServerId, Timeout) when is_atom(System) ->
     Node = ra_lib:ra_server_id_node(ServerId),
     RaName = ra_lib:ra_server_id_to_local_name(ServerId),
     Res = rpc:call(Node, ?MODULE,
-                   prepare_server_stop_rpc, [System, RaName]),
+                   prepare_server_stop_rpc, [System, RaName], Timeout),
     case Res of
         {error, _} = Err ->
             Err;
@@ -158,12 +166,17 @@ prepare_server_stop_rpc(System, RaName) ->
 
 -spec delete_server(atom(), ServerId :: ra_server_id()) ->
     ok | {error, term()} | {badrpc, term()}.
-delete_server(System, ServerId) when is_atom(System) ->
+delete_server(System, ServerId) ->
+    delete_server(System, ServerId, infinity).
+
+-spec delete_server(atom(), ServerId :: ra_server_id(), Timeout :: timeout()) ->
+    ok | {error, term()} | {badrpc, term()}.
+delete_server(System, ServerId, Timeout) when is_atom(System) ->
     Node = ra_lib:ra_server_id_node(ServerId),
     Name = ra_lib:ra_server_id_to_local_name(ServerId),
-    case stop_server(System, ServerId) of
+    case stop_server(System, ServerId, Timeout) of
         ok ->
-            rpc:call(Node, ?MODULE, delete_server_rpc, [System, Name]);
+            rpc:call(Node, ?MODULE, delete_server_rpc, [System, Name], Timeout);
         {error, _} = Err -> Err
     end.
 

--- a/test/ra_2_SUITE.erl
+++ b/test/ra_2_SUITE.erl
@@ -30,6 +30,8 @@ all_tests() ->
      server_config,
      start_stopped_server,
      server_is_force_deleted,
+     server_is_force_deleted_with_timeout,
+     force_delete_server_times_out,
      force_deleted_server_mem_tables_are_cleaned_up,
      leave_and_delete_server,
      cluster_is_deleted,
@@ -211,6 +213,61 @@ server_is_force_deleted(Config) ->
     end,
 
     ok = ra:force_delete_server(?SYS, ServerId),
+    ok.
+
+server_is_force_deleted_with_timeout(Config) ->
+    %% force_delete_server/3 with a finite timeout should behave exactly like
+    %% the /2 variant when the server responds within the timeout
+    ClusterName = ?config(cluster_name, Config),
+    PrivDir = ?config(priv_dir, Config),
+    ServerId = ?config(server_id, Config),
+    UId = ?config(uid, Config),
+    Conf = conf(ClusterName, UId, ServerId, PrivDir, []),
+    _ = ra:start_server(?SYS, Conf),
+    ok = ra:trigger_election(ServerId),
+    ok = enqueue(ServerId, msg1),
+    Pid = ra_directory:where_is(?SYS, UId),
+    {Name, _} = ServerId,
+    ?assertEqual(ServerId, ra_leaderboard:lookup_leader(Name)),
+
+    ok = ra:force_delete_server(?SYS, ServerId, 60000),
+
+    validate_ets_table_deletes([UId], [Pid], [ServerId]),
+    ?assertEqual(undefined, ra_leaderboard:lookup_leader(Name)),
+    ok.
+
+force_delete_server_times_out(Config) ->
+    %% when the remote call to the server's node does not return within the
+    %% timeout the operation should fail with a badrpc timeout instead of
+    %% blocking indefinitely
+    ClusterName = ?config(cluster_name, Config),
+    PrivDir = ?config(priv_dir, Config),
+    ServerId = ?config(server_id, Config),
+    UId = ?config(uid, Config),
+    Conf = conf(ClusterName, UId, ServerId, PrivDir, []),
+    _ = ra:start_server(?SYS, Conf),
+    ok = ra:trigger_election(ServerId),
+    ok = enqueue(ServerId, msg1),
+    %% make the stop preparation rpc block for longer than the timeout so the
+    %% bounded call returns rather than hanging
+    meck:new(ra_server_sup_sup, [passthrough]),
+    meck:expect(ra_server_sup_sup, prepare_server_stop_rpc,
+                fun(_System, _RaName) ->
+                        timer:sleep(30000),
+                        error(should_have_timed_out)
+                end),
+    try
+        ?assertEqual({error, {badrpc, timeout}},
+                     ra:force_delete_server(?SYS, ServerId, 100))
+    after
+        meck:unload(ra_server_sup_sup)
+    end,
+    %% the timeout must not have taken the server down: it is still registered
+    %% and running
+    ?assert(is_pid(ra_directory:where_is(?SYS, UId))),
+    %% and can be deleted normally once the blocking behaviour is removed
+    ok = ra:force_delete_server(?SYS, ServerId),
+    ?assertEqual(undefined, ra_directory:where_is(?SYS, UId)),
     ok.
 
 force_deleted_server_mem_tables_are_cleaned_up(Config) ->


### PR DESCRIPTION
## Proposed Changes

This is required in https://github.com/rabbitmq/rabbitmq-server/pull/17214 

Part of the fix for this issue: https://github.com/rabbitmq/rabbitmq-server/issues/17137 

This extends the following `ra` functions to take timeout parameters for bounded operations:

 - ra:force_delete_server/3
 - ra_server_sup_sup:stop_server/3
 - ra_server_sup_sup:delete_server/3

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
