### PR TITLE
rebar.config: Remove `elvis` as a test dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,6 @@
 {profiles,
  [{test, [{deps, [proper,
                   meck,
-                  elvis,
                   {inet_tcp_proxy_dist,
                    {git, "https://github.com/rabbitmq/inet_tcp_proxy",
                     {branch, "master"}}}


### PR DESCRIPTION
Tests do not depend on Elvis currently. It recently even broke CI on Erlang/OTP 26 because the latest Elvis 6.0.0 release requires Erlang/OTP 27. We can safely remore it from test dependencies.

Elvis could be integrated again using the `rebar3_lint` project plugin: https://hex.pm/packages/rebar3_lint

I didn't add it in this patch because Elvis does not like the existing `elvis.config` configuration. Perhaps something change with a major release.