### PR TITLE
Ra log performance improvements

### DIFF
--- a/src/ra.hrl
+++ b/src/ra.hrl
@@ -243,17 +243,25 @@
 -define(ERROR(Fmt, Args), ?DISPATCH_LOG(error, Fmt, Args)).
 
 -define(DISPATCH_LOG(Level, Fmt, Args),
-        %% same as OTP logger does when using the macro
-        try
-            (ra_env:logger_mod()):log(Level, Fmt, Args,
-                                      #{mfa => {?MODULE,
-                                                ?FUNCTION_NAME,
-                                                ?FUNCTION_ARITY},
-                                        file => ?FILE,
-                                        line => ?LINE,
-                                        domain => [ra]})
-        catch
-            _:_ -> ok
+        %% same as OTP logger does when using the macro: gate on the level
+        %% first so that Fmt/Args are not evaluated (they may contain
+        %% arbitrarily expensive calls) when the event would be discarded
+        %% anyway
+        case logger:allow(Level, ?MODULE) of
+            true ->
+                try
+                    (ra_env:logger_mod()):log(Level, Fmt, Args,
+                                              #{mfa => {?MODULE,
+                                                        ?FUNCTION_NAME,
+                                                        ?FUNCTION_ARITY},
+                                                file => ?FILE,
+                                                line => ?LINE,
+                                                domain => [ra]})
+                catch
+                    _:_ -> ok
+                end;
+            false ->
+                ok
         end,
         ok).
 

--- a/src/ra_log.erl
+++ b/src/ra_log.erl
@@ -1747,7 +1747,7 @@ my_segrefs(UId, SegWriter) ->
                         %% if a server recovered when a segment had been opened
                         %% but never had any entries written the segref would be
                         %% undefined
-                        case ra_log_segment:info(File) of
+                        case ra_log_segment:segref_info(File) of
                             #{ref := SegRef,
                               file_type := regular}
                               when is_tuple(SegRef) ->

--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -725,7 +725,6 @@ segref(Filename) ->
                    links => non_neg_integer(),
                    num_entries => non_neg_integer(),
                    ref => option(ra_log:segment_ref()),
-                   indexes => ra_seq:state(),
                    live_size => non_neg_integer()
                   }.
 
@@ -748,13 +747,9 @@ info(Filename, Live0)
         IndexRecordSize = index_record_size(Version),
         IndexSize = MaxCount * IndexRecordSize,
         DataStart = ?HEADER_SIZE + IndexSize,
-        %% Pass Live0 directly - ra_seq:in/2 is used for membership checks
-        %% This avoids expanding the sequence to a set which could be expensive
-        %% for large sequences. ra_seq:in/2 is efficient for compact sequences
-        %% with ranges.
         case file:pread(Fd, ?HEADER_SIZE, IndexSize) of
             {ok, Data} ->
-                {NumEntries, DataOffset, Range, IndexesSeq, LiveSize} =
+                {NumEntries, DataOffset, Range, LiveSize} =
                     parse_index_info(Version, Data, DataStart, Live0),
                 Ref = case Range of
                           undefined -> undefined;
@@ -768,8 +763,7 @@ info(Filename, Live0)
                   max_count => MaxCount,
                   num_entries => NumEntries,
                   ref => Ref,
-                  live_size => LiveSize,
-                  indexes => IndexesSeq};
+                  live_size => LiveSize};
             eof ->
                 %% Empty segment
                 #{size => DataStart,
@@ -780,8 +774,7 @@ info(Filename, Live0)
                   max_count => MaxCount,
                   num_entries => 0,
                   ref => undefined,
-                  live_size => 0,
-                  indexes => []}
+                  live_size => 0}
         end
     after
         _ = file:close(Fd)
@@ -1074,46 +1067,87 @@ parse_index_data_loop(Fmt, Bin, ByteOffset, Num, LastIdx, DataOffset, Range, Ind
                                   Index1#{Idx => {Term, Offset, Length, Crc}})
     end.
 
-%% Optimized index parsing for info/2 that computes stats in a single pass
-%% without building a full index map. Returns:
-%% {NumEntries, DataOffset, Range, IndexesSeq, LiveSize}
+%% Index parsing for info/2 that computes stats in a single pass without
+%% building a full index map. Returns {NumEntries, DataOffset, Range, LiveSize}.
+%%
+%% Index records are appended in index order and LiveSeq is ordered
+%% high -> low, so both sides are sorted and can be walked together with a
+%% cursor. Doing a ra_seq:in/2 membership test per record instead would be
+%% O(records * runs), which for a sparse live sequence - exactly the case
+%% where major compaction is worth running - is pathological.
 parse_index_info(Version, Data, DataOffset, LiveSeq) ->
     Fmt = idx_fmt(Version),
-    parse_index_info_loop(Fmt, Data, 0, 0, 0, DataOffset, undefined, [], 0, LiveSeq).
+    %% undefined means "no live sequence supplied", i.e. count everything
+    Live = case LiveSeq of
+               undefined ->
+                   undefined;
+               _ ->
+                   lists:reverse(LiveSeq)
+           end,
+    parse_index_info_loop(Fmt, Data, 0, 0, 0, DataOffset, undefined, 0,
+                          Live, Live).
 
 parse_index_info_loop(Fmt, Bin, ByteOffset, Num, LastIdx, DataOffset, Range,
-                      IdxAcc, LiveSize, LiveSeq) ->
+                      LiveSize, Cur0, Live) ->
     case decode_index_record(Fmt, Bin, ByteOffset) of
         eof ->
             %% End of data or partially written index
-            {Num, DataOffset, Range, ra_seq:from_list(lists:reverse(IdxAcc)),
-             LiveSize};
+            {Num, DataOffset, Range, LiveSize};
         {ok, {Idx, _Term, Offset, Length, _Crc}} ->
-            %% Handle index going backwards (trim entries)
-            IdxAcc1 = case Idx < LastIdx of
-                          true ->
-                              lists:dropwhile(fun(I) -> I > Idx end, IdxAcc);
-                          false ->
-                              IdxAcc
-                      end,
-            %% Compute live size: if LiveSeq is undefined, all entries are live
-            LiveSize1 = case LiveSeq of
-                            undefined ->
-                                LiveSize + Length;
-                            _ ->
-                                case ra_seq:in(Idx, LiveSeq) of
-                                    true ->
-                                        LiveSize + Length;
-                                    false ->
-                                        LiveSize
-                                end
-                        end,
+            {LiveSize1, Cur} = live_size_add(Idx, Length, LastIdx, LiveSize,
+                                             Cur0, Live),
             RecSize = Fmt#idx_fmt.record_size,
             parse_index_info_loop(Fmt, Bin, ByteOffset + RecSize, Num + 1, Idx,
                                   Offset + Length,
                                   update_range(Range, Idx),
-                                  [Idx | IdxAcc1], LiveSize1, LiveSeq)
+                                  LiveSize1, Cur, Live)
     end.
+
+live_size_add(_Idx, Length, _LastIdx, LiveSize, Cur, undefined) ->
+    %% no live sequence, every entry counts
+    {LiveSize + Length, Cur};
+live_size_add(Idx, Length, LastIdx, LiveSize, Cur0, Live) ->
+    %% an index going backwards means the segment contains overwrites, so the
+    %% cursor has to restart. Overwrites are one off truncation points so this
+    %% stays effectively O(records + runs).
+    %% NB: as before, a live index appearing twice in an overwritten segment
+    %% contributes its length twice.
+    Cur1 = case Idx < LastIdx of
+               true -> Live;
+               false -> Cur0
+           end,
+    Cur = live_advance(Idx, Cur1),
+    case live_holds(Idx, Cur) of
+        true ->
+            {LiveSize + Length, Cur};
+        false ->
+            {LiveSize, Cur}
+    end.
+
+%% drop live runs that end below Idx
+live_advance(Idx, [E | Rem] = Cur) ->
+    case live_end(E) < Idx of
+        true ->
+            live_advance(Idx, Rem);
+        false ->
+            Cur
+    end;
+live_advance(_Idx, []) ->
+    [].
+
+%% after live_advance/2 the leading run ends at or above Idx, so Idx is live
+%% exactly when that run also starts at or below it
+live_holds(_Idx, []) ->
+    false;
+live_holds(Idx, [{Start, _} | _]) ->
+    Start =< Idx;
+live_holds(Idx, [I | _]) when is_integer(I) ->
+    I =< Idx.
+
+live_end({_, End}) ->
+    End;
+live_end(I) when is_integer(I) ->
+    I.
 
 write_header(MaxCount, Fd) ->
     Header = <<?MAGIC, ?VERSION:16/unsigned, MaxCount:16/unsigned>>,

--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -99,6 +99,9 @@
                                     compute_checksums => boolean(),
                                     mode => append | read,
                                     index_mode => index_mode(),
+                                    %% in append mode, fail with enoent rather
+                                    %% than creating the file if it is missing
+                                    must_exist => boolean(),
                                     access_pattern => sequential | random,
                                     file_advise => posix_file_advise()}.
 -opaque state() :: #state{}.
@@ -145,10 +148,20 @@ open(Filename, Options) ->
                 read ->
                     [read, raw, binary]
             end,
-    case file:open(Filename, Modes) of
-        {ok, Fd} ->
-            process_file(FileExists, Mode, Filename, Fd, Options);
-        Err -> Err
+    case not FileExists andalso maps:get(must_exist, Options, false) of
+        true ->
+            %% the caller reached us via a cached filename and needs to know
+            %% the file has gone, rather than have an empty one created in
+            %% its place. NB: this reuses the read_file_info above so it
+            %% costs no extra syscall.
+            {error, enoent};
+        false ->
+            case file:open(Filename, Modes) of
+                {ok, Fd} ->
+                    process_file(FileExists, Mode, Filename, Fd, Options);
+                Err ->
+                    Err
+            end
     end.
 
 process_file(true, Mode, Filename, Fd, Options) ->

--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -678,7 +678,11 @@ fold0(#state{cfg = Cfg, cache = Cache0} = State, Idx, FinalIdx, Fun, AccFun,
       Acc0, MissingKeyStrat) ->
     case lookup_index(State, Idx) of
         {ok, {Term, Offset, Length, Crc} = IdxRec} ->
-            case pread(Cfg, Cache0, Offset, Length) of
+            %% a fold walks Idx .. FinalIdx contiguously by construction,
+            %% so it should always use the read-ahead cache regardless of
+            %% the segment's declared access pattern
+            case pread(Cfg#cfg{access_pattern = sequential}, Cache0, Offset,
+                       Length) of
                 {ok, Data, Cache} ->
                     case validate_checksum(Crc, Data) of
                         true ->

--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -24,6 +24,7 @@
          data_size/1,
          filename/1,
          segref/1,
+         segref_info/1,
          info/1,
          info/2,
          is_same_as/2,
@@ -796,6 +797,63 @@ info(Filename, Live0)
     after
         _ = file:close(Fd)
     end.
+
+%% @doc Like info/1 but for a caller that only needs the segref and file
+%% type (e.g. ra_log:my_segrefs/2): skips num_entries, live_size and the
+%% ctime/links stat fields entirely.
+-spec segref_info(file:filename_all()) ->
+    #{ref => option(ra_log:segment_ref()),
+      file_type => regular | symlink}.
+segref_info(Filename)
+  when not is_tuple(Filename) ->
+    {ok, #file_info{type = Type}} =
+        prim_file:read_link_info(Filename, [raw, {time, posix}]),
+    {ok, Fd} = file:open(Filename, [read, raw, binary]),
+    try
+        {ok, Version, MaxCount} = read_header(Fd),
+        IndexSize = MaxCount * index_record_size(Version),
+        Ref = case file:pread(Fd, ?HEADER_SIZE, IndexSize) of
+                  {ok, Data} ->
+                      case scan_range(Version, Data) of
+                          undefined ->
+                              undefined;
+                          Range ->
+                              {ra_lib:to_binary(filename:basename(Filename)),
+                               Range}
+                      end;
+                  eof ->
+                      undefined
+              end,
+        #{ref => Ref, file_type => Type}
+    after
+        _ = file:close(Fd)
+    end.
+
+%% Index parsing for segref_info/1: only the index range is needed. Written
+%% as a directly-recursing binary match (rather than reusing
+%% decode_index_record/3's by-offset lookup) so the emulator can keep a
+%% single match context across the whole scan instead of re-deriving a
+%% sub-binary for every record.
+scan_range(2, Bin) ->
+    scan_range_v2(Bin, undefined);
+scan_range(1, Bin) ->
+    scan_range_v1(Bin, undefined).
+
+scan_range_v2(<<0:64, 0:64, 0:64, 0:32, 0:32/integer, _/binary>>, Range) ->
+    Range;
+scan_range_v2(<<Idx:64/unsigned, _Term:64/unsigned, _DataOffset:64/unsigned,
+                _Length:32/unsigned, _Crc:32/integer, Rest/binary>>, Range) ->
+    scan_range_v2(Rest, update_range(Range, Idx));
+scan_range_v2(_, Range) ->
+    Range.
+
+scan_range_v1(<<0:64, 0:64, 0:32, 0:32, 0:32/integer, _/binary>>, Range) ->
+    Range;
+scan_range_v1(<<Idx:64/unsigned, _Term:64/unsigned, _DataOffset:32/unsigned,
+                _Length:32/unsigned, _Crc:32/integer, Rest/binary>>, Range) ->
+    scan_range_v1(Rest, update_range(Range, Idx));
+scan_range_v1(_, Range) ->
+    Range.
 
 -spec is_same_as(state(), file:filename_all()) -> boolean().
 is_same_as(#state{cfg = #cfg{filename = Fn0}}, Fn) ->

--- a/src/ra_log_segment.erl
+++ b/src/ra_log_segment.erl
@@ -680,10 +680,9 @@ fold0(#state{cfg = Cfg, cache = Cache0} = State, Idx, FinalIdx, Fun, AccFun,
     case lookup_index(State, Idx) of
         {ok, {Term, Offset, Length, Crc} = IdxRec} ->
             %% a fold walks Idx .. FinalIdx contiguously by construction,
-            %% so it should always use the read-ahead cache regardless of
+            %% so it always uses pread/4's read-ahead cache regardless of
             %% the segment's declared access pattern
-            case pread(Cfg#cfg{access_pattern = sequential}, Cache0, Offset,
-                       Length) of
+            case pread(Cfg, Cache0, Offset, Length) of
                 {ok, Data, Cache} ->
                     case validate_checksum(Crc, Data) of
                         true ->
@@ -1246,23 +1245,15 @@ read_header(Fd) ->
             Err
     end.
 
-pread(#cfg{access_pattern = random,
-           fd = Fd}, Cache, Pos, Length) ->
-    %% no cache
-    {ok, Data} = file:pread(Fd, Pos, Length),
-    case byte_size(Data)  of
-        Length ->
-            {ok, Data, Cache};
-        _ ->
-            {error, partial_data}
-    end;
 pread(#cfg{}, {CPos, CLen, Bin} = Cache, Pos, Length)
   when Pos >= CPos andalso
        Pos + Length =< (CPos + CLen) ->
     %% read fits inside cache
     {ok, binary:part(Bin, Pos - CPos, Length), Cache};
-pread(#cfg{access_pattern = sequential,
-           fd = Fd} = Cfg, undefined, Pos, Length) ->
+pread(#cfg{fd = Fd} = Cfg, undefined, Pos, Length) ->
+    %% pread/4's only caller is fold0/7, which always wants read-ahead
+    %% caching regardless of the segment's declared access pattern (a fold
+    %% is sequential by construction), so this always builds a cache
     CacheLen = max(Length, ?READ_AHEAD_B),
     {ok, CacheData} = file:pread(Fd, Pos, CacheLen),
     case byte_size(CacheData) >= Length  of

--- a/src/ra_log_segment_writer.erl
+++ b/src/ra_log_segment_writer.erl
@@ -27,6 +27,16 @@
 -record(state, {data_dir :: file:filename(),
                 system :: atom(),
                 counter :: counters:counters_ref(),
+                %% Caches the current (highest numbered) segment file per uid
+                %% so that the common flush does not have to list the server
+                %% directory, which is O(number of segment files).
+                %%
+                %% This has to be an ETS table rather than a field: the flush
+                %% runs in processes spawned by ra_lib:partition_parallel/3
+                %% over a closure that captures #state{}, so anything held
+                %% here is deep copied into every worker. It also has to be
+                %% public, as those workers both read and update it.
+                seg_cache :: ets:tid(),
                 segment_conf = #{} :: ra_log_segment:ra_log_segment_options()}).
 
 -include("ra.hrl").
@@ -120,9 +130,12 @@ init([#{data_dir := DataDir,
                              module => ?MODULE}),
     SegmentConf = maps:get(segment_conf, Conf, #{}),
     maybe_upgrade_segment_file_names(System, DataDir),
+    Cache = ets:new(ra_log_segment_writer_cache,
+                    [set, public, {read_concurrency, true}]),
     {ok, #state{system = System,
                 data_dir = DataDir,
                 counter = CRef,
+                seg_cache = Cache,
                 segment_conf = SegmentConf}}.
 
 handle_call(await, _From, State) ->
@@ -138,7 +151,8 @@ segments_for(UId, #state{data_dir = DataDir}) ->
     segment_files(Dir).
 
 handle_cast({mem_tables, UIdTidRanges, WalFile},
-            #state{system = System} = State) ->
+            #state{system = System,
+                   seg_cache = Cache} = State) ->
     T1 = erlang:monotonic_time(),
     ok = counters:add(State#state.counter, ?C_MEM_TABLES, map_size(UIdTidRanges)),
     #{names := Names} = ra_system:fetch(System),
@@ -157,6 +171,7 @@ handle_cast({mem_tables, UIdTidRanges, WalFile},
                                    ?DEBUG("segment_writer in '~ts': deleting memtable "
                                           "for ~ts as not a registered uid",
                                           [System, UId]),
+                                   _ = ets:delete(Cache, UId),
                                    ok = ra_log_ets:delete_mem_tables(Names, UId),
                                    Acc
                            end
@@ -189,9 +204,12 @@ handle_cast({mem_tables, UIdTidRanges, WalFile},
     {noreply, State};
 handle_cast({truncate_segments, Who, {Name, _Range} = SegRef},
             #state{segment_conf = SegConf,
+                   seg_cache = Cache,
                    system = System} = State0) ->
     %% remove all segments below the provided SegRef
     %% Also delete the segref if the file hasn't changed
+    %% this can replace the current segment so the cache has to be dropped
+    _ = ets:delete(Cache, Who),
     T1 = erlang:monotonic_time(),
     Files = segments_for(Who, State0),
     {_Keep, Discard} = lists:splitwith(
@@ -331,22 +349,26 @@ flush_mem_table_ranges({ServerUId, TidSeqs0},
 flush_mem_table_range(ServerUId, {Tid, Seq},
                       #state{data_dir = DataDir,
                              system = System,
+                             seg_cache = Cache,
                              segment_conf = SegConf} = State) ->
     Dir = filename:join(DataDir, binary_to_list(ServerUId)),
-    case open_file(Dir, SegConf) of
+    case open_file(Dir, ServerUId, SegConf, Cache) of
         enoent ->
             ?DEBUG("segment_writer: skipping segment as directory ~ts does "
                    "not exist", [Dir]),
             %% Directory gone (server deleted), clean up the memtable
+            _ = ets:delete(Cache, ServerUId),
             #{names := Names} = ra_system:fetch(System),
             ok = ra_log_ets:delete_mem_tables(Names, ServerUId),
             [];
-        Segment0 ->
-            Segment1 = maybe_open_new_segment(ServerUId, Segment0, SegConf),
+        {Segment0, Created0} ->
+            {Segment1, Created1} = maybe_open_new_segment(ServerUId, Segment0,
+                                                          SegConf),
             case append_to_segment(ServerUId, Tid, Seq, Segment1, State) of
                 undefined ->
                     %% Directory disappeared during write - close segment handle
                     _ = ra_log_segment:close(Segment1),
+                    _ = ets:delete(Cache, ServerUId),
                     ?WARN("segment_writer: skipping segments for ~w as "
                           "directory ~ts disappeared whilst writing",
                           [ServerUId, Dir]),
@@ -366,8 +388,20 @@ flush_mem_table_range(ServerUId, {Tid, Seq},
                                       [SRef | ClosedSegRefs]
                               end,
 
+                    %% remember where to resume appending next time
+                    true = ets:insert(Cache,
+                                      {ServerUId,
+                                       ra_log_segment:filename(Segment)}),
                     ok = ra_log_segment:close(Segment),
-                    _ = ra_lib:sync_dir(Dir),
+                    %% the directory only needs syncing if a file appeared in
+                    %% it, an append to an existing segment does not change
+                    %% the directory entry
+                    case Created0 orelse Created1 orelse Closed0 =/= [] of
+                        true ->
+                            _ = ra_lib:sync_dir(Dir);
+                        false ->
+                            ok
+                    end,
                     SegRefs
             end
     end.
@@ -512,6 +546,9 @@ segment_files(Dir) ->
             []
     end.
 
+-spec maybe_open_new_segment(ra_uid(), ra_log_segment:state(),
+                             ra_log_segment:ra_log_segment_options()) ->
+    {ra_log_segment:state(), Created :: boolean()}.
 maybe_open_new_segment(ServerUId, Seg, SegConf) ->
     case ra_log_segment:range(Seg) of
         {_First, Last} ->
@@ -520,15 +557,15 @@ maybe_open_new_segment(ServerUId, Seg, SegConf) ->
                 true ->
                     case open_successor_segment(Seg, SegConf) of
                         enoent ->
-                            Seg;
+                            {Seg, false};
                         NewSeg ->
-                            NewSeg
+                            {NewSeg, true}
                     end;
                 false ->
-                    Seg
+                    {Seg, false}
             end;
         _ ->
-            Seg
+            {Seg, false}
     end.
 
 open_successor_segment(CurSeg, SegConf) ->
@@ -544,19 +581,48 @@ open_successor_segment(CurSeg, SegConf) ->
             Seg
     end.
 
+-spec open_file(file:filename_all(), ra_uid(),
+                ra_log_segment:ra_log_segment_options(), ets:tid()) ->
+    {ra_log_segment:state(), Created :: boolean()} | enoent.
+open_file(Dir, ServerUId, SegConf, Cache) ->
+    case ets:lookup(Cache, ServerUId) of
+        [{_, File}] ->
+            %% Trust the cached filename but require it to still exist. If it
+            %% has gone we must fall back to a scan: creating a fresh file
+            %% under a name that already had entries would leave two segments
+            %% claiming overlapping ranges.
+            case ra_log_segment:open(File, SegConf#{mode => append,
+                                                    must_exist => true}) of
+                {ok, Segment} ->
+                    {Segment, false};
+                {error, enoent} ->
+                    open_file(Dir, SegConf);
+                Err ->
+                    open_file_err(Dir, File, SegConf, Err)
+            end;
+        [] ->
+            open_file(Dir, SegConf)
+    end.
+
 open_file(Dir, SegConf) ->
-    File = case find_segment_files(Dir) of
-               [] ->
-                   F = ra_lib:zpad_filename("", "segment", 1),
-                   filename:join(Dir, F);
-               [F | _] ->
-                   F
-           end,
+    {File, Created} = case find_segment_files(Dir) of
+                          [] ->
+                              F = ra_lib:zpad_filename("", "segment", 1),
+                              {filename:join(Dir, F), true};
+                          [F | _] ->
+                              {F, false}
+                      end,
     %% There is a chance we'll get here without the target directory
     %% existing which could happen after server deletion
     case ra_log_segment:open(File, SegConf#{mode => append}) of
         {ok, Segment} ->
-            Segment;
+            {Segment, Created};
+        Err ->
+            open_file_err(Dir, File, SegConf, Err)
+    end.
+
+open_file_err(Dir, File, SegConf, Err) ->
+    case Err of
         {error, missing_segment_header} ->
             %% A file was created but the segment header had not been
             %% synced. In this case it is typically safe to just delete
@@ -569,7 +635,7 @@ open_file(Dir, SegConf) ->
             ?DEBUG("segment_writer: failed to open segment file ~ts "
                   "error: enoent", [File]),
             enoent;
-        Err ->
+        _ ->
             %% Any other error should be considered a hard error or else
             %% we'd risk data loss
             ?WARN("segment_writer: failed to open segment file ~ts "

--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -679,12 +679,13 @@ roll_over(#state{wal = Wal0, file_num = Num0,
     %% if this is the first wal since restart randomise the first
     %% max wal size to reduce the likelihood that each erlang node will
     %% flush mem tables at the same time
-    %% persist writers map so that sequence tracking survives crashes
-    %% even after all WAL files have been deleted by the segment writer
-    ok = persist_writers(Dir, Writers),
     NextMaxBytes =
         case Wal0 of
             undefined ->
+                %% persist writers map so that sequence tracking survives
+                %% crashes even after all WAL files have been deleted by
+                %% the segment writer
+                ok = persist_writers(Dir, Writers),
                 Half = MaxBytes div 2,
                 Half + rand:uniform(Half);
             #wal{ranges = Ranges,
@@ -701,6 +702,10 @@ roll_over(#state{wal = Wal0, file_num = Num0,
                 ok = ra_log_segment_writer:accept_mem_tables(SegWriter,
                                                              MemTables,
                                                              Filename),
+                %% persist writers map after handing the mem tables to the
+                %% segment writer so it can start flushing sooner, rather
+                %% than waiting behind this write+rename
+                ok = persist_writers(Dir, Writers),
                 MaxBytes
         end,
 
@@ -724,7 +729,10 @@ persist_writers(Dir, Writers) ->
     File = writers_snapshot_file(Dir),
     Tmp = File ++ ".tmp",
     Bin = term_to_binary(Writers),
-    ok = ra_lib:write_file(Tmp, Bin),
+    %% this is a recovery optimisation only: recover_writers/1 falls back to
+    %% #{} if the file is missing, truncated or undecodable, so the fsync
+    %% that Sync = true would cost here isn't needed
+    ok = ra_lib:write_file(Tmp, Bin, false),
     ok = prim_file:rename(Tmp, File).
 
 recover_writers(Dir) ->

--- a/src/ra_log_wal.erl
+++ b/src/ra_log_wal.erl
@@ -73,7 +73,13 @@
 
 -record(batch, {num_writes = 0 :: non_neg_integer(),
                 waiting = #{} :: #{pid() => #batch_writer{}},
-                pending = [] :: iolist()
+                pending = [] :: iolist(),
+                %% bytes written in this batch, so that ?C_BYTES_WRITTEN can
+                %% be updated once per batch rather than per entry
+                bytes = 0 :: non_neg_integer(),
+                %% the smallest live index per writer, resolved once per
+                %% batch rather than looked up per entry
+                smallest = #{} :: #{ra_uid() => ra:index()}
                }).
 
 -type writer_name_cache() :: {NextIntId :: non_neg_integer(),
@@ -535,10 +541,15 @@ write_data({UId, Pid} = Id, MtTid, Idx, Term, Data0, Trunc, SmallestIndex,
             Record = [HeaderData,
                       <<Checksum:32/integer, EntryDataLen:32/unsigned>> |
                       Entry],
-            Batch = incr_batch(Batch0, UId, Pid, MtTid,
-                               Idx, Term, Record, SmallestIndex),
+            Batch1 = incr_batch(Batch0, UId, Pid, MtTid,
+                                Idx, Term, Record, SmallestIndex),
+            %% ?C_BYTES_WRITTEN is cumulative so it is accumulated here and
+            %% added once per batch in complete_batch/1. ?C_CURRENT_FILE_SIZE
+            %% is deliberately still updated per entry: fill_ratio/1 reads it
+            %% and callers use that for back pressure, so it should not lag a
+            %% batch behind.
+            Batch = Batch1#batch{bytes = Batch1#batch.bytes + DataSize},
             NewFileSize = FileSize + DataSize,
-            counters:add(Counter, ?C_BYTES_WRITTEN, DataSize),
             counters:put(Counter, ?C_CURRENT_FILE_SIZE, NewFileSize),
             State0#state{batch = Batch,
                          wal = Wal#wal{writer_name_cache = Cache,
@@ -550,8 +561,24 @@ write_data({UId, Pid} = Id, MtTid, Idx, Term, Data0, Trunc, SmallestIndex,
 
 handle_msg({append, {UId, Pid} = Id, MtTid, ExpectedPrevIdx, Idx, Term, Entry},
            #state{conf = Conf,
-                  writers = Writers} = State0) ->
-    SmallestIdx = smallest_live_index(Conf, UId),
+                  batch = Batch0,
+                  writers = Writers} = State1) ->
+    %% The smallest live index is resolved once per writer per batch rather
+    %% than per entry. A snapshot completing mid batch is therefore noticed
+    %% one batch later, which only means an entry that could have been
+    %% dropped gets written. Recovery and the segment writer both re-read
+    %% the snapshot state, so they still skip it.
+    {SmallestIdx, State0} =
+        case Batch0 of
+            #batch{smallest = #{UId := S}} ->
+                {S, State1};
+            #batch{smallest = Sm} ->
+                S = smallest_live_index(Conf, UId),
+                {S, State1#state{batch =
+                                     Batch0#batch{smallest = Sm#{UId => S}}}};
+            _ ->
+                {smallest_live_index(Conf, UId), State1}
+        end,
     %% detect if truncating flag should be set
     Trunc = Idx == SmallestIdx,
 
@@ -785,13 +812,16 @@ sync(Fd, Meth) ->
 complete_batch(#state{batch = undefined} = State) ->
     State;
 complete_batch(#state{batch = #batch{waiting = Waiting,
+                                     bytes = Bytes,
                                      num_writes = NumWrites},
                       wal = Wal,
                       conf = Cfg} = State0) ->
     % TS = erlang:system_time(microsecond),
     State = flush_pending(State0),
     % SyncTS = erlang:system_time(microsecond),
-    counters:add(Cfg#conf.counter, ?C_WRITES, NumWrites),
+    Counter = Cfg#conf.counter,
+    counters:add(Counter, ?C_WRITES, NumWrites),
+    counters:add(Counter, ?C_BYTES_WRITTEN, Bytes),
 
     %% process writers
     Ranges = maps:fold(fun complete_batch_writer/3, Wal#wal.ranges, Waiting),

--- a/src/ra_seq.erl
+++ b/src/ra_seq.erl
@@ -93,9 +93,10 @@ limit(_CeilIdxIncl, Seq) ->
     Seq.
 
 %% @doc adds two sequences together where To is
-%% the "lower" sequence
-%% TODO: optimise to avoid the fold which could be expensive
-%% for very large sequences containing large ranges
+%% the "lower" sequence.
+%% Runs in O(length(Add) + length(To)) where length is the number of
+%% elements (indexes or ranges) rather than the number of indexes, i.e.
+%% ranges are merged rather than expanded.
 -spec add(Add :: state(), To :: state()) -> state().
 add([], To) ->
     To;
@@ -103,7 +104,7 @@ add(Add, []) ->
     Add;
 add(Add, To) ->
     Fst = first0(Add),
-    fold(fun append/2, limit(Fst - 1, To), Add).
+    merge0(lists:reverse(Add), limit(Fst - 1, To)).
 
 -spec fold(fun ((ra:index(), Acc) -> Acc), Acc, state()) -> Acc.
 fold(Fun, Acc0, Seq)
@@ -139,12 +140,28 @@ last([]) ->
 last(Seq) ->
     last0(Seq).
 
+%% @doc Removes Prefix from the front of Seq.
+%% Prefix may contain indexes that are not in Seq (they have already been
+%% removed) but every index of Seq at or below `last(Prefix)' must be
+%% covered by Prefix, else `{error, not_prefix}' is returned.
+%% Runs in O(number of elements) rather than O(number of indexes).
 -spec remove_prefix(state(), state()) ->
     {ok, state()} | {error, not_prefix}.
+remove_prefix([], Seq) ->
+    {ok, Seq};
+remove_prefix(_Prefix, []) ->
+    {ok, []};
 remove_prefix(Prefix, Seq) ->
-    P = iterator(Prefix),
-    S = iterator(Seq),
-    drop_prefix(next(P), next(S)).
+    PrefLast = last0(Prefix),
+    %% only the part of Seq at or below the last prefix index needs to be
+    %% covered by the prefix, the rest is the remainder
+    case covers(lists:reverse(Prefix),
+                lists:reverse(limit(PrefLast, Seq))) of
+        true ->
+            {ok, floor(PrefLast + 1, Seq)};
+        false ->
+            {error, not_prefix}
+    end.
 
 -spec iterator(state()) -> iter().
 iterator(Seq) when is_list(Seq) ->
@@ -275,20 +292,80 @@ has_overlap0(Start, End, [{RStart, REnd} | Rem]) ->
            true
     end.
 
-drop_prefix({IDX, PI}, {IDX, SI}) ->
-    drop_prefix(next(PI), next(SI));
-drop_prefix(_, end_of_seq) ->
-    %% TODO: is this always right as it includes the case where there is
-    %% more prefex left to drop but nothing in the target?
-    {ok, []};
-drop_prefix(end_of_seq, {Idx, #i{seq = RevSeq}}) ->
-    {ok, add(lists:reverse(RevSeq), [Idx])};
-drop_prefix({PrefIdx, PI}, {Idx, _SI} = I)
-  when PrefIdx < Idx ->
-    drop_prefix(next(PI), I);
-drop_prefix({PrefIdx, _PI}, {Idx, _SI})
-  when Idx < PrefIdx ->
-    {error, not_prefix}.
+%% Merges the elements of the ascending list Asc onto the high->low
+%% sequence Acc. The result is identical to folding append/2 over every
+%% index of Asc, canonical representation included, but ranges are merged
+%% rather than expanded.
+merge0([], Acc) ->
+    Acc;
+merge0([E | Rem], Acc) ->
+    merge0(Rem, push0(E, Acc)).
+
+push0(Idx, Acc) when is_integer(Idx) ->
+    push_range(Idx, Idx, Acc);
+push0({S, E}, Acc) ->
+    push_range(S, E, Acc).
+
+%% Appends the indexes S..E (S =< E) to Acc in closed form.
+%% NB: append/2 only compacts *three* consecutive singletons into a range
+%% and floor/2 and limit/2 split two element ranges back into singletons,
+%% so the canonical form never contains a range shorter than 3. The clauses
+%% below preserve that invariant.
+push_range(S, E, [{AS, AE} | Rem]) when S == AE + 1 ->
+    %% extend the leading range
+    [{AS, E} | Rem];
+push_range(S, E, [A, B | Rem]) when is_integer(A) andalso
+                                    is_integer(B) andalso
+                                    S == A + 1 andalso
+                                    S == B + 2 ->
+    %% three consecutive singletons compact into a range
+    [{B, E} | Rem];
+push_range(S, E, [A | Rem]) when is_integer(A) andalso S == A + 1 ->
+    case E > S of
+        true ->
+            %% A, S, S+1... is at least three consecutive indexes
+            [{A, E} | Rem];
+        false ->
+            [S, A | Rem]
+    end;
+push_range(S, E, Acc) ->
+    %% no adjacency with the head of Acc
+    if E >= S + 2 ->
+           [{S, E} | Acc];
+       E == S + 1 ->
+           [E, S | Acc];
+       true ->
+           [S | Acc]
+    end.
+
+%% True if every index in Sub appears in Sup. Both are in ascending order
+%% with non-overlapping elements, so a single merge pass suffices.
+covers(_Sup, []) ->
+    true;
+covers([], _Sub) ->
+    false;
+covers([SupE | SupRem] = Sup, [SubE | SubRem]) ->
+    {SupS, SupEnd} = as_range(SupE),
+    {SubS, SubEnd} = as_range(SubE),
+    if SupEnd < SubS ->
+           %% Sup element is entirely below Sub, skip it
+           covers(SupRem, [SubE | SubRem]);
+       SupS =< SubS andalso SupEnd >= SubEnd ->
+           %% Sub element fully covered, a single Sup element may cover
+           %% several Sub elements so do not advance Sup
+           covers(Sup, SubRem);
+       SupS =< SubS ->
+           %% partially covered, continue with the uncovered remainder
+           covers(SupRem, [{SupEnd + 1, SubEnd} | SubRem]);
+       true ->
+           %% SubS is below anything Sup can cover from here on
+           false
+    end.
+
+as_range({_, _} = R) ->
+    R;
+as_range(I) when is_integer(I) ->
+    {I, I}.
 
 
 

--- a/src/ra_seq.erl
+++ b/src/ra_seq.erl
@@ -217,9 +217,17 @@ in(_Idx, []) ->
     false;
 in(Idx, [Idx | _]) ->
     true;
+in(Idx, [Next | _])
+  when is_integer(Next) andalso Next < Idx ->
+    %% sequences are ordered high -> low so nothing from here on can
+    %% match either
+    false;
 in(Idx, [Next | Rem])
  when is_integer(Next) ->
     in(Idx, Rem);
+in(Idx, [{_, End} | _])
+  when End < Idx ->
+    false;
 in(Idx, [Range | Rem]) ->
     case ra_range:in(Idx, Range) of
         true ->

--- a/test/ra_log_2_SUITE.erl
+++ b/test/ra_log_2_SUITE.erl
@@ -2413,7 +2413,7 @@ sparse_write(Config) ->
     run_effs(AEffs),
     Log3 = ra_log:set_snapshot_state(SnapState, Log2),
     {ok, Log4, _} = ra_log:install_snapshot({15, 2}, ?MODULE,
-                                            LiveIndexes, Log3),
+                                            LiveIndexesSeq, Log3),
 
     ct:pal("overview Log4 ~p", [ra_log:overview(Log4)]),
     ?assertEqual(16, ra_log:next_index(Log4)),

--- a/test/ra_log_segment_SUITE.erl
+++ b/test/ra_log_segment_SUITE.erl
@@ -38,6 +38,8 @@ all_tests() ->
      corrupted_segment,
      large_segment,
      segref,
+     segref_info,
+     segref_info_v1,
      info,
      info_2,
      versions_v1,
@@ -215,6 +217,63 @@ segref(Config) ->
     undefined = ra_log_segment:segref(Seg0),
     {ok, Seg1} = ra_log_segment:append(Seg0, 1, 2, <<"Adsf">>),
     {<<"seg1.seg">>, {1, 1}} = ra_log_segment:segref(Seg1),
+    ok.
+
+segref_info(Config) ->
+    Dir = ?config(data_dir, Config),
+    Fn = filename:join(Dir, "seg1.seg"),
+    {ok, Seg0} = ra_log_segment:open(Fn, #{max_count => 128}),
+    ?assertMatch(#{ref := undefined, file_type := regular},
+                 ra_log_segment:segref_info(Fn)),
+    {ok, Seg1} = ra_log_segment:append(Seg0, 1, 2, <<"Adsf">>),
+    {ok, Seg2} = ra_log_segment:append(Seg1, 2, 2, <<"Adsf">>),
+    _ = ra_log_segment:flush(Seg2),
+    ?assertMatch(#{ref := {<<"seg1.seg">>, {1, 2}}, file_type := regular},
+                 ra_log_segment:segref_info(Fn)),
+    %% must always agree with info/1's ref for the same file
+    ?assertEqual(maps:get(ref, ra_log_segment:info(Fn)),
+                 maps:get(ref, ra_log_segment:segref_info(Fn))),
+    ok.
+
+segref_info_v1(Config) ->
+    %% segref_info/1 has its own record scan per index version, exercise
+    %% the v1 path directly as append/4 only ever writes the current
+    %% version. Two real records so a wrong v1 record width would land the
+    %% second record's Idx on the wrong bytes rather than accidentally
+    %% still reading correctly off the front of the index.
+    Dir = ?config(data_dir, Config),
+    Fn = filename:join(Dir, "seg1.seg"),
+    Data1 = make_data(64),
+    Data2 = make_data(64),
+    Crc1 = erlang:crc32(Data1),
+    Crc2 = erlang:crc32(Data2),
+    NumEntries = 4,
+    Term = 2,
+    Version = 1,
+    %% v1 index record size was 28, header size is 8
+    DataOffset1 = 8 + (NumEntries * 28),
+    DataOffset2 = DataOffset1 + byte_size(Data1),
+    %% in v1 the offset was 32 bit
+    IndexData = <<1:64/unsigned, Term:64/unsigned,
+                  DataOffset1:32/unsigned,
+                  (byte_size(Data1)):32/unsigned,
+                  Crc1:32/unsigned,
+                  5:64/unsigned, Term:64/unsigned,
+                  DataOffset2:32/unsigned,
+                  (byte_size(Data2)):32/unsigned,
+                  Crc2:32/unsigned>>,
+    Header = <<"RASG", Version:16/unsigned, NumEntries:16/unsigned>>,
+    {ok, Fd} = file:open(Fn, [write, raw, binary]),
+    ok = file:pwrite(Fd, [{0, Header},
+                     {8, IndexData},
+                     {DataOffset1, Data1},
+                     {DataOffset2, Data2}]),
+    ok = file:sync(Fd),
+    ok = file:close(Fd),
+    ?assertMatch(#{ref := {<<"seg1.seg">>, {1, 5}}, file_type := regular},
+                 ra_log_segment:segref_info(Fn)),
+    ?assertEqual(maps:get(ref, ra_log_segment:info(Fn)),
+                 maps:get(ref, ra_log_segment:segref_info(Fn))),
     ok.
 
 info(Config) ->

--- a/test/ra_log_wal_SUITE.erl
+++ b/test/ra_log_wal_SUITE.erl
@@ -1594,6 +1594,12 @@ writers_snapshot_persisted_at_rollover(Config) ->
               flush(),
               ct:fail("mem_tables timeout")
     end,
+    %% the writers snapshot is now persisted *after* the mem_tables cast is
+    %% sent (so the segment writer can start sooner), so receiving that cast
+    %% does not by itself guarantee the WAL has finished writing the
+    %% snapshot yet. A synchronous round-trip through the WAL process does:
+    %% it can only reply once it has returned from handling the roll-over.
+    _ = sys:get_state(Pid),
     %% verify the writers.snapshot file was created
     WritersFile = filename:join(Dir, "writers.snapshot"),
     ?assert(filelib:is_file(WritersFile)),

--- a/test/ra_log_wal_SUITE.erl
+++ b/test/ra_log_wal_SUITE.erl
@@ -65,6 +65,7 @@ all_tests() ->
      writers_snapshot_persisted_at_rollover,
      writers_snapshot_survives_empty_wal_recovery,
      forget_writer_removes_entry,
+     counters_track_writes_and_file_size,
      recovery_trims_stale_writers,
      recover_multi_wal_with_concurrent_deletes
     ].
@@ -300,6 +301,53 @@ sparse_write_recover_with_mt(Config) ->
 %% TODO: as sparse writes are pre committed I dont
 %% think we'll ever overwrite anything.
 sparse_write_overwrite(_Config) ->
+    ok.
+
+%% The byte counter is accumulated per batch while the file size gauge is
+%% updated per entry (fill_ratio/1 reads the latter for back pressure), so
+%% assert both stay in step with what actually landed on disk.
+counters_track_writes_and_file_size(Config) ->
+    meck:new(ra_log_segment_writer, [passthrough]),
+    meck:expect(ra_log_segment_writer, await, fun(_) -> ok end),
+    Conf = ?config(wal_conf, Config),
+    #{dir := Dir, names := #{wal := WalName}} = Conf,
+    WriterId = ?config(writer_id, Config),
+    Tid = ets:new(?FUNCTION_NAME, []),
+    {ok, Pid} = ra_log_wal:start_link(Conf),
+    ?assertMatch(#{writes := 0,
+                   bytes_written := 0,
+                   current_file_size := 0},
+                 ra_counters:overview(WalName)),
+
+    %% a run of single writes, each one likely its own batch
+    Data = <<"counter-test-data">>,
+    [begin
+         {ok, _} = ra_log_wal:write(Pid, WriterId, Tid, I, 1, Data),
+         ok = await_written(WriterId, 1, [I])
+     end || I <- lists:seq(1, 10)],
+    check_counters(WalName, Dir, 10),
+
+    %% then a batch of many writes issued before any are awaited, so that
+    %% several entries share a batch
+    [{ok, _} = ra_log_wal:write(Pid, WriterId, Tid, I, 1, Data)
+     || I <- lists:seq(11, 210)],
+    ok = await_written(WriterId, 1, [{11, 210}]),
+    check_counters(WalName, Dir, 210),
+
+    proc_lib:stop(Pid),
+    meck:unload(),
+    ok.
+
+check_counters(WalName, Dir, ExpectedWrites) ->
+    #{writes := Writes,
+      bytes_written := BytesWritten,
+      current_file_size := FileSize} = ra_counters:overview(WalName),
+    ?assertEqual(ExpectedWrites, Writes),
+    %% both track the same quantity within a single wal file
+    ?assertEqual(BytesWritten, FileSize),
+    %% and it must match the file on disk, less the 5 byte wal header
+    [WalFile] = filelib:wildcard(filename:join(Dir, "*.wal")),
+    ?assertEqual(filelib:file_size(WalFile) - 5, FileSize),
     ok.
 
 wal_filename_upgrade(Config) ->

--- a/test/ra_seq_SUITE.erl
+++ b/test/ra_seq_SUITE.erl
@@ -34,7 +34,8 @@ all_tests() ->
      remove_prefix,
      remove_prefix_2,
      from_list_with_duplicates,
-     has_overlap
+     has_overlap,
+     in
     ].
 
 %% Property tests. `add/2' and `remove_prefix/2' merge and split runs
@@ -52,7 +53,8 @@ prop_tests() ->
      prop_remove_prefix_model,
      prop_remove_prefix_canonical,
      prop_remove_prefix_roundtrip,
-     prop_remove_prefix_detects_gaps
+     prop_remove_prefix_detects_gaps,
+     prop_in_model
     ].
 
 groups() ->
@@ -293,6 +295,29 @@ has_overlap(_Config) ->
 
     ok.
 
+in(_Config) ->
+    ?assertEqual(false, ra_seq:in(1, [])),
+
+    %% S = [11, {5, 9}, {1, 3}]
+    S = ra_seq:from_list([1, 2, 3, 5, 6, 7, 8, 9, 11]),
+    ?assertEqual(true, ra_seq:in(11, S)),
+    ?assertEqual(true, ra_seq:in(1, S)),
+    ?assertEqual(true, ra_seq:in(3, S)),
+    ?assertEqual(true, ra_seq:in(5, S)),
+    ?assertEqual(true, ra_seq:in(7, S)),
+    ?assertEqual(true, ra_seq:in(9, S)),
+
+    %% absent, above the whole sequence - must exit early rather than scan
+    ?assertEqual(false, ra_seq:in(12, S)),
+    %% absent, in the gap directly above a range
+    ?assertEqual(false, ra_seq:in(10, S)),
+    %% absent, in the gap between two ranges
+    ?assertEqual(false, ra_seq:in(4, S)),
+    %% absent, below the whole sequence
+    ?assertEqual(false, ra_seq:in(0, S)),
+
+    ok.
+
 %%%===================================================================
 %%% Property tests
 %%%===================================================================
@@ -411,6 +436,15 @@ prop_remove_prefix_detects_gaps(_Config) ->
                           {error, not_prefix} ==
                               ra_seq:remove_prefix(Prefix, Seq)
                       end)
+      end, [], 2000).
+
+%% in/2 relies on the high -> low ordering to exit early; check it against
+%% the naive membership test on the fully expanded sequence.
+prop_in_model(_Config) ->
+    run_proper(
+      fun () ->
+              ?FORALL({Idx, S}, {index(), seq()},
+                      ra_seq:in(Idx, S) == lists:member(Idx, ra_seq:expand(S)))
       end, [], 2000).
 
 %%%===================================================================

--- a/test/ra_seq_SUITE.erl
+++ b/test/ra_seq_SUITE.erl
@@ -6,6 +6,9 @@
 -export([
          ]).
 
+%% NB: proper must be included before eunit as both define ?LET
+-include_lib("proper/include/proper.hrl").
+-include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 %%%===================================================================
@@ -14,7 +17,8 @@
 
 all() ->
     [
-     {group, tests}
+     {group, tests},
+     {group, props}
     ].
 
 
@@ -33,8 +37,27 @@ all_tests() ->
      has_overlap
     ].
 
+%% Property tests. `add/2' and `remove_prefix/2' merge and split runs
+%% rather than walking individual indexes, so these check both the values
+%% they compute and that the representation stays canonical - a sequence
+%% never holds a range shorter than three indexes, which `append/2',
+%% `floor/2' and `limit/2' all rely on.
+prop_tests() ->
+    [
+     prop_from_list_canonical,
+     prop_expand_descending,
+     prop_add_model,
+     prop_add_canonical,
+     prop_add_appendable,
+     prop_remove_prefix_model,
+     prop_remove_prefix_canonical,
+     prop_remove_prefix_roundtrip,
+     prop_remove_prefix_detects_gaps
+    ].
+
 groups() ->
-    [{tests, [], all_tests()}].
+    [{tests, [], all_tests()},
+     {props, [], prop_tests()}].
 
 init_per_suite(Config) ->
     Config.
@@ -269,3 +292,234 @@ has_overlap(_Config) ->
     ?assertEqual([], ra_seq:in_range({4, 4}, S)),
 
     ok.
+
+%%%===================================================================
+%%% Property tests
+%%%===================================================================
+
+prop_from_list_canonical(_Config) ->
+    run_proper(
+      fun () ->
+              ?FORALL(L, list(index()),
+                      begin
+                          S = ra_seq:from_list(L),
+                          is_canonical(S) andalso
+                          lists:usort(L) == lists:sort(ra_seq:expand(S))
+                      end)
+      end, [], 1000).
+
+%% expand/1 must always yield strictly descending, duplicate free indexes.
+%% add/2 and remove_prefix/2 both rely on this ordering.
+prop_expand_descending(_Config) ->
+    run_proper(
+      fun () ->
+              ?FORALL(S, seq(),
+                      begin
+                          E = ra_seq:expand(S),
+                          E == lists:reverse(lists:usort(E))
+                      end)
+      end, [], 1000).
+
+prop_add_model(_Config) ->
+    run_proper(
+      fun () ->
+              ?FORALL({Add, To}, {seq(), seq()},
+                      ra_seq:expand(ra_seq:add(Add, To)) ==
+                          model_add(Add, To))
+      end, [], 2000).
+
+prop_add_canonical(_Config) ->
+    run_proper(
+      fun () ->
+              ?FORALL({Add, To}, {seq(), seq()},
+                      is_canonical(ra_seq:add(Add, To)))
+      end, [], 2000).
+
+%% the result of add/2 must still be appendable, i.e. append/2 must not
+%% raise a function_clause on the next index
+prop_add_appendable(_Config) ->
+    run_proper(
+      fun () ->
+              ?FORALL({Add, To}, {non_empty_seq(), seq()},
+                      begin
+                          S = ra_seq:add(Add, To),
+                          Next = ra_seq:last(S) + 1,
+                          is_canonical(ra_seq:append(Next, S))
+                      end)
+      end, [], 2000).
+
+prop_remove_prefix_model(_Config) ->
+    run_proper(
+      fun () ->
+              ?FORALL({Prefix, Seq}, prefix_and_seq(),
+                      begin
+                          Expected = model_remove_prefix(Prefix, Seq),
+                          case ra_seq:remove_prefix(Prefix, Seq) of
+                              {ok, S} ->
+                                  {ok, ra_seq:expand(S)} == Expected;
+                              {error, not_prefix} = Err ->
+                                  Err == Expected
+                          end
+                      end)
+      end, [], 3000).
+
+prop_remove_prefix_canonical(_Config) ->
+    run_proper(
+      fun () ->
+              ?FORALL({Prefix, Seq}, prefix_and_seq(),
+                      case ra_seq:remove_prefix(Prefix, Seq) of
+                          {ok, S} ->
+                              is_canonical(S);
+                          {error, not_prefix} ->
+                              true
+                      end)
+      end, [], 3000).
+
+%% splitting a sequence at an arbitrary point and removing the lower half
+%% must always yield exactly the upper half
+prop_remove_prefix_roundtrip(_Config) ->
+    run_proper(
+      fun () ->
+              ?FORALL({Seq, N}, {seq(), integer(0, 30)},
+                      begin
+                          %% expand/1 is descending, take the N lowest
+                          Asc = lists:reverse(ra_seq:expand(Seq)),
+                          K = min(N, length(Asc)),
+                          {Low, High} = lists:split(K, Asc),
+                          Prefix = ra_seq:from_list(Low),
+                          Expected = ra_seq:from_list(High),
+                          case ra_seq:remove_prefix(Prefix, Seq) of
+                              {ok, Expected} ->
+                                  true;
+                              _ ->
+                                  false
+                          end
+                      end)
+      end, [], 2000).
+
+%% if the prefix omits an index that the sequence holds below the prefix's
+%% last index, that must be reported rather than silently dropped
+prop_remove_prefix_detects_gaps(_Config) ->
+    run_proper(
+      fun () ->
+              ?FORALL(Seq, seq_of_at_least(2),
+                      begin
+                          Asc = lists:reverse(ra_seq:expand(Seq)),
+                          %% a prefix of everything but the lowest index,
+                          %% so it always covers something it should not
+                          Prefix = ra_seq:from_list(tl(Asc)),
+                          {error, not_prefix} ==
+                              ra_seq:remove_prefix(Prefix, Seq)
+                      end)
+      end, [], 2000).
+
+%%%===================================================================
+%%% Generators
+%%%===================================================================
+
+index() ->
+    integer(0, 40).
+
+%% A mix of sparse sequences (mostly singletons, exercises the gap
+%% handling) and run based sequences (multi index ranges, exercises the
+%% range merging and splitting paths).
+seq() ->
+    union([sparse_seq(), run_seq()]).
+
+sparse_seq() ->
+    ?LET(L, list(index()), ra_seq:from_list(L)).
+
+run_seq() ->
+    ?LET(Runs, list({index(), integer(1, 8)}),
+         ra_seq:from_list(
+           lists:append([lists:seq(S, S + Len - 1) || {S, Len} <- Runs]))).
+
+non_empty_seq() ->
+    ?SUCHTHAT(S, seq(), S =/= []).
+
+seq_of_at_least(N) ->
+    ?SUCHTHAT(S, seq(), ra_seq:length(S) >= N).
+
+%% Prefix/sequence pairs. Weighted towards genuine prefixes so that the
+%% success path is well covered, but includes prefixes with extra lower
+%% indexes (legal, they have already been removed) and entirely unrelated
+%% sequences (which must be rejected).
+prefix_and_seq() ->
+    ?LET(Seq, seq(),
+         frequency(
+           [{5, {genuine_prefix(Seq), Seq}},
+            {3, {prefix_with_extras(Seq), Seq}},
+            {2, {seq(), Seq}}])).
+
+genuine_prefix(Seq) ->
+    ?LET(N, integer(0, 30),
+         begin
+             Asc = lists:reverse(ra_seq:expand(Seq)),
+             ra_seq:from_list(lists:sublist(Asc, min(N, length(Asc))))
+         end).
+
+prefix_with_extras(Seq) ->
+    ?LET({N, Extras}, {integer(0, 30), list(index())},
+         begin
+             Asc = lists:reverse(ra_seq:expand(Seq)),
+             Taken = lists:sublist(Asc, min(N, length(Asc))),
+             Ceil = case Taken of
+                        [] -> 0;
+                        _ -> lists:max(Taken)
+                    end,
+             %% extras must stay at or below the prefix's last index, else
+             %% they would extend the prefix over indexes of Seq that are
+             %% deliberately not being removed
+             ra_seq:from_list(Taken ++ [E || E <- Extras, E =< Ceil])
+         end).
+
+%%%===================================================================
+%%% Property helpers
+%%%===================================================================
+
+%% from_list/1 is usort + repeated append/2, so it produces the canonical
+%% representation by construction. Any sequence must round-trip through it.
+is_canonical(S) ->
+    S == ra_seq:from_list(ra_seq:expand(S)).
+
+model_add(Add, To) ->
+    A = ra_seq:expand(Add),
+    T = ra_seq:expand(To),
+    case {A, T} of
+        {[], _} ->
+            T;
+        {_, []} ->
+            A;
+        _ ->
+            Fst = lists:min(A),
+            lists:reverse(lists:sort([I || I <- T, I < Fst] ++ A))
+    end.
+
+model_remove_prefix(Prefix, Seq) ->
+    P = ra_seq:expand(Prefix),
+    S = ra_seq:expand(Seq),
+    case {P, S} of
+        {[], _} ->
+            {ok, S};
+        {_, []} ->
+            {ok, []};
+        _ ->
+            PrefLast = lists:max(P),
+            Low = [I || I <- S, I =< PrefLast],
+            case Low -- P of
+                [] ->
+                    {ok, [I || I <- S, I > PrefLast]};
+                _ ->
+                    {error, not_prefix}
+            end
+    end.
+
+run_proper(Fun, Args, NumTests) ->
+    ?assertEqual(
+       true,
+       proper:counterexample(erlang:apply(Fun, Args),
+                             [{numtests, NumTests},
+                              {on_output,
+                               fun(".", _) -> ok;
+                                  (F, A) -> ct:pal(?LOW_IMPORTANCE, F, A)
+                               end}])).


### PR DESCRIPTION
This branch is a performance pass over the Ra log write/read/recovery paths — WAL, segment writer, segment reads, and the ra_seq index-sequence library — plus one correctness fix and one logging fix found along the way.

ra_seq (index sequences)
- add/2 and remove_prefix/2 now merge runs in closed form instead of expanding index-by-index (439us → 0.035us at 100k indexes; 178us → flat 29 reductions for a typical written-event batch), while preserving the canonical run representation.
- in/2 gets an early exit once the sought index falls below the current run, fixing an O(n) miss-scan on large sequences (15.3us → ~O(1)); this also surfaced a test bug in ra_log_2_SUITE:sparse_write passing indexes in the wrong order.

ra_log_wal
- Roll-over no longer blocks on an inline fsync+rename of the (optional, best-effort) writers snapshot before accept_mem_tables, so the segment writer can start flushing sooner.
- Per-entry work in the write path (smallest_live_index lookup, bytes-written counter) is now resolved/accumulated once per batch instead of once per entry (-10% to -13% reductions/entry).

ra_log_segment / ra_log_segment_writer
- info/2's live-index accounting is now a merge over two sorted sequences instead of an O(records × runs) membership scan — flat ~310-400us regardless of live-set shape (was up to 10.3ms on sparse live sets, i.e. exactly when major compaction matters most). Also drops the unused indexes field from its return map.
- fold/7 now forces sequential access so it always benefits from read-ahead, even on segments opened as random (e.g. followers) — up to 10x on the measured case.
- New segref_info/1 for the startup segref scan avoids computing unused stats (num_entries, live_size, ctime/links) and avoids decode_index_record/3's per-record sub-binary churn (279us → 151.6us per segment; ~130ms off startup for 1000 segments).
- Segment writer caches the current segment file per uid instead of re-listing/sorting the directory on every flush (down from up to 4.2ms to a flat ~18us at 2048 segments), with a must_exist guard on cache hits and directory-sync skipped for pure appends.

ra.hrl
- ?DEBUG now checks logger:allow/2 before evaluating its arguments, matching OTP's own macros, so expensive debug-only argument expressions aren't built when debug logging is off.