### PR TITLE
Support PID alias in the `send_msg` effect

### DIFF
--- a/docs/internals/STATE_MACHINE_TUTORIAL.md
+++ b/docs/internals/STATE_MACHINE_TUTORIAL.md
@@ -185,8 +185,8 @@ returned by the state machine unless specific effect provide the `local` option.
 
 | Spec | Executed on |
 | -----| ----------- |
-| `{send_msg, pid(), Msg :: term()}` | leader |
-| `{send_msg, pid(), Msg :: term(), [local]}` | on member local to `pid()` else leader |
+| `{send_msg, locator(), Msg :: term()}` | leader |
+| `{send_msg, locator(), Msg :: term(), [local]}` | on member local to `locator()` else leader |
 | `{monitor \| demonitor, process \| node, pid() \| node()}` | leader |
 | `{mod_call, mfa()}` | leader |
 | `{timer, Name :: term(), Time :: non_neg_integer() \| infinity}` | leader |
@@ -202,16 +202,20 @@ returned by the state machine unless specific effect provide the `local` option.
 
 ### Send a message
 
-The `{send_msg, pid(), Msg :: term()}` effect asynchronously sends a message
-to the specified
-`pid`. Note that `ra` uses `erlang:send/3` with the `no_connect` and `no_suspend`
+The `{send_msg, locator(), Msg :: term()}` effect asynchronously sends a message
+to the specified target `locator()`. The target can be:
+* a PID (`pid()`)
+* a registered process (`atom()` or `{atom(), node()}`)
+* a process alias (`reference()`)
+
+Note that `ra` uses `erlang:send/3` with the `no_connect` and `no_suspend`
 options which are the least reliable message sending options. It does this so
 that a state machine `send_msg` effect will never block the main `ra` process.
 To ensure message reliability normal [Automatic Repeat Query (ARQ)](https://en.wikipedia.org/wiki/Automatic_repeat_request)
 like protocols between the state machine and the receiver should be implemented
 if needed.
 
-The `{send_msg, pid(), Msg :: term(), Options :: list()}` effect can be used to further
+The `{send_msg, locator(), Msg :: term(), Options :: list()}` effect can be used to further
 control how the effect is executed via options. The options are:
 
 * `ra_event`: the message will be wrapped in a `ra_event` structure like
@@ -219,9 +223,9 @@ control how the effect is executed via options. The options are:
     a `ra_event_formatter` server configuration.
 * `cast`: the message will be wrappen in a standard `{$gen_cast, Msg}` wrapper
     to conform to OTP `gen` conventions.
-* `local`: if the target `pid()` is local to any member of the Ra cluster the delivery
+* `local`: if the target `locator()` is local to any member of the Ra cluster the delivery
 of the message will be done from the local member even if this is a follower.
-This way a network hop can be avoided. If the target `pid()` is on a node
+This way a network hop can be avoided. If the target `locator()` is on a node
 without a Ra member it will be sent from the leader.
 
 ### Monitors

--- a/src/ra_machine.erl
+++ b/src/ra_machine.erl
@@ -121,7 +121,7 @@
 %% configured
 
 -type send_msg_opts() :: send_msg_opt() | [send_msg_opt()].
--type locator() :: pid() | atom() | {atom(), node()}.
+-type locator() :: pid() | atom() | {atom(), node()} | reference().
 
 -type release_cursor_condition() :: {written, ra_index()} | no_snapshot_sends.
 -type release_cursor_opts() :: #{condition => [release_cursor_condition()]}.
@@ -182,7 +182,7 @@
 %%
 %% <dl>
 %% <dt><b>send_msg</b></dt>
-%% <dd> send a message to a pid or registered process
+%% <dd> send a message to a pid, a registered process or a process alias
 %% NB: this is sent using `noconnect' and `nosuspend' options in order to avoid
 %% blocking the ra process on connectivity failures. It can optionally be wrapped up as
 %% a `ra_event' and/or as a gen cast message (``{'$cast', Msg}'')

--- a/src/ra_server_proc.erl
+++ b/src/ra_server_proc.erl
@@ -2393,7 +2393,9 @@ get_node(P) when is_pid(P) ->
 get_node({_, Node}) ->
     Node;
 get_node(Proc) when is_atom(Proc) ->
-    node().
+    node();
+get_node(Alias) when is_reference(Alias) ->
+    node(Alias).
 
 can_execute_locally(RaftState, TargetNode,
                     #state{server_state = ServerState} = State) ->

--- a/test/ra_machine_int_SUITE.erl
+++ b/test/ra_machine_int_SUITE.erl
@@ -29,6 +29,7 @@ all() ->
 all_tests() ->
     [
      send_msg_without_options,
+     send_msg_with_alias,
      send_msg_with_ra_event_option,
      send_msg_with_cast_option,
      send_msg_with_ra_event_and_cast_options,
@@ -113,6 +114,25 @@ send_msg_without_options(Config) ->
     ServerId = ?config(server_id, Config),
     ok = start_cluster(ClusterName, {module, Mod, #{}}, [ServerId]),
     {ok, ok, _} = ra:process_command(ServerId, {echo, self(), ?FUNCTION_NAME}),
+    receive ?FUNCTION_NAME -> ok
+    after 250 ->
+              flush(),
+              exit(receive_msg_timeout)
+    end,
+    ok.
+
+send_msg_with_alias(Config) ->
+    Mod = ?config(modname, Config),
+    meck:new(Mod, [non_strict]),
+    meck:expect(Mod, init, fun (_) -> the_state end),
+    meck:expect(Mod, apply, fun (_, {echo, Alias, Msg}, State) ->
+                                    {State, ok, {send_msg, Alias, Msg}}
+                            end),
+    ClusterName = ?config(cluster_name, Config),
+    ServerId = ?config(server_id, Config),
+    ok = start_cluster(ClusterName, {module, Mod, #{}}, [ServerId]),
+    Alias = erlang:alias([reply]),
+    {ok, ok, _} = ra:process_command(ServerId, {echo, Alias, ?FUNCTION_NAME}),
     receive ?FUNCTION_NAME -> ok
     after 250 ->
               flush(),


### PR DESCRIPTION
This is the same as a PID except that the process who created its alias can decide if it is still interested in a reply or not. If the alias is deleted, the message won't reach the process mailbox.

However, it is not possible to query the PID or its node from an alias. In the context of Ra, it is impossible to implement the `local` option of the `send_msg` effect.

Because of this, the message is always sent from the leader.